### PR TITLE
Gradle publish can publish to Sonatype Repository (Maven)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,4 @@ gradle-app.setting
 # End of https://www.gitignore.io/api/node,gradle,kotlin,intellij
 
 # Ignore files with secrets.
-signing.properties
+publish.properties

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This is a multiplatform Kotlin library which targets both the **Java Runtime Env
 
 For `carp.core-kotlin`:
 - **build**: Builds the full project, for both runtimes.
-- **clean jvmTest**: Test the full project using JUnit5. `clean` is optional, but ensures that test results always show up in IntelliJ; when tasks haven't changed it otherwise lists "Test events were not received".
+- **cleanAllTests jvmTest**: Test the full project using JUnit5. `cleanAllTests` is optional, but ensures that test results always show up in IntelliJ; when tasks haven't changed it otherwise lists "Test events were not received".
 - **jsTest**: Test the full project using Mocha. Test results only show up in the build output and not in IntelliJ.
 
 For `:carp.*.core` libraries:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,4 @@ For `carp.core-kotlin`:
 - **build**: Builds the full project, for both runtimes.
 - **cleanAllTests jvmTest**: Test the full project using JUnit5. `cleanAllTests` is optional, but ensures that test results always show up in IntelliJ; when tasks haven't changed it otherwise lists "Test events were not received".
 - **jsTest**: Test the full project using Mocha. Test results only show up in the build output and not in IntelliJ.
-
-For `:carp.*.core` libraries:
-- **publishSigned**: Prepare all jars to be published to Maven. This includes documentation, sources, and signing.
+- **publishSigned**: Publish all projects to Maven. This includes documentation, sources, and signing. For this to work you need to configure a `publish.properties` file with a signing signature and repository user in the project root folder. See main `build.gradle` for details.

--- a/build.gradle
+++ b/build.gradle
@@ -112,75 +112,6 @@ subprojects {
         useJUnitPlatform()
     }
 
-    // JVM publish configuration.
-    apply plugin: 'maven-publish'
-    apply plugin: 'org.jetbrains.dokka'
-    dokka {
-        outputFormat = 'html'
-        outputDirectory = "$buildDir/javadoc"
-    }
-    task javadocJar(type: Jar) {
-        group JavaBasePlugin.DOCUMENTATION_GROUP
-        description 'Create javadoc jar using Dokka'
-        archiveClassifier = "javadoc"
-        from dokka
-    }
-    publishing {
-        publications {
-            jvm {
-                pom {
-                    url = 'https://github.com/cph-cachet/carp.core-kotlin'
-                    licenses {
-                        license {
-                            name = 'MIT License'
-                            url = 'https://github.com/cph-cachet/carp.core-kotlin/blob/master/LICENSE.md'
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = 'whathecode'
-                            name = 'Steven Jeuris'
-                            email = 'steven.jeuris@gmail.com'
-                            organization = 'CACHET'
-                            organizationUrl = 'http://www.cachet.dk/'
-                        }
-                    }
-                    scm {
-                        connection = 'scm:git:git://github.com/cph-cachet/carp.core-kotlin.git'
-                        developerConnection = 'scm:git:ssh://github.com:cph-cachet/carp.core-kotlin.git'
-                        url = 'https://github.com/cph-cachet/carp.core-kotlin'
-                    }
-                }
-
-                artifact javadocJar
-            }
-        }
-        repositories {
-            maven {
-                url "$buildDir/repository"
-            }
-        }
-    }
-    // Configure the 'sign' task to sign all files part of the maven package.
-    // For signing to work, a 'signing.properties' file needs to be added to the root containing the OpenPGP signature credentials:
-    // > signing.keyId=<LAST 8 SYMBOLS OF KEY ID>
-    // > signing.password=<SECRET>
-    // > signing.secretKeyRingFile=<ABSOLUTE PATH TO THE SECRET KEY RING FILE WITH PRIVATE KEY>
-    apply plugin: 'signing'
-    signing {
-        sign publishing.publications.jvm
-    }
-    task publishSigned {
-        doFirst {
-            def signingProperties = new Properties()
-            signingProperties.load(new FileInputStream(rootProject.file('signing.properties')))
-            allprojects { ext."signing.keyId" = signingProperties['signing.keyId'] }
-            allprojects { ext."signing.password" = signingProperties['signing.password'] }
-            allprojects { ext."signing.secretKeyRingFile" = signingProperties['signing.secretKeyRingFile'] }
-        }
-    }
-    publishSigned.finalizedBy publish
-
     // JS test configuration.
     // This is adapted from kotlinx-io's build file; I do not fully understand this configuration:
     // https://stackoverflow.com/a/55244288/590790
@@ -214,6 +145,90 @@ subprojects {
         args = [compileTestKotlinJs.outputFile]
     }
     jsTest.dependsOn runMocha
