### PR TITLE
Manage and store participation in StudyDeployment

### DIFF
--- a/carp.deployment.core/package-lock.json
+++ b/carp.deployment.core/package-lock.json
@@ -20,6 +20,15 @@
         "color-convert": "^1.9.0"
       }
     },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -33,6 +42,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -40,6 +54,14 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "browser-stdout": {
@@ -70,6 +92,21 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
       }
     },
     "cliui": {
@@ -201,6 +238,14 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -249,6 +294,14 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "global-modules": {
@@ -328,6 +381,14 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
@@ -343,10 +404,28 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -457,85 +536,6 @@
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
-        "anymatch": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          }
-        },
-        "binary-extensions": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "chokidar": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-          "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.1",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.2.0"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
-        "is-binary-path": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-          "requires": {
-            "binary-extensions": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-        },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-        },
         "node-environment-flags": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -543,32 +543,6 @@
           "requires": {
             "object.getownpropertydescriptors": "^2.0.3",
             "semver": "^5.7.0"
-          }
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-        },
-        "picomatch": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-          "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
-        },
-        "readdirp": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-          "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
-          "requires": {
-            "picomatch": "^2.0.4"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "requires": {
-            "is-number": "^7.0.0"
           }
         }
       }
@@ -586,6 +560,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -660,6 +639,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "picomatch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
+    },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -741,6 +733,14 @@
       "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
       }
     },
     "which": {

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -5,7 +5,9 @@ import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.deployment.domain.users.Participation
+import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
+import dk.cachet.carp.protocols.domain.InvalidConfigurationError
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
 
@@ -63,4 +65,9 @@ interface DeploymentService
      * @throws IllegalArgumentException in case there is no study deployment with [studyDeploymentId].
      */
     suspend fun addParticipation( studyDeploymentId: UUID, identity: AccountIdentity, invitation: StudyInvitation ): Participation
+
+    /**
+     * Get all participations to study deployments the account with the given [accountId] has been invited to.
+     */
+    suspend fun getParticipationInvitations( accountId: UUID ): Set<ParticipationInvitation>
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -116,16 +116,16 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
                 if ( isNewAccount ) null
                 else repository.getParticipations( account!!.id ).firstOrNull { it.studyDeploymentId == studyDeploymentId }
         val isNewParticipation = participation == null
-        participation = participation ?: Participation( studyDeploymentId, invitation )
+        participation = participation ?: Participation( studyDeploymentId )
 
         // Ensure an account exists for the given identity and an invitation has been sent out.
         if ( isNewAccount )
         {
-            account = accountService.inviteNewAccount( identity, participation )
+            account = accountService.inviteNewAccount( identity, invitation, participation )
         }
         else if ( isNewParticipation )
         {
-            accountService.inviteExistingAccount( identity, participation )
+            accountService.inviteExistingAccount( identity, invitation, participation )
         }
 
         // Add participation to repository.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.deployment.domain
 
 import dk.cachet.carp.common.UUID
-import dk.cachet.carp.deployment.domain.users.Participation
 
 
 interface DeploymentRepository
@@ -27,22 +26,4 @@ interface DeploymentRepository
      * @throws IllegalArgumentException when no previous version of this study deployment is stored in the repository.
      */
     fun update( studyDeployment: StudyDeployment )
-
-    /**
-     * Add [participation] information for a study deployment that an account with the given [accountId] should participate in.
-     *
-     * @param accountId The ID of the account which acts as a [Participation] in a study.
-     * @param participation The [Participation] information of the study to participate in.
-     */
-    fun addParticipation( accountId: UUID, participation: Participation )
-
-    /**
-     * Get [Participation] information for all study deployments an account with the given [accountId] participates in.
-     */
-    fun getParticipations( accountId: UUID ): List<Participation>
-
-    /**
-     * Get all participations included in a study deployment for the given [studyDeploymentId].
-     */
-    fun getParticipationsForStudyDeployment( studyDeploymentId: UUID ): List<Participation>
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.deployment.domain
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 
 
 interface DeploymentRepository
@@ -26,4 +27,14 @@ interface DeploymentRepository
      * @throws IllegalArgumentException when no previous version of this study deployment is stored in the repository.
      */
     fun update( studyDeployment: StudyDeployment )
+
+    /**
+     * Add a participation [invitation] for an account with the given [accountId].
+     */
+    fun addInvitation( accountId: UUID, invitation: ParticipationInvitation )
+
+    /**
+     * Get all participation invitations for the account with the specified [accountId].
+     */
+    fun getInvitations( accountId: UUID ): Set<ParticipationInvitation>
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -3,6 +3,9 @@ package dk.cachet.carp.deployment.domain
 import dk.cachet.carp.common.Trilean
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.serialization.UnknownPolymorphicWrapper
+import dk.cachet.carp.common.users.Account
+import dk.cachet.carp.deployment.domain.users.AccountParticipation
+import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.protocols.domain.InvalidConfigurationError
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
@@ -34,12 +37,17 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
                 deployment.registerDevice( registrable.device, r.value )
             }
 
