### PR TITLE
Add and get participants for study

### DIFF
--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -3,7 +3,7 @@ package dk.cachet.carp.studies.application
 import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
-import dk.cachet.carp.studies.domain.StudyOwner
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudyStatus
 import dk.cachet.carp.studies.domain.users.Participant
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -1,9 +1,11 @@
 package dk.cachet.carp.studies.application
 
+import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.studies.domain.StudyOwner
 import dk.cachet.carp.studies.domain.StudyStatus
+import dk.cachet.carp.studies.domain.users.Participant
 
 
 /**
@@ -34,4 +36,19 @@ interface StudyService
      * Get status for all studies created by the specified [owner].
      */
     suspend fun getStudiesOverview( owner: StudyOwner ): List<StudyStatus>
+
+    /**
+     * Add a [Participant] to the study with the specified [studyId], identified by the specified [email] address.
+     * In case the [email] was already added before, the same [Participant] is returned.
+     *
+     * @throws IllegalArgumentException when a study with [studyId] does not exist.
+     */
+    suspend fun addParticipant( studyId: UUID, email: EmailAddress ): Participant
+
+    /**
+     * Get all [Participant]s for the study with the specified [studyId].
+     *
+     * @throws IllegalArgumentException when a study with [studyId] does not exist.
+     */
+    suspend fun getParticipants( studyId: UUID ): List<Participant>
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
@@ -5,7 +5,7 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.EmailAccountIdentity
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.studies.domain.Study
-import dk.cachet.carp.studies.domain.StudyOwner
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudyRepository
 import dk.cachet.carp.studies.domain.StudyStatus
 import dk.cachet.carp.studies.domain.users.Participant

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
@@ -1,11 +1,14 @@
 package dk.cachet.carp.studies.application
 
+import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.users.EmailAccountIdentity
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.studies.domain.Study
 import dk.cachet.carp.studies.domain.StudyOwner
 import dk.cachet.carp.studies.domain.StudyRepository
 import dk.cachet.carp.studies.domain.StudyStatus
+import dk.cachet.carp.studies.domain.users.Participant
 
 
 /**
@@ -51,4 +54,34 @@ class StudyServiceHost( private val repository: StudyRepository ) : StudyService
      */
     override suspend fun getStudiesOverview( owner: StudyOwner ): List<StudyStatus> =
         repository.getForOwner( owner ).map { it.getStatus() }
+
+    /**
+     * Add a [Participant] to the study with the specified [studyId], identified by the specified [email] address.
+     * In case the [email] was already added before, the same [Participant] is returned.
+     *
+     * @throws IllegalArgumentException when a study with [studyId] does not exist.
+     */
+    override suspend fun addParticipant( studyId: UUID, email: EmailAddress ): Participant
+    {
+        // Verify whether participant was already added.
+        val identity = EmailAccountIdentity( email )
+        var participant = repository.getParticipants( studyId ).firstOrNull { it.accountIdentity == identity }
+
+        // Add new participant in case it was not added before.
+        if ( participant == null )
+        {
+            participant = Participant( identity )
+            repository.addParticipant( studyId, participant )
+        }
+
+        return participant
+    }
+
+    /**
+     * Get all [Participant]s for the study with the specified [studyId].
+     *
+     * @throws IllegalArgumentException when a study with [studyId] does not exist.
+     */
+    override suspend fun getParticipants( studyId: UUID ): List<Participant> =
+        repository.getParticipants( studyId )
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.studies.domain
 import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
+import dk.cachet.carp.studies.domain.users.StudyOwner
 
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -31,9 +31,6 @@ class Study(
             val study = Study( StudyOwner( snapshot.ownerId ), snapshot.name, snapshot.invitation, snapshot.studyId )
             study.creationDate = snapshot.creationDate
 
-            // Add participants.
-            snapshot.participantIds.forEach { study.includeParticipant( it ) }
-
             return study
         }
     }