+
+    // Publish configuration.
+    // For signing and publishing to work, a 'publish.properties' file needs to be added to the root containing:
+    // The OpenPGP signature credentials to sign all artifacts:
+    // > signing.keyId=<LAST 8 SYMBOLS OF KEY ID>
+    // > signing.password=<SECRET>
+    // > signing.secretKeyRingFile=<ABSOLUTE PATH TO THE SECRET KEY RING FILE WITH PRIVATE KEY>
+    // A username and password to upload artifacts to the Sonatype repository:
+    // > repository.username=<SONATYPE USERNAME>
+    // > repository.password=<SONATYPE PASSWORD>
+    apply plugin: 'maven-publish'
+    apply plugin: 'org.jetbrains.dokka'
+    dokka {
+        outputFormat = 'html'
+        outputDirectory = "$buildDir/javadoc"
+    }
+    task javadocJar(type: Jar) {
+        group JavaBasePlugin.DOCUMENTATION_GROUP
+        description 'Create javadoc jar using Dokka'
+        archiveClassifier = "javadoc"
+        from dokka
+    }
+    def publishProperties = new Properties()
+    publishProperties.load(new FileInputStream(rootProject.file('publish.properties')))
+    publishing {
+        publications {
+            jvm {
+                pom {
+                    url = 'https://github.com/cph-cachet/carp.core-kotlin'
+                    licenses {
+                        license {
+                            name = 'MIT License'
+                            url = 'https://github.com/cph-cachet/carp.core-kotlin/blob/master/LICENSE.md'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'whathecode'
+                            name = 'Steven Jeuris'
+                            email = 'steven.jeuris@gmail.com'
+                            organization = 'CACHET'
+                            organizationUrl = 'http://www.cachet.dk/'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:git://github.com/cph-cachet/carp.core-kotlin.git'
+                        developerConnection = 'scm:git:ssh://github.com:cph-cachet/carp.core-kotlin.git'
+                        url = 'https://github.com/cph-cachet/carp.core-kotlin'
+                    }
+                }
+
+                artifact javadocJar
+            }
+        }
+        repositories {
+            maven {
+                name "local"
+                url "$buildDir/repository"
+            }
+            maven {
+                name = "sonatype"
+                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+                def stagingRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : stagingRepoUrl
+                credentials {
+                    username = publishProperties['repository.username']
+                    password = publishProperties['repository.password']
+                }
+            }
+        }
+    }
+    // Configure the 'sign' task to sign all files part of the maven package.
+    apply plugin: 'signing'
+    signing {
+        sign publishing.publications.jvm
+    }
+    task publishSigned {
+        doFirst {
+            allprojects { ext."signing.keyId" = publishProperties['signing.keyId'] }
+            allprojects { ext."signing.password" = publishProperties['signing.password'] }
+            allprojects { ext."signing.secretKeyRingFile" = publishProperties['signing.secretKeyRingFile'] }
+        }
+    }
+    publishSigned.finalizedBy publish
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
 }
 
 
-// Configure all subprojects as testable Kotlin multiplatform projects.
+// Configure all subprojects as testable, publishable, Kotlin multiplatform projects.
 subprojects {
     version = globalVersion
 
@@ -122,7 +122,7 @@ subprojects {
     task javadocJar(type: Jar) {
         group JavaBasePlugin.DOCUMENTATION_GROUP
         description 'Create javadoc jar using Dokka'
-        classifier 'javadoc'
+        archiveClassifier = "javadoc"
         from dokka
     }
     publishing {
@@ -280,8 +280,6 @@ configure( coreModules ) {
 
 
 // HACK: Dokka currently does not work for multiplatform projects.
-// The following configuration is a workaround: https://discuss.kotlinlang.org/t/how-to-configure-dokka-for-kotlin-multiplatform/9834
-configure( coreModules ) {
 // The following configuration is a workaround to configure Dokka for JVM solely:
 // https://discuss.kotlinlang.org/t/how-to-configure-dokka-for-kotlin-multiplatform/9834
 configure( subprojects ) {

--- a/build.gradle
+++ b/build.gradle
@@ -282,6 +282,9 @@ configure( coreModules ) {
 // HACK: Dokka currently does not work for multiplatform projects.
 // The following configuration is a workaround: https://discuss.kotlinlang.org/t/how-to-configure-dokka-for-kotlin-multiplatform/9834
 configure( coreModules ) {
+// The following configuration is a workaround to configure Dokka for JVM solely:
+// https://discuss.kotlinlang.org/t/how-to-configure-dokka-for-kotlin-multiplatform/9834
+configure( subprojects ) {
     dokka {
         kotlinTasks { [] }
         // Dokka fails to retrieve sources from multiplatform tasks. Setting this as empty avoids exceptions.
@@ -293,8 +296,11 @@ configure( coreModules ) {
             path = kotlin.sourceSets.jvmMain.kotlin.srcDirs[0] // There is only one source dir.
             platforms = ["JVM"]
         }
-
-        // Add source sets of 'carp.common'.
+    }
+}
+// HACK: Manually add source dependencies of core modules to 'common' so that Dokka can resolve them.
+configure( coreModules ) {
+    dokka {
         sourceRoot {
             path = project(':carp.common').kotlin.sourceSets.commonMain.kotlin.srcDirs[0] // There is only one source dir.
             platforms = ["Common"]

--- a/carp.test/build.gradle
+++ b/carp.test/build.gradle
@@ -1,3 +1,5 @@
+group = 'dk.cachet.carp.test'
+
 // `carp.test` extends test libraries, thus has a dependency on them in the main components.
 kotlin {
     sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,7 @@
-globalVersion = 1.0.0-alpha.1
+# Version used for all submodule artifacts.
+# Suffix the version with '-SNAPSHOT' to publish to snapshot repository. All other versions will be published to staging.
+globalVersion = 1.0.0-SNAPSHOT
+# globalVersion = 1.0.0-alpha.2
 
 # Kotlin multiplatform versions.
 kotlinVersion = 1.3.41


### PR DESCRIPTION
Versions with '-SNAPSHOT' will publish to the snapshot repository. Other versions will be published to staging and still need to be approved manually through the frontend: https://oss.sonatype.org/