### PR TITLE
Convert DeploymentService functions to suspending functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
             // Kotlin multiplatform versions.
             kotlin:'1.3.41',
             serialization:'0.11.1',
+            coroutines:'1.2.2',
 
             // JVM versions.
             jvmTarget:'1.6',

--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/ClientManager.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/ClientManager.kt
@@ -52,7 +52,7 @@ class ClientManager<TMasterDevice: MasterDeviceDescriptor<TRegistration,*>, TReg
      * or the [deviceRegistration] of this client is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device.
      * @return The [StudyRuntime] through which data collection for the newly added study can be managed.
      */
-    fun addStudy( studyDeploymentId: UUID, deviceRoleName: String ): StudyRuntime
+    suspend fun addStudy( studyDeploymentId: UUID, deviceRoleName: String ): StudyRuntime
     {
         // TODO: Can/should it be reinforced here that only study runtimes for a matching master device type can be created?
 

--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
@@ -44,7 +44,7 @@ class StudyRuntime private constructor(
          *
          * @throws UnsupportedOperationException in case deployment failed since not all necessary plugins to execute the study are available.
          */
-        internal fun initialize(
+        internal suspend fun initialize(
             /**
              * The application service to use to retrieve and manage the study deployment with [studyDeploymentId].
              * This deployment service should have the deployment with [studyDeploymentId] available.
@@ -111,7 +111,7 @@ class StudyRuntime private constructor(
      *
      * @throws UnsupportedOperationException in case deployment failed since not all necessary plugins to execute the study are available.
      */
-    fun tryDeployment(): DeploymentState
+    suspend fun tryDeployment(): DeploymentState
     {
         val deploymentStatus = deploymentService.getStudyDeploymentStatus( studyDeploymentId )
         val clientDeviceStatus = deploymentStatus.devicesStatus.first { it.device == device }

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/ClientManagerTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/ClientManagerTest.kt
@@ -1,8 +1,8 @@
 package dk.cachet.carp.client.domain
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.test.runBlockingTest
 import kotlin.test.*
-
 
 /**
  * Tests for [ClientManager].
@@ -10,8 +10,7 @@ import kotlin.test.*
 class ClientManagerTest
 {
     @Test
-    fun add_study_succeeds()
-    {
+    fun add_study_succeeds() = runBlockingTest {
         // Create deployment service and client manager.
         val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val clientManager = createSmartphoneManager( deploymentService )
@@ -20,8 +19,7 @@ class ClientManagerTest
     }
 
     @Test
-    fun add_study_fails_for_invalid_deployment()
-    {
+    fun add_study_fails_for_invalid_deployment() = runBlockingTest {
         // Create deployment service and client manager.
         val ( deploymentService, _) = createStudyDeployment( createSmartphoneStudy() )
         val clientManager = createSmartphoneManager( deploymentService )
@@ -34,8 +32,7 @@ class ClientManagerTest
     }
 
     @Test
-    fun add_study_fails_for_nonexisting_device_role()
-    {
+    fun add_study_fails_for_nonexisting_device_role() = runBlockingTest {
         // Create deployment service and client manager.
         val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val clientManager = createSmartphoneManager( deploymentService )
@@ -47,8 +44,7 @@ class ClientManagerTest
     }
 
     @Test
-    fun add_study_fails_for_device_role_name_already_in_use()
-    {
+    fun add_study_fails_for_device_role_name_already_in_use() = runBlockingTest {
         // Create deployment service and client manager.
         val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val clientManager = createSmartphoneManager( deploymentService )
@@ -61,8 +57,7 @@ class ClientManagerTest
     }
 
     @Test
-    fun creating_manager_fromSnapshot_obtained_by_getSnapshot_is_the_same()
-    {
+    fun creating_manager_fromSnapshot_obtained_by_getSnapshot_is_the_same() = runBlockingTest {
         // Create deployment service and client manager with one study.
         val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val clientManager = createSmartphoneManager( deploymentService )

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/CreateTestObjects.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/CreateTestObjects.kt
@@ -35,7 +35,7 @@ fun createDependentSmartphoneStudy(): StudyProtocol
 /**
  * Create a deployment service which contains a study deployment for the specified [protocol].
  */
-fun createStudyDeployment( protocol: StudyProtocol ): Pair<DeploymentService, StudyDeploymentStatus>
+suspend fun createStudyDeployment( protocol: StudyProtocol ): Pair<DeploymentService, StudyDeploymentStatus>
 {
     val deploymentService = DeploymentServiceHost( InMemoryDeploymentRepository() )
     val status = deploymentService.createStudyDeployment( protocol.getSnapshot() )

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.client.domain
 
 import dk.cachet.carp.client.infrastructure.*
+import dk.cachet.carp.test.runBlockingTest
 import kotlin.test.*
 
 
@@ -10,8 +11,7 @@ import kotlin.test.*
 class StudyRuntimeTest
 {
     @Test
-    fun initialize_matches_requested_runtime()
-    {
+    fun initialize_matches_requested_runtime() = runBlockingTest {
         // Create a deployment manager which contains a 'smartphone study'.
         val ( deploymentManager, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
 
@@ -23,8 +23,7 @@ class StudyRuntimeTest
     }
 
     @Test
-    fun initialize_deploys_when_possible()
-    {
+    fun initialize_deploys_when_possible() = runBlockingTest {
         // Create a deployment manager which contains a 'smartphone study'.
         val ( deploymentManager, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
 
@@ -35,8 +34,7 @@ class StudyRuntimeTest
     }
 
     @Test
-    fun initialize_does_not_deploy_when_depending_on_other_devices()
-    {
+    fun initialize_does_not_deploy_when_depending_on_other_devices() = runBlockingTest {
         // Create a deployment manager which contains a study where 'smartphone' depends on another master device.
         val ( deploymentManager, deploymentStatus) = createStudyDeployment( createDependentSmartphoneStudy() )
 
@@ -47,8 +45,7 @@ class StudyRuntimeTest
     }
 
     @Test
-    fun tryDeployment_only_succeeds_after_dependent_devices_are_registered()
-    {
+    fun tryDeployment_only_succeeds_after_dependent_devices_are_registered() = runBlockingTest {
         // Create a study runtime for a study where 'smartphone' depends on another master device ('deviceSmartphoneDependsOn').
         val ( deploymentManager, deploymentStatus) = createStudyDeployment( createDependentSmartphoneStudy() )
         val deviceRegistration = smartphone.createRegistration()
@@ -67,8 +64,7 @@ class StudyRuntimeTest
     }
 
     @Test
-    fun creating_runtime_fromSnapshot_obtained_by_getSnapshot_is_the_same()
-    {
+    fun creating_runtime_fromSnapshot_obtained_by_getSnapshot_is_the_same() = runBlockingTest {
         // Create a study runtime snapshot for the 'smartphone' in 'smartphone study'.
         val ( deploymentManager, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val deviceRegistration = smartphone.createRegistration()

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
@@ -12,11 +12,11 @@ class StudyRuntimeTest
 {
     @Test
     fun initialize_matches_requested_runtime() = runBlockingTest {
-        // Create a deployment manager which contains a 'smartphone study'.
-        val ( deploymentManager, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
+        // Create a deployment service which contains a 'smartphone study'.
+        val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
 
         val deviceRegistration = smartphone.createRegistration()
-        val runtime = StudyRuntime.initialize( deploymentManager, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
+        val runtime = StudyRuntime.initialize( deploymentService, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
 
         assertEquals( deploymentStatus.studyDeploymentId, runtime.studyDeploymentId )
         assertEquals( smartphone.roleName, runtime.device.roleName )
@@ -24,22 +24,22 @@ class StudyRuntimeTest
 
     @Test
     fun initialize_deploys_when_possible() = runBlockingTest {
-        // Create a deployment manager which contains a 'smartphone study'.
-        val ( deploymentManager, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
+        // Create a deployment service which contains a 'smartphone study'.
+        val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
 
         val deviceRegistration = smartphone.createRegistration()
-        val runtime = StudyRuntime.initialize( deploymentManager, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
+        val runtime = StudyRuntime.initialize( deploymentService, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
 
         assertTrue( runtime.isDeployed )
     }
 
     @Test
     fun initialize_does_not_deploy_when_depending_on_other_devices() = runBlockingTest {
-        // Create a deployment manager which contains a study where 'smartphone' depends on another master device.
-        val ( deploymentManager, deploymentStatus) = createStudyDeployment( createDependentSmartphoneStudy() )
+        // Create a deployment service which contains a study where 'smartphone' depends on another master device.
+        val ( deploymentService, deploymentStatus) = createStudyDeployment( createDependentSmartphoneStudy() )
 
         val deviceRegistration = smartphone.createRegistration()
-        val runtime = StudyRuntime.initialize( deploymentManager, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
+        val runtime = StudyRuntime.initialize( deploymentService, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
 
         assertFalse( runtime.isDeployed )
     }
@@ -47,9 +47,9 @@ class StudyRuntimeTest
     @Test
     fun tryDeployment_only_succeeds_after_dependent_devices_are_registered() = runBlockingTest {
         // Create a study runtime for a study where 'smartphone' depends on another master device ('deviceSmartphoneDependsOn').
-        val ( deploymentManager, deploymentStatus) = createStudyDeployment( createDependentSmartphoneStudy() )
+        val ( deploymentService, deploymentStatus) = createStudyDeployment( createDependentSmartphoneStudy() )
         val deviceRegistration = smartphone.createRegistration()
-        val runtime = StudyRuntime.initialize( deploymentManager, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
+        val runtime = StudyRuntime.initialize( deploymentService, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
 
         // Dependent devices are not yet registered.
         val status = runtime.tryDeployment()
@@ -57,7 +57,7 @@ class StudyRuntimeTest
         assertFalse( status.isDeployed )
 
         // Once dependent devices are registered, deployment succeeds.
-        deploymentManager.registerDevice( deploymentStatus.studyDeploymentId, deviceSmartphoneDependsOn.roleName, deviceSmartphoneDependsOn.createRegistration() )
+        deploymentService.registerDevice( deploymentStatus.studyDeploymentId, deviceSmartphoneDependsOn.roleName, deviceSmartphoneDependsOn.createRegistration() )
         val succeededStatus = runtime.tryDeployment()
         assertTrue( succeededStatus.isReadyForDeployment )
         assertTrue( succeededStatus.isDeployed )
@@ -66,9 +66,9 @@ class StudyRuntimeTest
     @Test
     fun creating_runtime_fromSnapshot_obtained_by_getSnapshot_is_the_same() = runBlockingTest {
         // Create a study runtime snapshot for the 'smartphone' in 'smartphone study'.
-        val ( deploymentManager, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
+        val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val deviceRegistration = smartphone.createRegistration()
-        val runtime = StudyRuntime.initialize( deploymentManager, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
+        val runtime = StudyRuntime.initialize( deploymentService, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
         val snapshot = StudyRuntimeSnapshot.fromStudyRuntime( runtime )
 
         val serialized = snapshot.toJson()

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/infrastructure/ClientManagerSnapshotTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/infrastructure/ClientManagerSnapshotTest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.client.infrastructure
 
 import dk.cachet.carp.client.domain.*
+import dk.cachet.carp.test.runBlockingTest
 import kotlin.test.*
 
 
@@ -10,8 +11,7 @@ import kotlin.test.*
 class ClientManagerSnapshotTest
 {
     @Test
-    fun can_serialize_and_deserialize_snapshot_using_JSON()
-    {
+    fun can_serialize_and_deserialize_snapshot_using_JSON() = runBlockingTest {
         // Create deployment service and client manager with one study.
         val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val clientManager = SmartphoneManager( smartphone.createRegistration(), deploymentService )

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/infrastructure/StudyRuntimeSnapshotTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/infrastructure/StudyRuntimeSnapshotTest.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.client.infrastructure
 
 import dk.cachet.carp.client.domain.*
 import dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistrationBuilder
+import dk.cachet.carp.test.runBlockingTest
 import kotlin.test.*
 
 
@@ -11,8 +12,7 @@ import kotlin.test.*
 class StudyRuntimeSnapshotTest
 {
     @Test
-    fun can_serialize_and_deserialize_snapshot_using_JSON()
-    {
+    fun can_serialize_and_deserialize_snapshot_using_JSON() = runBlockingTest {
         // Create deployment service with one 'smartphone' study.
         val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val deviceRegistration = DefaultDeviceRegistrationBuilder().build()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -17,7 +17,7 @@ interface DeploymentService
      * @throws InvalidConfigurationError when [protocol] is invalid.
      * @return The [StudyDeploymentStatus] of the newly created study deployment.
      */
-    fun createStudyDeployment( protocol: StudyProtocolSnapshot ): StudyDeploymentStatus
+    suspend fun createStudyDeployment( protocol: StudyProtocolSnapshot ): StudyDeploymentStatus
 
     /**
      * Get the status for a study deployment with the given [studyDeploymentId].
@@ -26,7 +26,7 @@ interface DeploymentService
      *
      * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist.
      */
-    fun getStudyDeploymentStatus( studyDeploymentId: UUID ): StudyDeploymentStatus
+    suspend fun getStudyDeploymentStatus( studyDeploymentId: UUID ): StudyDeploymentStatus
 
     /**
      * Register the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].
@@ -39,7 +39,7 @@ interface DeploymentService
      * [deviceRoleName] is not present in the deployment or is already registered,
      * or [registration] is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device.
      */
-    fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
+    suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
 
     /**
      * Get the deployment configuration for the master device with [masterDeviceRoleName] in the study deployment with [studyDeploymentId].
@@ -47,5 +47,5 @@ interface DeploymentService
      * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
      * or [masterDeviceRoleName] is not present in the deployment, or not yet registered.
      */
-    fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
+    suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -17,7 +17,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository ) : De
      * @throws InvalidConfigurationError when [protocol] is invalid.
      * @return The [StudyDeploymentStatus] of the newly created study deployment.
      */
-    override fun createStudyDeployment( protocol: StudyProtocolSnapshot ): StudyDeploymentStatus
+    override suspend fun createStudyDeployment( protocol: StudyProtocolSnapshot ): StudyDeploymentStatus
     {
         val newDeployment = StudyDeployment( protocol )
 
@@ -33,7 +33,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository ) : De
      *
      * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist.
      */
-    override fun getStudyDeploymentStatus( studyDeploymentId: UUID ): StudyDeploymentStatus
+    override suspend fun getStudyDeploymentStatus( studyDeploymentId: UUID ): StudyDeploymentStatus
     {
         val deployment: StudyDeployment = repository.getStudyDeploymentBy( studyDeploymentId )
 
@@ -51,7 +51,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository ) : De
      * [deviceRoleName] is not present in the deployment or is already registered,
      * or [registration] is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device.
      */
-    override fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
+    override suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
     {
         val deployment = repository.getStudyDeploymentBy( studyDeploymentId )
 
@@ -70,7 +70,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository ) : De
      * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
      * or [masterDeviceRoleName] is not present in the deployment, or not yet registered.
      */
-    override fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
+    override suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
     {
         val deployment = repository.getStudyDeploymentBy( studyDeploymentId )
 

--- a/carp.test/build.gradle
+++ b/carp.test/build.gradle
@@ -23,11 +23,13 @@ kotlin {
             dependencies {
                 implementation kotlin('test')
                 implementation kotlin('test-junit5')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
             }
         }
         jsMain {
             dependencies {
                 implementation kotlin('test-js')
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:${versions.coroutines}"
             }
         }
     }

--- a/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
+++ b/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
@@ -1,0 +1,3 @@
+package dk.cachet.carp.test
+
+expect fun runBlockingTest(block: suspend () -> Unit)

--- a/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
+++ b/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
@@ -1,3 +1,3 @@
 package dk.cachet.carp.test
 
-expect fun runBlockingTest(block: suspend () -> Unit)
+expect fun runBlockingTest( block: suspend () -> Unit )

--- a/carp.test/src/jsMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
+++ b/carp.test/src/jsMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
@@ -3,4 +3,4 @@ package dk.cachet.carp.test
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.promise
 
-actual fun runBlockingTest(block: suspend () -> Unit): dynamic = GlobalScope.promise { block() }
+actual fun runBlockingTest( block: suspend () -> Unit ): dynamic = GlobalScope.promise { block() }

--- a/carp.test/src/jsMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
+++ b/carp.test/src/jsMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
@@ -1,0 +1,6 @@
+package dk.cachet.carp.test
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+
+actual fun runBlockingTest(block: suspend () -> Unit): dynamic = GlobalScope.promise { block() }

--- a/carp.test/src/jvmMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
+++ b/carp.test/src/jvmMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
@@ -1,0 +1,5 @@
+package dk.cachet.carp.test
+
+import kotlinx.coroutines.runBlocking
+
+actual fun runBlockingTest(block: suspend () -> Unit) = runBlocking { block() }

--- a/carp.test/src/jvmMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
+++ b/carp.test/src/jvmMain/kotlin/dk/cachet/carp/test/runBlockingTest.kt
@@ -2,4 +2,4 @@ package dk.cachet.carp.test
 
 import kotlinx.coroutines.runBlocking
 
-actual fun runBlockingTest(block: suspend () -> Unit) = runBlocking { block() }
+actual fun runBlockingTest( block: suspend () -> Unit ) = runBlocking { block() }


### PR DESCRIPTION
The `DeploymentService` interface defines blocking methods. This is not a suitable API since implementations might rely on slow operations, such as REST calls.

A straightforward solution would be to rely on Kotlin's built-in language support for asynchronous operations: [coroutines](https://kotlinlang.org/docs/reference/coroutines-overview.html). There is multiplatform support for this. However, a potential downside is that it might be unclear how to consume such APIs natively. More research is needed to determine exactly how this would work.

Furthermore, we have had a discussion on the following two related points:

- Should the same interface be used to _implement_ the service as well as to consume it?
- Is the need for an asynchronous implementation of this interface an implementation detail or not? I.e., is this an infrastructural concern or not?

The current pull request includes the required changes to be able to implement `DeploymentService` using coroutines. Note: every function that implements or consumes the suspending functions in `DeploymentService` also had to be converted into suspending functions. Helper functions are created in the `carp.test` module to consume the new suspending functions by blocking.