@@ -45,23 +42,10 @@ class Study(
     var creationDate: DateTime = DateTime.now()
         private set
 
-    private val _participantIds: MutableSet<UUID> = mutableSetOf()
-
-    /**
-     * The set of participants which have been included in this [Study].
-     */
-    val participantIds: Set<UUID>
-        get() = _participantIds
-
     /**
      * Get the status (serializable) of this [Study].
      */
     fun getStatus(): StudyStatus = StudyStatus( id, name, creationDate )
-
-    /**
-     * Include a participant in this [Study].
-     */
-    fun includeParticipant( participantId: UUID ) = _participantIds.add( participantId )
 
 
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyRepository.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.studies.domain
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.studies.domain.users.Participant
 
 
 interface StudyRepository
@@ -21,4 +22,19 @@ interface StudyRepository
      * Returns the studies created by the specified [owner].
      */
     fun getForOwner( owner: StudyOwner ): List<Study>
+
+    /**
+     * Adds a new [participant] for the study with [studyId] to the repository.
+     *
+     * @throws IllegalArgumentException when a study with the specified [studyId] does not exist,
+     * or when a participant with the specified ID already exists within the study.
+     */
+    fun addParticipant( studyId: UUID, participant: Participant )
+
+    /**
+     * Returns the participants which were added to the study with the specified [studyId].
+     *
+     * @throws IllegalArgumentException when a study with the specified [studyId] does not exist.
+     */
+    fun getParticipants( studyId: UUID ): List<Participant>
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyRepository.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.studies.domain
 
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.studies.domain.users.Participant
+import dk.cachet.carp.studies.domain.users.StudyOwner
 
 
 interface StudyRepository

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
@@ -12,8 +12,7 @@ data class StudySnapshot(
     val ownerId: UUID,
     val name: String,
     val invitation: StudyInvitation,
-    val creationDate: DateTime,
-    val participantIds: List<UUID>
+    val creationDate: DateTime
 )
 {
     companion object
@@ -30,8 +29,7 @@ data class StudySnapshot(
                 ownerId = study.owner.id,
                 name = study.name,
                 invitation = study.invitation,
-                creationDate = study.creationDate,
-                participantIds = study.participantIds.toList() )
+                creationDate = study.creationDate )
         }
     }
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Participant.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Participant.kt
@@ -1,0 +1,13 @@
+package dk.cachet.carp.studies.domain.users
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.users.AccountIdentity
+import dk.cachet.carp.studies.domain.Study
+import kotlinx.serialization.Serializable
+
+
+/**
+ * A person to be invited or participating in a [Study].
+ */
+@Serializable
+data class Participant( val accountIdentity: AccountIdentity, val id: UUID = UUID.randomUUID() )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/StudyOwner.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/StudyOwner.kt
@@ -1,4 +1,4 @@
-package dk.cachet.carp.studies.domain
+package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.UUID
 import kotlinx.serialization.Serializable

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryStudyRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryStudyRepository.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.studies.domain.Study
-import dk.cachet.carp.studies.domain.StudyOwner
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudyRepository
 import dk.cachet.carp.studies.domain.users.Participant
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryStudyRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryStudyRepository.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.studies.domain.Study
 import dk.cachet.carp.studies.domain.StudyOwner
 import dk.cachet.carp.studies.domain.StudyRepository
+import dk.cachet.carp.studies.domain.users.Participant
 
 
 /**
@@ -12,6 +13,7 @@ import dk.cachet.carp.studies.domain.StudyRepository
 class InMemoryStudyRepository : StudyRepository
 {
     private val studies: MutableList<Study> = mutableListOf()
+    private val participants: MutableMap<UUID, MutableList<Participant>> = mutableMapOf()
 
 
     /**
@@ -36,4 +38,31 @@ class InMemoryStudyRepository : StudyRepository
      */
     override fun getForOwner( owner: StudyOwner ): List<Study> =
         studies.filter { it.owner.id == owner.id }
