### PR TITLE
Add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,7 @@ gradle-app.setting
 
 # Ignore files with secrets.
 publish.properties
+
+# OS generated files
+.DS_Store
+


### PR DESCRIPTION
.DS_Store files stores information about personal MacOS folder settings, that Finder creates and uses. They should be ignored by Git.