### PR TITLE
Retrieve study information

### DIFF
--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -29,4 +29,9 @@ interface StudyService
      * @throws IllegalArgumentException when a study with [studyId] does not exist.
      */
     suspend fun getStudyStatus( studyId: UUID ): StudyStatus
+
+    /**
+     * Get status for all studies created by the specified [owner].
+     */
+    suspend fun getStudiesOverview( owner: StudyOwner ): List<StudyStatus>
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
@@ -45,4 +45,10 @@ class StudyServiceHost( private val repository: StudyRepository ) : StudyService
 
         return study.getStatus()
     }
+
+    /**
+     * Get status for all studies created by the specified [owner].
+     */
+    override suspend fun getStudiesOverview( owner: StudyOwner ): List<StudyStatus> =
+        repository.getForOwner( owner ).map { it.getStatus() }
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -56,7 +56,7 @@ class Study(
     /**
      * Get the status (serializable) of this [Study].
      */
-    fun getStatus(): StudyStatus = StudyStatus( id, name )
+    fun getStatus(): StudyStatus = StudyStatus( id, name, creationDate )
 
     /**
      * Include a participant in this [Study].

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.studies.domain
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 
@@ -28,6 +29,7 @@ class Study(
         fun fromSnapshot( snapshot: StudySnapshot ): Study
         {
             val study = Study( StudyOwner( snapshot.ownerId ), snapshot.name, snapshot.invitation, snapshot.studyId )
+            study.creationDate = snapshot.creationDate
 
             // Add participants.
             snapshot.participantIds.forEach { study.includeParticipant( it ) }
@@ -36,6 +38,12 @@ class Study(
         }
     }
 
+
+    /**
+     * The date when this study was created.
+     */
+    var creationDate: DateTime = DateTime.now()
+        private set
 
     private val _participantIds: MutableSet<UUID> = mutableSetOf()
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyRepository.kt
@@ -16,4 +16,9 @@ interface StudyRepository
      * Returns the [Study] which has the specified [studyId], or null when no study is found.
      */
     fun getById( studyId: UUID ): Study?
+
+    /**
+     * Returns the studies created by the specified [owner].
+     */
+    fun getForOwner( owner: StudyOwner ): List<Study>
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.studies.domain
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import kotlinx.serialization.Serializable
@@ -11,6 +12,7 @@ data class StudySnapshot(
     val ownerId: UUID,
     val name: String,
     val invitation: StudyInvitation,
+    val creationDate: DateTime,
     val participantIds: List<UUID>
 )
 {
@@ -28,6 +30,7 @@ data class StudySnapshot(
                 ownerId = study.owner.id,
                 name = study.name,
                 invitation = study.invitation,
+                creationDate = study.creationDate,
                 participantIds = study.participantIds.toList() )
         }
     }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyStatus.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyStatus.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.studies.domain
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import kotlinx.serialization.Serializable
 
@@ -13,5 +14,9 @@ data class StudyStatus(
     /**
      * A descriptive name for the study, as assigned by the [StudyOwner].
      */
-    val name: String
+    val name: String,
+    /**
+     * The date when this study was created.
+     */
+    val creationDate: DateTime
 )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryStudyRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryStudyRepository.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.studies.domain.Study
+import dk.cachet.carp.studies.domain.StudyOwner
 import dk.cachet.carp.studies.domain.StudyRepository
 
 
@@ -29,4 +30,10 @@ class InMemoryStudyRepository : StudyRepository
      * Returns the [Study] which has the specified [studyId], or null when no study is found.
      */
     override fun getById( studyId: UUID ): Study? = studies.firstOrNull { it.id == studyId }
+
+    /**
+     * Returns the studies created by the specified [owner].
+     */
+    override fun getForOwner( owner: StudyOwner ): List<Study> =
+        studies.filter { it.owner.id == owner.id }
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -25,4 +25,9 @@ sealed class StudyServiceRequest
     data class GetStudyStatus( val studyId: UUID ) :
         StudyServiceRequest(),
         ServiceInvoker<StudyService, StudyStatus> by createServiceInvoker( StudyService::getStudyStatus, studyId )