+
+    /**
+     * Adds a new [participant] for the study with [studyId] to the repository.
+     *
+     * @throws IllegalArgumentException when a study with the specified [studyId] does not exist,
+     * or when a participant with the specified ID already exists within the study.
+     */
+    override fun addParticipant( studyId: UUID, participant: Participant )
+    {
+        require( studies.any { it.id == studyId } )
+
+        val studyParticipants = participants.getOrPut( studyId ) { mutableListOf() }
+        require( studyParticipants.none { it.id == participant.id } )
+        studyParticipants.add( participant )
+    }
+
+    /**
+     * Returns the participants which were added to the study with the specified [studyId].
+     *
+     * @throws IllegalArgumentException when a study with the specified [studyId] does not exist.
+     */
+    override fun getParticipants( studyId: UUID ): List<Participant>
+    {
+        require( studies.any { it.id == studyId } )
+
+        return participants[ studyId ] ?: listOf()
+    }
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/Serialization.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/Serialization.kt
@@ -4,7 +4,7 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.serialization.createDefaultJSON
 import dk.cachet.carp.protocols.infrastructure.PROTOCOLS_SERIAL_MODULE
-import dk.cachet.carp.studies.domain.StudyOwner
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudySnapshot
 import dk.cachet.carp.studies.domain.StudyStatus
 import dk.cachet.carp.studies.domain.users.Participant

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/Serialization.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/Serialization.kt
@@ -7,6 +7,7 @@ import dk.cachet.carp.protocols.infrastructure.PROTOCOLS_SERIAL_MODULE
 import dk.cachet.carp.studies.domain.StudyOwner
 import dk.cachet.carp.studies.domain.StudySnapshot
 import dk.cachet.carp.studies.domain.StudyStatus
+import dk.cachet.carp.studies.domain.users.Participant
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.EmptyModule
 import kotlinx.serialization.modules.plus
@@ -41,6 +42,18 @@ fun StudySnapshot.Companion.fromJson( json: String ): StudySnapshot =
  */
 fun StudySnapshot.toJson(): String =
     JSON.stringify( StudySnapshot.serializer(), this )