+            // Add participations.
+            snapshot.participations.forEach { p ->
+                deployment._participations.add( AccountParticipation( p.accountId, p.participationId ) )
+            }
+
             return deployment
         }
     }
 
 
-    private val _protocol: StudyProtocol =
+    private val protocol: StudyProtocol =
         try
         {
             StudyProtocol.fromSnapshot( protocolSnapshot )
@@ -65,12 +73,20 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
 
     private val _registeredDevices: MutableMap<AnyDeviceDescriptor, DeviceRegistration> = mutableMapOf()
 
+    /**
+     * The account IDs participating in this study deployment and the pseudonym IDs assigned to them.
+     */
+    val participations: Set<AccountParticipation>
+        get() = _participations
+
+    private val _participations: MutableSet<AccountParticipation> = mutableSetOf()
+
     init
     {
-        require( _protocol.isDeployable() ) { "The passed protocol snapshot contains deployment errors." }
+        require( protocol.isDeployable() ) { "The passed protocol snapshot contains deployment errors." }
 
         // Initialize information which devices can or should be registered for this deployment.
-        _registrableDevices = _protocol.devices
+        _registrableDevices = protocol.devices
             // Top-level master devices require registration.
             .map { RegistrableDevice( it, isTopLevelMasterDevice( it ) ) }
             .toMutableSet()
@@ -95,7 +111,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
     }
 
     private fun isTopLevelMasterDevice( device: AnyDeviceDescriptor ): Boolean =
-        device is AnyMasterDeviceDescriptor && _protocol.masterDevices.contains( device )
+        device is AnyMasterDeviceDescriptor && protocol.masterDevices.contains( device )
 
     /**
      * Determines whether the deployment configuration (to initialize the device environment) for a specific device can be obtained.
@@ -171,7 +187,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
         val configuration: DeviceRegistration = _registeredDevices[ device ]!! // Must be non-null, otherwise canObtainDeviceDeployment would fail.
 
         // Determine which devices this device needs to connect to and retrieve configuration for preregistered devices.
-        val connectedDevices: Set<AnyDeviceDescriptor> = _protocol.getConnectedDevices( device ).toSet()
+        val connectedDevices: Set<AnyDeviceDescriptor> = protocol.getConnectedDevices( device ).toSet()
         val deviceRegistrations: Map<String, DeviceRegistration> = _registeredDevices
             .filter { connectedDevices.contains( it.key ) }
             .mapKeys { it.key.roleName }
@@ -179,7 +195,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
         // Get all tasks which might need to be executed on this or connected devices.
         val relevantDevices = arrayOf( device ).union( connectedDevices )
         val tasks = relevantDevices
-            .flatMap { _protocol.getTasksForDevice( it ) }
+            .flatMap { protocol.getTasksForDevice( it ) }
             .toSet()
 
         // Get all trigger information for this and connected devices.
@@ -188,7 +204,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
         val usedTriggers = protocolSnapshot.triggers
             .filter { relevantDeviceRoles.contains( it.value.sourceDeviceRoleName ) }
         val triggeredTasks = usedTriggers
-            .map { it to _protocol.getTriggeredTasks( it.value ) }
+            .map { it to protocol.getTriggeredTasks( it.value ) }
             .flatMap { pair -> pair.second.map {
                 MasterDeviceDeployment.TriggeredTask( pair.first.key, it.task.name, it.targetDevice.roleName ) } }
             .toSet()
@@ -201,6 +217,30 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
             usedTriggers,
             triggeredTasks )
     }
+
+    /**
+     * Add [participation] details for a given [account] to this study deployment.
+     *
+     * @throws IllegalArgumentException if the specified [account] already participates in this deployment,
+     * or if the [participation] details do not match this study deployment.
+     */
+    fun addParticipation( account: Account, participation: Participation )
+    {
+        require( id == participation.studyDeploymentId ) { "The specified participation details do not match this study deployment." }
+        require( _participations.none { it.accountId == account.id } ) { "The specified account already participates in this study deployment." }
+
+        _participations.add( AccountParticipation( account.id, participation.id ) )
+    }
+
+    /**
+     * Get the participation details for a given [account] in this study deployment,
+     * or null in case the [account] does not participate in this study deployment.
+     */
+    fun getParticipation( account: Account ): Participation? =
+        _participations
+            .filter { it.accountId == account.id }
+            .map { Participation( id, it.participationId ) }
+            .singleOrNull()
 
 
     /**

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.deployment.domain
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.deployment.domain.users.AccountParticipation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistrationSerializer
@@ -14,7 +15,8 @@ import kotlinx.serialization.Serializable
 data class StudyDeploymentSnapshot(
     val studyDeploymentId: UUID,
     val studyProtocolSnapshot: StudyProtocolSnapshot,
-    val registeredDevices: Map<String, @Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>
+    val registeredDevices: Map<String, @Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>,
+    val participations: Set<AccountParticipation>
 )
 {
     companion object
@@ -29,7 +31,8 @@ data class StudyDeploymentSnapshot(
             return StudyDeploymentSnapshot(
                 studyDeployment.id,
                 studyDeployment.protocolSnapshot,
-                studyDeployment.registeredDevices.mapKeys { it.key.roleName } )
+                studyDeployment.registeredDevices.mapKeys { it.key.roleName },
+                studyDeployment.participations )
         }
     }
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/AccountParticipation.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/AccountParticipation.kt
@@ -1,0 +1,11 @@
+package dk.cachet.carp.deployment.domain.users
+
+import dk.cachet.carp.common.UUID
+import kotlinx.serialization.Serializable
+
+
+/**
+ * An account participating in a study deployment and the pseudonym ID assigned to this participation.
+ */
+@Serializable
+data class AccountParticipation( val accountId: UUID, val participationId: UUID )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/AccountService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/AccountService.kt
@@ -11,18 +11,18 @@ interface AccountService
 {
     /**
      * Create a new account identified by [identity] to participate in a study deployment with the given [participation] details.
-     * An invitation and account details should be delivered, or made available, to the user managing the [identity].
+     * The [invitation] and account details should be delivered, or made available, to the user managing the [identity].
      *
      * @throws IllegalArgumentException when an account with a matching [AccountIdentity] already exists.
      */
-    suspend fun inviteNewAccount( identity: AccountIdentity, participation: Participation ): Account
+    suspend fun inviteNewAccount( identity: AccountIdentity, invitation: StudyInvitation, participation: Participation ): Account
 
     /**
-     * Provide [participation] details, or make it available, to the user managing [identity].
+     * Send out a [participation] [invitation] for a study, or make it available, to the user managing [identity].
      *
      * @throws IllegalArgumentException when no account with a matching [identity] exists.
      */
-    suspend fun inviteExistingAccount( identity: AccountIdentity, participation: Participation )
+    suspend fun inviteExistingAccount( identity: AccountIdentity, invitation: StudyInvitation, participation: Participation )
 
     /**
      * Returns the [Account] which has the specified [identity], or null when no account is found.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/Participation.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/Participation.kt
@@ -10,9 +10,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Participation(
     val studyDeploymentId: UUID,
-    /**
-     * The invitation to participate in this study which should be sent to the participant.
-     */
-    val invitation: StudyInvitation,
     val id: UUID = UUID.randomUUID()
 )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationInvitation.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationInvitation.kt
@@ -1,0 +1,10 @@
+package dk.cachet.carp.deployment.domain.users
+
+import kotlinx.serialization.Serializable
+
+
+/**
+ * A [participation] in a study deployment and the [invitation] to participate in the study.
+ */
+@Serializable
+data class ParticipationInvitation( val participation: Participation, val invitation: StudyInvitation )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/StudyInvitation.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/StudyInvitation.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class StudyInvitation(
     /**
-     * A descriptive name for the [Study] to be shown to participants.
+     * A descriptive name for the study to be shown to participants.
      */
     val name: String
 )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -8,6 +8,7 @@ import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.deployment.domain.users.Participation
+import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
@@ -49,4 +50,9 @@ sealed class DeploymentServiceRequest
     data class AddParticipation( val studyDeploymentId: UUID, val identity: AccountIdentity, val invitation: StudyInvitation ) :
         DeploymentServiceRequest(),
         ServiceInvoker<DeploymentService, Participation> by createServiceInvoker( DeploymentService::addParticipation, studyDeploymentId, identity, invitation )
+
+    @Serializable
+    data class GetParticipationInvitations( val accountId: UUID ) :
+        DeploymentServiceRequest(),
+        ServiceInvoker<DeploymentService, Set<ParticipationInvitation>> by createServiceInvoker( DeploymentService::getParticipationInvitations, accountId )
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryAccountService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryAccountService.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.users.Account
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.users.AccountService
 import dk.cachet.carp.deployment.domain.users.Participation
+import dk.cachet.carp.deployment.domain.users.StudyInvitation
 
 
 /**
@@ -16,11 +17,11 @@ class InMemoryAccountService : AccountService
 
     /**
      * Create a new account identified by [identity] to participate in a study deployment with the given [participation] details.
-     * An invitation and account details should be delivered, or made available, to the user managing the [identity].
+     * The [invitation] and account details should be delivered, or made available, to the user managing the [identity].
      *
      * @throws IllegalArgumentException when an account with a matching [AccountIdentity] already exists.
      */
-    override suspend fun inviteNewAccount( identity: AccountIdentity, participation: Participation ): Account
+    override suspend fun inviteNewAccount( identity: AccountIdentity, invitation: StudyInvitation, participation: Participation ): Account
     {
         require( accounts.none { it.identity == identity } )
 
@@ -31,11 +32,11 @@ class InMemoryAccountService : AccountService
     }
 
     /**
-     * Provide [participation] details, or make it available, to the user managing [identity].
+     * Send out a [participation] [invitation] for a study, or make it available, to the user managing [identity].
      *
      * @throws IllegalArgumentException when no account with a matching [identity] exists.
      */
-    override suspend fun inviteExistingAccount( identity: AccountIdentity, participation: Participation )
+    override suspend fun inviteExistingAccount( identity: AccountIdentity, invitation: StudyInvitation, participation: Participation )
     {
         require( accounts.any { it.identity == identity } )
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.deployment.infrastructure
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.DeploymentRepository
 import dk.cachet.carp.deployment.domain.StudyDeployment
+import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 
 
 /**
@@ -11,6 +12,7 @@ import dk.cachet.carp.deployment.domain.StudyDeployment
 class InMemoryDeploymentRepository : DeploymentRepository
 {
     private val studyDeployments: MutableMap<UUID, StudyDeployment> = mutableMapOf()
+    private val participationInvitations: MutableMap<UUID, MutableSet<ParticipationInvitation>> = mutableMapOf()
 
 
     /**
@@ -44,4 +46,19 @@ class InMemoryDeploymentRepository : DeploymentRepository
 
         studyDeployments[ studyDeployment.id ] = studyDeployment
     }
+
+    /**
+     * Add a participation [invitation] for an account with the given [accountId].
+     */
+    override fun addInvitation( accountId: UUID, invitation: ParticipationInvitation )
+    {
+        val invitations = participationInvitations.getOrPut( accountId ) { mutableSetOf() }
+        invitations.add( invitation )
+    }
+
+    /**
+     * Get all participation invitations for the account with the specified [accountId].
+     */
+    override fun getInvitations( accountId: UUID ): Set<ParticipationInvitation> =
+        participationInvitations.getOrElse( accountId ) { setOf() }
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
@@ -3,7 +3,6 @@ package dk.cachet.carp.deployment.infrastructure
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.DeploymentRepository
 import dk.cachet.carp.deployment.domain.StudyDeployment
-import dk.cachet.carp.deployment.domain.users.Participation
 
 
 /**
@@ -12,7 +11,7 @@ import dk.cachet.carp.deployment.domain.users.Participation
 class InMemoryDeploymentRepository : DeploymentRepository
 {
     private val studyDeployments: MutableMap<UUID, StudyDeployment> = mutableMapOf()
-    private val participations: MutableMap<UUID, MutableSet<Participation>> = mutableMapOf()
+
 
     /**
      * Adds the specified [studyDeployment] to the repository.
@@ -45,28 +44,4 @@ class InMemoryDeploymentRepository : DeploymentRepository
 
         studyDeployments[ studyDeployment.id ] = studyDeployment
     }
-
-    /**
-     * Add [participation] information for a study deployment that an account with the given [accountId] should participate in.
-     *
-     * @param accountId The ID of the account which acts as a [Participation] in a study.
-     * @param participation The [Participation] information of the study to participate in.
-     */
-    override fun addParticipation( accountId: UUID, participation: Participation )
-    {
-        val accountParticipations = participations.getOrPut( accountId ) { mutableSetOf() }
-        accountParticipations.add( participation )
-    }
-
-    /**
-     * Get [Participation] information for all study deployments an account with the given [accountId] participates in.
-     */
-    override fun getParticipations( accountId: UUID ): List<Participation> =
-        participations[ accountId ]?.toList() ?: listOf()
-
-    /**
-     * Get all participations included in a study deployment for the given [studyDeploymentId].
-     */
-    override fun getParticipationsForStudyDeployment( studyDeploymentId: UUID ): List<Participation> =
-        participations.flatMap { it.component2().filter { p -> p.studyDeploymentId == studyDeploymentId } }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.deployment.domain.users.Participation
+import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
@@ -16,7 +17,8 @@ class DeploymentServiceMock(
     private val createStudyDeploymentResult: StudyDeploymentStatus = emptyStatus,
     private val getStudyDeploymentStatusResult: StudyDeploymentStatus = emptyStatus,
     private val registerDeviceResult: StudyDeploymentStatus = emptyStatus,
-    private val getDeviceDeploymentForResult: MasterDeviceDeployment = emptyMasterDeviceDeployment
+    private val getDeviceDeploymentForResult: MasterDeviceDeployment = emptyMasterDeviceDeployment,
+    private val getParticipationInvitationResult: Set<ParticipationInvitation> = setOf()
 ) : Mock<DeploymentService>(), DeploymentService
 {
     companion object
@@ -58,5 +60,11 @@ class DeploymentServiceMock(
     {
         trackSuspendCall( DeploymentService::addParticipation, studyDeploymentId, identity, invitation )
         return Participation( studyDeploymentId )
+    }
+
+    override suspend fun getParticipationInvitations( accountId: UUID ): Set<ParticipationInvitation>
+    {
+        trackSuspendCall( DeploymentService::getParticipationInvitations, accountId )
+        return getParticipationInvitationResult
     }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -57,6 +57,6 @@ class DeploymentServiceMock(
     override suspend fun addParticipation( studyDeploymentId: UUID, identity: AccountIdentity, invitation: StudyInvitation ): Participation
     {
         trackSuspendCall( DeploymentService::addParticipation, studyDeploymentId, identity, invitation )
-        return Participation( studyDeploymentId, invitation )
+        return Participation( studyDeploymentId )
     }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.createSingleMasterWithConnectedDeviceProtocol
 import dk.cachet.carp.deployment.domain.users.AccountService
 import dk.cachet.carp.deployment.domain.users.Participation
+import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.test.runBlockingTest
 import kotlin.test.*
@@ -72,6 +73,20 @@ abstract class DeploymentServiceTest
         {
             deploymentService.addParticipation( unknownId, identity, StudyInvitation.empty() )
         }
+    }
+
+    @Test
+    fun addParticipation_and_retrieving_invitation_succeeds() = runBlockingTest {
+        val ( deploymentService, accountService ) = createService()
+        val studyDeploymentId = addTestDeployment( deploymentService )
+        val identity = AccountIdentity.fromEmailAddress( "test@test.com" )
+        val invitation = StudyInvitation.empty()
+
+        val participation = deploymentService.addParticipation( studyDeploymentId, identity, invitation )
+        val account = accountService.findAccount( identity )
+        assertNotNull( account )
+        val retrievedInvitations = deploymentService.getParticipationInvitations( account.id )
+        assertEquals( ParticipationInvitation( participation, invitation ), retrievedInvitations.single() )
     }
 
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -3,7 +3,9 @@ package dk.cachet.carp.deployment.domain
 import dk.cachet.carp.common.Trilean
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.serialization.NotSerializable
+import dk.cachet.carp.common.users.Account
 import dk.cachet.carp.deployment.domain.triggers.StubTrigger
+import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
@@ -21,8 +23,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlin.reflect.KClass
 
-
-val testId = UUID( "27c56423-b7cd-48dd-8b7f-f819621a34f0" )
 
 /**
  * Stubs for testing extending from types in [dk.cachet.carp.protocols] module which need to be registered when using [Json] serializer.
@@ -83,7 +83,26 @@ fun createSingleMasterWithConnectedDeviceProtocol(
 fun studyDeploymentFor( protocol: StudyProtocol ): StudyDeployment
 {
     val snapshot = protocol.getSnapshot()
-    return StudyDeployment( snapshot, testId )
+    return StudyDeployment( snapshot )
+}
+
+/**
+ * Creates a study deployment with a registered device and participation added.
+ */
+fun createComplexDeployment(): StudyDeployment
+{
+    val protocol = createSingleMasterWithConnectedDeviceProtocol()
+    val deployment = studyDeploymentFor( protocol )
+
+    // Add device registration.
+    deployment.registerDevice( deployment.registrableDevices.first().device, DefaultDeviceRegistration( "test" ) )
+
+    // Add a participation.
+    val account = Account.withUsernameIdentity( "test" )
+    val participation = Participation( deployment.id )
+    deployment.addParticipation( account, participation )
+
+    return deployment
 }
 
 @Serializable

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
@@ -1,8 +1,6 @@
 package dk.cachet.carp.deployment.domain
 
 import dk.cachet.carp.common.UUID
-import dk.cachet.carp.common.users.Account
-import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
 import kotlin.test.*
 
@@ -80,50 +78,5 @@ interface DeploymentRepositoryTest
         {
             repo.update( deployment )
         }
-    }
-
-    @Test
-    fun addStudyParticipation_and_retrieving_it_succeeds()
-    {
-        val repo = createRepository()
-        val account = Account.withUsernameIdentity( "test" )
-        val studyDeploymentId = UUID.randomUUID()
-        val participation = Participation( studyDeploymentId )
-
-        repo.addParticipation( account.id, participation )
-        val participations = repo.getParticipationsForStudyDeployment( studyDeploymentId )
-
-        assertEquals( participation, participations.single() )
-    }
-
-    @Test
-    fun addStudyParticipation_with_existing_participation_only_adds_once()
-    {
-        val repo = createRepository()
-        val account = Account.withUsernameIdentity( "test" )
-        val studyDeploymentId = UUID.randomUUID()
-        val participation = Participation( studyDeploymentId )
-
-        repo.addParticipation( account.id, participation )
-        repo.addParticipation( account.id, participation )
-        val participations = repo.getParticipationsForStudyDeployment( studyDeploymentId )
-
-        assertEquals( participation, participations.single() )
-    }
-
-    @Test
-    fun getParticipationsForStudyDeployment_returns_matching_participations_only()
-    {
-        val repo = createRepository()
-        val account = Account.withUsernameIdentity( "test" )
-        val studyDeploymentId = UUID.randomUUID()
-        val participations = listOf( Participation( studyDeploymentId ), Participation( studyDeploymentId )
-        )
-        val otherParticipations = Participation( UUID.randomUUID() ) // Some other study deployment.
-
-        (participations + otherParticipations).forEach { repo.addParticipation( account.id, it ) }
-        val retrievedParticipations = repo.getParticipationsForStudyDeployment( studyDeploymentId )
-
-        assertEquals( 2, retrievedParticipations.intersect( participations ).count() )
     }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
@@ -1,6 +1,10 @@
 package dk.cachet.carp.deployment.domain
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.users.Account
+import dk.cachet.carp.deployment.domain.users.Participation
+import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
+import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
 import kotlin.test.*
 
@@ -78,5 +82,27 @@ interface DeploymentRepositoryTest
         {
             repo.update( deployment )
         }
+    }
+
+    @Test
+    fun addInvitation_and_retrieving_it_succeeds()
+    {
+        val repo = createRepository()
+
+        val account = Account.withUsernameIdentity( "test" )
+        val participation = Participation( UUID.randomUUID() )
+        val invitation = ParticipationInvitation( participation, StudyInvitation.empty() )
+        repo.addInvitation( account.id, invitation )
+        val retrievedInvitations = repo.getInvitations( account.id )
+        assertEquals( invitation, retrievedInvitations.single() )
+    }
+
+    @Test
+    fun getInvitations_is_empty_when_no_invitations()
+    {
+        val repo = createRepository()
+
+        val invitations = repo.getInvitations( UUID.randomUUID() )
+        assertEquals( 0, invitations.count() )
     }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
@@ -3,7 +3,6 @@ package dk.cachet.carp.deployment.domain
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.Account
 import dk.cachet.carp.deployment.domain.users.Participation
-import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
 import kotlin.test.*
 
@@ -89,8 +88,7 @@ interface DeploymentRepositoryTest
         val repo = createRepository()
         val account = Account.withUsernameIdentity( "test" )
         val studyDeploymentId = UUID.randomUUID()
-        val invitation = StudyInvitation( "Welcome to this study!" )
-        val participation = Participation( studyDeploymentId, invitation )
+        val participation = Participation( studyDeploymentId )
 
         repo.addParticipation( account.id, participation )
         val participations = repo.getParticipationsForStudyDeployment( studyDeploymentId )
@@ -104,7 +102,7 @@ interface DeploymentRepositoryTest
         val repo = createRepository()
         val account = Account.withUsernameIdentity( "test" )
         val studyDeploymentId = UUID.randomUUID()
-        val participation = Participation( studyDeploymentId, StudyInvitation.empty() )
+        val participation = Participation( studyDeploymentId )
 
         repo.addParticipation( account.id, participation )
         repo.addParticipation( account.id, participation )
@@ -119,11 +117,9 @@ interface DeploymentRepositoryTest
         val repo = createRepository()
         val account = Account.withUsernameIdentity( "test" )
         val studyDeploymentId = UUID.randomUUID()
-        val participations = listOf(
-            Participation( studyDeploymentId, StudyInvitation.empty() ),
-            Participation( studyDeploymentId, StudyInvitation.empty() )
+        val participations = listOf( Participation( studyDeploymentId ), Participation( studyDeploymentId )
         )
-        val otherParticipations = Participation( UUID.randomUUID(), StudyInvitation.empty() ) // Some other study deployment.
+        val otherParticipations = Participation( UUID.randomUUID() ) // Some other study deployment.
 
         (participations + otherParticipations).forEach { repo.addParticipation( account.id, it ) }
         val retrievedParticipations = repo.getParticipationsForStudyDeployment( studyDeploymentId )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/AccountServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/AccountServiceTest.kt
@@ -29,8 +29,8 @@ abstract class AccountServiceTest
         val service = createService()
 
         // Create and verify account.
-        val participation = Participation( UUID.randomUUID(), StudyInvitation.empty() )
-        val account = service.inviteNewAccount( identity, participation )
+        val participation = Participation( UUID.randomUUID() )
+        val account = service.inviteNewAccount( identity, StudyInvitation.empty(), participation )
         assertEquals( identity, account.identity )
 
         // Verify whether account can be retrieved.
@@ -48,11 +48,11 @@ abstract class AccountServiceTest
 
     private fun inviteNewAccountWithExistingTest( identity: AccountIdentity ) = runBlockingTest {
         val service = createService()
-        val participation = Participation( UUID.randomUUID(), StudyInvitation.empty() )
-        service.inviteNewAccount( identity, participation )
+        val participation = Participation( UUID.randomUUID() )
+        service.inviteNewAccount( identity, StudyInvitation.empty(), participation )
 
         assertFailsWith<IllegalArgumentException> {
-            service.inviteNewAccount( identity, participation )
+            service.inviteNewAccount( identity, StudyInvitation.empty(), participation )
         }
     }
 
@@ -66,10 +66,10 @@ abstract class AccountServiceTest
 
     private fun inviteExistingAccountWithNewTest( identity: AccountIdentity ) = runBlockingTest {
         val service = createService()
-        val participation = Participation( UUID.randomUUID(), StudyInvitation.empty() )
+        val participation = Participation( UUID.randomUUID() )
 
         assertFailsWith<IllegalArgumentException> {
-            service.inviteExistingAccount( identity, participation )
+            service.inviteExistingAccount( identity, StudyInvitation.empty(), participation )
         }
     }
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -24,7 +24,8 @@ class DeploymentServiceRequestsTest
             DeploymentServiceRequest.GetStudyDeploymentStatus( UUID.randomUUID() ),
             DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration( "Device ID" ) ),
             DeploymentServiceRequest.GetDeviceDeploymentFor( UUID.randomUUID(), "Test role" ),
-            DeploymentServiceRequest.AddParticipation( UUID.randomUUID(), UsernameAccountIdentity( "Test" ), StudyInvitation.empty() )
+            DeploymentServiceRequest.AddParticipation( UUID.randomUUID(), UsernameAccountIdentity( "Test" ), StudyInvitation.empty() ),
+            DeploymentServiceRequest.GetParticipationInvitations( UUID.randomUUID() )
         )
     }
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipationTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipationTest.kt
@@ -2,7 +2,6 @@ package dk.cachet.carp.deployment.infrastructure
 
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.Participation
-import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import kotlin.test.*
 
 
@@ -14,7 +13,7 @@ class ParticipationTest
     @Test
     fun can_serialize_and_deserialize_participation_using_JSON()
     {
-        val participation = Participation( UUID.randomUUID(), StudyInvitation.empty() )
+        val participation = Participation( UUID.randomUUID() )
 
         val serialized = participation.toJson()
         val parsed = Participation.fromJson( serialized )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentSnapshotTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentSnapshotTest.kt
@@ -1,10 +1,10 @@
 package dk.cachet.carp.deployment.infrastructure
 
+import dk.cachet.carp.deployment.domain.createComplexDeployment
 import dk.cachet.carp.deployment.domain.createEmptyProtocol
-import dk.cachet.carp.deployment.domain.createSingleMasterWithConnectedDeviceProtocol
-import dk.cachet.carp.deployment.domain.STUBS_SERIAL_MODULE
 import dk.cachet.carp.deployment.domain.studyDeploymentFor
 import dk.cachet.carp.deployment.domain.StudyDeploymentSnapshot
+import dk.cachet.carp.deployment.domain.STUBS_SERIAL_MODULE
 import dk.cachet.carp.deployment.domain.UnknownDeviceRegistration
 import dk.cachet.carp.deployment.domain.UnknownMasterDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.CustomDeviceRegistration
@@ -25,10 +25,8 @@ class StudyDeploymentSnapshotTest
     @Test
     fun can_serialize_and_deserialize_snapshot_using_JSON()
     {
-        val protocol = createSingleMasterWithConnectedDeviceProtocol()
-        val deployment = studyDeploymentFor( protocol )
+        val deployment = createComplexDeployment()
         val snapshot: StudyDeploymentSnapshot = deployment.getSnapshot()
-
 
         val serialized: String = snapshot.toJson()
         val parsed: StudyDeploymentSnapshot = StudyDeploymentSnapshot.fromJson( serialized )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentTest.kt
@@ -1,12 +1,12 @@
 package dk.cachet.carp.deployment.infrastructure
 
+import dk.cachet.carp.deployment.domain.createComplexDeployment
 import dk.cachet.carp.deployment.domain.createEmptyProtocol
 import dk.cachet.carp.deployment.domain.StubMasterDeviceDescriptor
 import dk.cachet.carp.deployment.domain.STUBS_SERIAL_MODULE
 import dk.cachet.carp.deployment.domain.StudyDeployment
-import dk.cachet.carp.deployment.domain.StudyDeploymentSnapshot
 import dk.cachet.carp.deployment.domain.studyDeploymentFor
-import dk.cachet.carp.deployment.domain.testId
+import dk.cachet.carp.deployment.domain.StudyDeploymentSnapshot
 import dk.cachet.carp.deployment.domain.UnknownDeviceRegistration
 import dk.cachet.carp.deployment.domain.UnknownMasterDeviceDescriptor
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
@@ -27,6 +27,24 @@ class StudyDeploymentTest
     }
 
     @Test
+    fun creating_study_deployment_fromSnapshot_obtained_by_getSnapshot_is_the_same()
+    {
+        val deployment = createComplexDeployment()
+
+        val snapshot = deployment.getSnapshot()
+        val fromSnapshot = StudyDeployment.fromSnapshot( snapshot )
+
+        assertEquals( deployment.id, fromSnapshot.id )
+        assertEquals( deployment.protocolSnapshot, fromSnapshot.protocolSnapshot )
+        val commonRegisteredDevices =
+            deployment.registeredDevices.asIterable().intersect( fromSnapshot.registeredDevices.asIterable() )
+        assertEquals( deployment.registeredDevices.count(), commonRegisteredDevices.count() )
+        val commonParticipations =
+            deployment.participations.intersect( fromSnapshot.participations )
+        assertEquals( deployment.participations.count(), commonParticipations.count() )
+    }
+
+    @Test
     fun cant_initialize_deployment_with_invalid_snapshot()
     {
         // Initialize valid protocol.
@@ -44,7 +62,7 @@ class StudyDeploymentTest
 
         assertFailsWith<IllegalArgumentException>
         {
-            StudyDeployment( invalidSnapshot, testId )
+            StudyDeployment( invalidSnapshot )
         }
     }
 


### PR DESCRIPTION
- Refactor: participation is now stored as part of `StudyDeployment`. `StudyRepository.update( studyDeployment )` is used to store participations added through `StudyDeployment.addParticipation()`.
- Added `DeploymentService.getParticipationInvitations` endpoint.

Although 'participations' are now stored within `StudyDeployment`, the invitations which are sent out to accounts are stored separately.

To discuss:
- Should we allow storing invitations for study deployments that do not exist (or have since been removed) in `DeploymentRepository`? Suppose an email was sent, and then later you do not see the invitation anymore. Perhaps we should later add a state such as 'removed' to `ParticipationInvitation`.