+
+    @Serializable
+    data class GetStudiesOverview( val owner: StudyOwner ) :
+        StudyServiceRequest(),
+        ServiceInvoker<StudyService, List<StudyStatus>> by createServiceInvoker( StudyService::getStudiesOverview, owner )
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.studies.application
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.studies.domain.StudyOwner
@@ -8,11 +9,17 @@ import dk.cachet.carp.test.Mock
 
 
 class StudyServiceMock(
-    private val createStudyResult: StudyStatus = StudyStatus( UUID.randomUUID(), "Test" ),
-    private val getStudyStatusResult: StudyStatus = StudyStatus( UUID.randomUUID(), "Test" ),
+    private val createStudyResult: StudyStatus = studyStatus,
+    private val getStudyStatusResult: StudyStatus = studyStatus,
     private val getStudiesOverview: List<StudyStatus> = listOf()
 ) : Mock<StudyService>(), StudyService
 {
+    companion object
+    {
+        private val studyStatus = StudyStatus( UUID.randomUUID(), "Test", DateTime.now() )
+    }
+
+
     override suspend fun createStudy( owner: StudyOwner, name: String, invitation: StudyInvitation? ): StudyStatus
     {
         trackSuspendCall( StudyService::createStudy, owner, name, invitation )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
@@ -9,7 +9,8 @@ import dk.cachet.carp.test.Mock
 
 class StudyServiceMock(
     private val createStudyResult: StudyStatus = StudyStatus( UUID.randomUUID(), "Test" ),
-    private val getStudyStatusResult: StudyStatus = StudyStatus( UUID.randomUUID(), "Test" )
+    private val getStudyStatusResult: StudyStatus = StudyStatus( UUID.randomUUID(), "Test" ),
+    private val getStudiesOverview: List<StudyStatus> = listOf()
 ) : Mock<StudyService>(), StudyService
 {
     override suspend fun createStudy( owner: StudyOwner, name: String, invitation: StudyInvitation? ): StudyStatus
@@ -22,5 +23,11 @@ class StudyServiceMock(
     {
         trackSuspendCall( StudyService::getStudyStatus, studyId )
         return getStudyStatusResult
+    }
+
+    override suspend fun getStudiesOverview( owner: StudyOwner ): List<StudyStatus>
+    {
+        trackSuspendCall( StudyService::getStudiesOverview, owner )
+        return getStudiesOverview
     }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
@@ -63,9 +63,19 @@ interface StudyServiceTest
     fun getStudyStatus_fails_for_unknown_study_id() = runBlockingTest {
         val ( service, _ ) = createService()
 
-        assertFailsWith<IllegalArgumentException>
-        {
-            service.getStudyStatus( UUID.randomUUID() )
-        }
+        assertFailsWith<IllegalArgumentException> { service.getStudyStatus( UUID.randomUUID() ) }
+    }
+
+    @Test
+    fun getStudiesOverview_returns_owner_studies() = runBlockingTest {
+        val ( service, _ ) = createService()
+        val owner = StudyOwner()
+        val studyOne = service.createStudy( owner, "One" )
+        val studyTwo = service.createStudy( owner, "Two" )
+        service.createStudy( StudyOwner(), "Three" )
+
+        val studiesOverview = service.getStudiesOverview( owner )
+        val expectedStudies = listOf( studyOne, studyTwo )
+        assertEquals( 2, studiesOverview.intersect( expectedStudies ).count() )
     }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
@@ -1,0 +1,20 @@
+package dk.cachet.carp.studies.domain
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.deployment.domain.users.StudyInvitation
+
+
+/**
+ * Create a study with a couple of participants added.
+ */
+fun createComplexStudy(): Study
+{
+    val owner = StudyOwner()
+    val invitation = StudyInvitation.empty()
+    val study = Study( owner, "Test", invitation )
+
+    study.includeParticipant( UUID.randomUUID() )
+    study.includeParticipant( UUID.randomUUID() )
+
+    return study
+}

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyRepositoryTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyRepositoryTest.kt
@@ -47,4 +47,18 @@ interface StudyRepositoryTest
         val foundStudy = repo.getById( UUID.randomUUID() )
         assertNull( foundStudy )
     }
+
+    @Test
+    fun getForOwner_returns_owner_studies_only()
+    {
+        val repo = createRepository()
+        val owner = StudyOwner()
+        val ownerStudy = Study( owner, "Test" )
+        val wrongStudy = Study( StudyOwner(), "Test" )
+        repo.add( ownerStudy )
+        repo.add( wrongStudy )
+
+        val ownerStudies = repo.getForOwner( owner )
+        assertEquals( ownerStudy.id, ownerStudies.single().id )
+    }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
@@ -43,20 +43,17 @@ class StudyTest
     @Test
     fun creating_study_fromSnapshot_obtained_by_getSnapshot_is_the_same()
     {
-        val owner = StudyOwner()
-        val invitation = StudyInvitation( "Test" )
-        val studyId = UUID.randomUUID()
-        val participantId = UUID.randomUUID()
-        val study = Study( owner, "Test study", invitation, studyId )
-        study.includeParticipant( participantId )
+        val study = createComplexStudy()
 
         val snapshot = study.getSnapshot()
         val fromSnapshot = Study.fromSnapshot( snapshot )
 
-        assertEquals( studyId, fromSnapshot.id )
-        assertEquals( owner, fromSnapshot.owner )
-        assertEquals( "Test study", fromSnapshot.name )
-        assertEquals( invitation, fromSnapshot.invitation )
-        assertEquals( participantId, fromSnapshot.participantIds.single() )
+        assertEquals( study.id, fromSnapshot.id )
+        assertEquals( study.owner, fromSnapshot.owner )
+        assertEquals( study.name, fromSnapshot.name )
+        assertEquals( study.invitation, fromSnapshot.invitation )
+        assertEquals( study.creationDate, fromSnapshot.creationDate )
+        val commonParticipants = study.participantIds.intersect( fromSnapshot.participantIds )
+        assertEquals( study.participantIds.count(), commonParticipants.count() )
     }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
@@ -19,7 +19,8 @@ class StudyServiceRequestsTest
     {
         val requests: List<StudyServiceRequest> = listOf(
             StudyServiceRequest.CreateStudy( StudyOwner(), "Test", StudyInvitation.empty() ),
-            StudyServiceRequest.GetStudyStatus( UUID.randomUUID() )
+            StudyServiceRequest.GetStudyStatus( UUID.randomUUID() ),
+            StudyServiceRequest.GetStudiesOverview( StudyOwner() )
         )
     }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudySnapshotTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudySnapshotTest.kt
@@ -1,0 +1,26 @@
+package dk.cachet.carp.studies.infrastructure
+
+import dk.cachet.carp.studies.domain.Study
+import dk.cachet.carp.studies.domain.StudySnapshot
+import dk.cachet.carp.studies.domain.createComplexStudy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+
+/**
+ * Tests for [StudySnapshot] relying on core infrastructure.
+ */
+class StudySnapshotTest
+{
+    @Test
+    fun can_serialize_and_deserialize_snapshot_using_JSON()
+    {
+        val study: Study = createComplexStudy()
+        val snapshot: StudySnapshot = study.getSnapshot()
+
+        val serialized: String = snapshot.toJson()
+        val parsed: StudySnapshot = StudySnapshot.fromJson( serialized )
+
+        assertEquals( snapshot, parsed )
+    }
+}

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyStatusTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.studies.infrastructure
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.studies.domain.StudyStatus
 import kotlin.test.*
@@ -13,7 +14,7 @@ class StudyStatusTest
     @Test
     fun can_serialize_and_deserialize_study_status_using_JSON()
     {
-        val status = StudyStatus( UUID.randomUUID(), "Test" )
+        val status = StudyStatus( UUID.randomUUID(), "Test", DateTime.now() )
 
         val serialized = status.toJson()
         val parsed = StudyStatus.fromJson( serialized )


### PR DESCRIPTION
Added a `getStudiesOverview` endpoint to the studies subsystem which should be used to populate the list of studies managed by a researcher. `Study` and `StudyStatus` now includes a creation date.