+
+/**
+ * Create a [Participant] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
+ */
+fun Participant.Companion.fromJson( json: String ): Participant =
+    JSON.parse( serializer(), json )
+
+/**
+ * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
+ */
+fun Participant.toJson(): String =
+    JSON.stringify( Participant.serializer(), this )
 
 /**
  * Create a [StudyOwner] from JSON, serialized using the globally set infrastructure serializer ([JSON]).

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.studies.infrastructure
 
+import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.createServiceInvoker
 import dk.cachet.carp.common.ddd.ServiceInvoker
@@ -7,6 +8,7 @@ import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.studies.application.StudyService
 import dk.cachet.carp.studies.domain.StudyOwner
 import dk.cachet.carp.studies.domain.StudyStatus
+import dk.cachet.carp.studies.domain.users.Participant
 import kotlinx.serialization.Serializable
 
 
@@ -30,4 +32,14 @@ sealed class StudyServiceRequest
     data class GetStudiesOverview( val owner: StudyOwner ) :
         StudyServiceRequest(),
         ServiceInvoker<StudyService, List<StudyStatus>> by createServiceInvoker( StudyService::getStudiesOverview, owner )
+
+    @Serializable
+    data class AddParticipant( val studyId: UUID, val email: EmailAddress ) :
+        StudyServiceRequest(),
+        ServiceInvoker<StudyService, Participant> by createServiceInvoker( StudyService::addParticipant, studyId, email )
+
+    @Serializable
+    data class GetParticipants( val studyId: UUID ) :
+        StudyServiceRequest(),
+        ServiceInvoker<StudyService, List<Participant>> by createServiceInvoker( StudyService::getParticipants, studyId )
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -6,7 +6,7 @@ import dk.cachet.carp.common.ddd.createServiceInvoker
 import dk.cachet.carp.common.ddd.ServiceInvoker
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.studies.application.StudyService
-import dk.cachet.carp.studies.domain.StudyOwner
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudyStatus
 import dk.cachet.carp.studies.domain.users.Participant
 import kotlinx.serialization.Serializable

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
@@ -1,17 +1,22 @@
 package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.DateTime
+import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.studies.domain.StudyOwner
 import dk.cachet.carp.studies.domain.StudyStatus
+import dk.cachet.carp.studies.domain.users.Participant
 import dk.cachet.carp.test.Mock
 
 
 class StudyServiceMock(
     private val createStudyResult: StudyStatus = studyStatus,
     private val getStudyStatusResult: StudyStatus = studyStatus,
-    private val getStudiesOverview: List<StudyStatus> = listOf()
+    private val getStudiesOverviewResult: List<StudyStatus> = listOf(),
+    private val addParticipantResult: Participant = Participant( AccountIdentity.fromEmailAddress( "test@test.com" ) ),
+    private val getParticipantsResult: List<Participant> = listOf()
 ) : Mock<StudyService>(), StudyService
 {
     companion object
@@ -35,6 +40,18 @@ class StudyServiceMock(
     override suspend fun getStudiesOverview( owner: StudyOwner ): List<StudyStatus>
     {
         trackSuspendCall( StudyService::getStudiesOverview, owner )
-        return getStudiesOverview
+        return getStudiesOverviewResult
+    }
+
+    override suspend fun addParticipant( studyId: UUID, email: EmailAddress ): Participant
+    {
+        trackSuspendCall( StudyService::addParticipant, studyId, email )
+        return addParticipantResult
+    }
+
+    override suspend fun getParticipants( studyId: UUID ): List<Participant>
+    {
+        trackSuspendCall( StudyService::getParticipants, studyId )
+        return getParticipantsResult
     }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
@@ -5,7 +5,7 @@ import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
-import dk.cachet.carp.studies.domain.StudyOwner
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudyStatus
 import dk.cachet.carp.studies.domain.users.Participant
 import dk.cachet.carp.test.Mock

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
@@ -37,7 +37,7 @@ interface StudyServiceTest
     }
 
     @Test
-    fun createStudy_with_description_succeeds() = runBlockingTest {
+    fun createStudy_with_invitation_succeeds() = runBlockingTest {
         val ( service, repo ) = createService()
 
         val owner = StudyOwner()

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
@@ -3,7 +3,7 @@ package dk.cachet.carp.studies.application
 import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
-import dk.cachet.carp.studies.domain.StudyOwner
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudyRepository
 import dk.cachet.carp.test.runBlockingTest
 import kotlin.test.*

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.studies.domain
 
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
+import dk.cachet.carp.studies.domain.users.StudyOwner
 
 
 /**

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
@@ -1,20 +1,15 @@
 package dk.cachet.carp.studies.domain
 
-import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 
 
 /**
- * Create a study with a couple of participants added.
+ * Create a 'complex' study for testing purposes.
  */
 fun createComplexStudy(): Study
 {
     val owner = StudyOwner()
     val invitation = StudyInvitation.empty()
-    val study = Study( owner, "Test", invitation )
 
-    study.includeParticipant( UUID.randomUUID() )
-    study.includeParticipant( UUID.randomUUID() )
-
-    return study
+    return Study( owner, "Test", invitation )
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyRepositoryTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyRepositoryTest.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.studies.domain.users.Participant
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import kotlin.test.*
 
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
@@ -1,7 +1,5 @@
 package dk.cachet.carp.studies.domain
 
-import dk.cachet.carp.common.UUID
-import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import kotlin.test.*
 
 
@@ -10,36 +8,6 @@ import kotlin.test.*
  */
 class StudyTest
 {
-    private fun createTestStudy(): Study
-    {
-        val owner = StudyOwner()
-        val id = UUID.randomUUID()
-        return Study( owner, "Test study", StudyInvitation.empty(), id )
-    }
-
-    @Test
-    fun includeParticipant_succeeds()
-    {
-        val study: Study = createTestStudy()
-        val participantId = UUID.randomUUID()
-
-        study.includeParticipant( participantId )
-
-        assertEquals( participantId, study.participantIds.single() )
-    }
-
-    @Test
-    fun includeParticipant_multiple_times_only_adds_once()
-    {
-        val study: Study = createTestStudy()
-        val participantId = UUID.randomUUID()
-
-        study.includeParticipant( participantId )
-        study.includeParticipant( participantId )
-
-        assertEquals( participantId, study.participantIds.single() )
-    }
-
     @Test
     fun creating_study_fromSnapshot_obtained_by_getSnapshot_is_the_same()
     {
@@ -53,7 +21,5 @@ class StudyTest
         assertEquals( study.name, fromSnapshot.name )
         assertEquals( study.invitation, fromSnapshot.invitation )
         assertEquals( study.creationDate, fromSnapshot.creationDate )
-        val commonParticipants = study.participantIds.intersect( fromSnapshot.participantIds )
-        assertEquals( study.participantIds.count(), commonParticipants.count() )
     }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantTest.kt
@@ -1,0 +1,23 @@
+package dk.cachet.carp.studies.infrastructure
+
+import dk.cachet.carp.common.users.AccountIdentity
+import dk.cachet.carp.studies.domain.users.Participant
+import kotlin.test.*
+
+
+/**
+ * Tests for [Participant] relying on core infrastructure.
+ */
+class ParticipantTest
+{
+    @Test
+    fun can_serialize_and_deserialize_participant_using_JSON()
+    {
+        val participant = Participant( AccountIdentity.fromEmailAddress( "test@test.com" ) )
+
+        val serialized: String = participant.toJson()
+        val parsed: Participant = Participant.fromJson( serialized )
+
+        assertEquals( participant, parsed )
+    }
+}

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyOwnerTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyOwnerTest.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.studies.infrastructure
 
-import dk.cachet.carp.studies.domain.StudyOwner
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import kotlin.test.*
 
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.studies.infrastructure
 
+import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.ServiceInvoker
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
@@ -20,7 +21,9 @@ class StudyServiceRequestsTest
         val requests: List<StudyServiceRequest> = listOf(
             StudyServiceRequest.CreateStudy( StudyOwner(), "Test", StudyInvitation.empty() ),
             StudyServiceRequest.GetStudyStatus( UUID.randomUUID() ),
-            StudyServiceRequest.GetStudiesOverview( StudyOwner() )
+            StudyServiceRequest.GetStudiesOverview( StudyOwner() ),
+            StudyServiceRequest.AddParticipant( UUID.randomUUID(), EmailAddress( "test@test.com" ) ),
+            StudyServiceRequest.GetParticipants( UUID.randomUUID() )
         )
     }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
@@ -6,7 +6,7 @@ import dk.cachet.carp.common.ddd.ServiceInvoker
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.studies.application.StudyService
 import dk.cachet.carp.studies.application.StudyServiceMock
-import dk.cachet.carp.studies.domain.StudyOwner
+import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.test.runBlockingTest
 import kotlin.test.*
 


### PR DESCRIPTION
I believe `Participant` should be an aggregate root, and therefore gets a UUID. Or, should we think of a more meaningful ID which makes sense within a `Study`, i.e., an increment ID?

Participants are retrieved through a separate repo call, which I believe makes sense for aggregate roots. Therefore, participant IDs were removed from the `Study` class since it was unclear what they would be used for. If there is a need to store the relation there as well, we can re-add it later.

Other than an ID, a `Participant` for now only has an `AccountIdentity` which is used to create the eventual deployment. But, there was some discussion on whether we should add a 'label' or 'name' so the researcher can make sense of it. I omitted this for now, since that type of 'meta data' should likely be implemented in a uniform way, similar to how 'CPR number' would be added. If we _always_ want to add a name, that should likely be implemented as that specific meta field always being added.