### PR TITLE
Add base class for aggregate roots

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/AggregateRoot.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/AggregateRoot.kt
@@ -1,0 +1,33 @@
+package dk.cachet.carp.common.ddd
+
+import dk.cachet.carp.common.Immutable
+
+
+/**
+ * A root objects which ensures the integrity of underlying state as a whole, tracks events raised from within,
+ * and for which an immutable 'snapshot' at any given moment in time can be obtained.
+ */
+abstract class AggregateRoot<TRoot, TSnapshot : Snapshot<TRoot>, TEvent : Immutable>
+{
+    private val events: MutableList<TEvent> = mutableListOf()
+
+    /**
+     * Add an event triggered by this aggregate root to a queue.
+     */
+    protected fun event( event: TEvent ) = events.add( event )
+
+    /**
+     * Returns all tracked events on this aggregate root in the order they were triggered and clears the queue.
+     */
+    fun consumeEvents(): List<TEvent>
+    {
+        val toProcess = events.toList()
+        events.clear()
+        return toProcess
+    }
+
+    /**
+     * Get an immutable snapshot representing the state of this aggregate at this moment in time.
+     */
+    abstract fun getSnapshot(): TSnapshot
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/Snapshot.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/Snapshot.kt
@@ -1,0 +1,15 @@
+package dk.cachet.carp.common.ddd
+
+import dk.cachet.carp.common.Immutable
+
+
+/**
+ * An immutable snapshot of an [AggregateRoot] at a given moment in time.
+ */
+abstract class Snapshot<TAggregateRoot> : Immutable()
+{
+    /**
+     * Load the aggregate root object from this snapshot.
+     */
+    abstract fun toObject(): TAggregateRoot
+}

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.deployment.domain
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.ddd.Snapshot
 import dk.cachet.carp.deployment.domain.users.AccountParticipation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
@@ -17,7 +18,7 @@ data class StudyDeploymentSnapshot(
     val studyProtocolSnapshot: StudyProtocolSnapshot,
     val registeredDevices: Map<String, @Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>,
     val participations: Set<AccountParticipation>
-)
+) : Snapshot<StudyDeployment>()
 {
     companion object
     {
@@ -35,4 +36,7 @@ data class StudyDeploymentSnapshot(
                 studyDeployment.participations )
         }
     }
+
+
+    override fun toObject(): StudyDeployment = StudyDeployment.fromSnapshot( this )
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -9,7 +9,9 @@ import dk.cachet.carp.protocols.domain.deployment.UnusedDevicesWarning
 import dk.cachet.carp.protocols.domain.deployment.UseCompositeTaskWarning
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
+import dk.cachet.carp.protocols.domain.devices.DeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.EmptyDeviceConfiguration
+import dk.cachet.carp.protocols.domain.devices.MasterDeviceDescriptor
 import dk.cachet.carp.protocols.domain.tasks.EmptyTaskConfiguration
 import dk.cachet.carp.protocols.domain.tasks.TaskDescriptor
 import dk.cachet.carp.protocols.domain.triggers.Trigger
@@ -83,7 +85,14 @@ class StudyProtocol(
         }
     }
 
-
+    /**
+     * Add a master device which is responsible for aggregating and synchronizing incoming data.
+     *
+     * Throws an [InvalidConfigurationError] in case a device with the specified role name already exists.
+     *
+     * @param masterDevice A description of the master device to add. Its role name should be unique in the protocol.
+     * @return True if the device has been added; false if the specified [MasterDeviceDescriptor] is already set as a master device.
+     */
     override fun addMasterDevice( masterDevice: AnyMasterDeviceDescriptor ): Boolean
     {
         val added = super.addMasterDevice( masterDevice )
@@ -94,6 +103,15 @@ class StudyProtocol(
         return added
     }
 
+    /**
+     * Add a device which is connected to a master device within this configuration.
+     *
+     * Throws an [InvalidConfigurationError] in case a device with the specified role name already exists.
+     *
+     * @param device The device to be connected to a master device. Its role name should be unique in the protocol.
+     * @param masterDevice The master device to connect to.
+     * @return True if the device has been added; false if the specified [DeviceDescriptor] is already connected to the specified [MasterDeviceDescriptor].
+     */
     override fun addConnectedDevice( device: AnyDeviceDescriptor, masterDevice: AnyMasterDeviceDescriptor ): Boolean
     {
         val added = super.addConnectedDevice(device, masterDevice)
@@ -199,6 +217,14 @@ class StudyProtocol(
             .toSet()
     }
 
+    /**
+     * Add a task to this configuration.
+     *
+     * Throws an [InvalidConfigurationError] in case a task with the specified name already exists.
+     *
+     * @param task The task to add.
+     * @return True if the task has been added; false if the specified [TaskDescriptor] is already included in this configuration.
+     */
     override fun addTask( task: TaskDescriptor ): Boolean
     {
         val added = super.addTask( task )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.protocols.domain
 
+import dk.cachet.carp.common.Immutable
 import dk.cachet.carp.protocols.domain.deployment.DeploymentError
 import dk.cachet.carp.protocols.domain.deployment.DeploymentIssue
 import dk.cachet.carp.protocols.domain.deployment.NoMasterDeviceError
@@ -19,6 +20,7 @@ import dk.cachet.carp.protocols.domain.triggers.TriggeredTask
  * A description of how a study is to be executed, defining the type(s) of master device(s) ([AnyMasterDeviceDescriptor]) responsible for aggregating data,
  * the optional devices ([AnyDeviceDescriptor]) connected to them, and the [Trigger]'s which lead to data collection on said devices.
  */
+@Suppress( "TooManyFunctions" ) // TODO: some of the device and task configuration methods are overridden solely to add events. Can this be refactored?
 class StudyProtocol(
     /**
      * The person or group that created this [StudyProtocol].
@@ -30,6 +32,18 @@ class StudyProtocol(
     val name: String
 ) : StudyProtocolComposition( EmptyDeviceConfiguration(), EmptyTaskConfiguration() )
 {
+    sealed class Event : Immutable()
+    {
+        data class MasterDeviceAdded( val device: AnyMasterDeviceDescriptor ) : Event()
+        data class ConnectedDeviceAdded( val connected: AnyDeviceDescriptor, val master: AnyMasterDeviceDescriptor ) : Event()
+        data class TriggerAdded( val trigger: Trigger ) : Event()
+        data class TaskAdded( val task: TaskDescriptor ) : Event()
+        data class TaskRemoved( val task: TaskDescriptor ) : Event()
+        data class TriggeredTaskAdded( val triggeredTask: TriggeredTask ) : Event()
+        data class TriggeredTaskRemoved( val triggeredTask: TriggeredTask ) : Event()
+    }
+
+
     companion object Factory
     {
         fun fromSnapshot( snapshot: StudyProtocolSnapshot ): StudyProtocol
@@ -70,6 +84,26 @@ class StudyProtocol(
     }
 
 
+    override fun addMasterDevice( masterDevice: AnyMasterDeviceDescriptor ): Boolean
+    {
+        val added = super.addMasterDevice( masterDevice )
+        if ( added )
+        {
+            event( Event.MasterDeviceAdded( masterDevice ) )
+        }
+        return added
+    }
+
+    override fun addConnectedDevice( device: AnyDeviceDescriptor, masterDevice: AnyMasterDeviceDescriptor ): Boolean
+    {
+        val added = super.addConnectedDevice(device, masterDevice)
+        if ( added )
+        {
+            event( Event.ConnectedDeviceAdded( device, masterDevice ) )
+        }
+        return added
+    }
+
     private val _triggers: MutableSet<Trigger> = mutableSetOf()
 
     /**
@@ -100,6 +134,7 @@ class StudyProtocol(
         if ( isAdded )
         {
             triggeredTasks[ trigger ] = mutableSetOf()
+            event( Event.TriggerAdded( trigger ) )
         }
         return isAdded
     }
@@ -124,9 +159,17 @@ class StudyProtocol(
 
         // Add trigger and task to ensure they are included in the protocol.
         addTrigger( trigger )
-        taskConfiguration.addTask( task )
+        addTask( task )
 
-        return triggeredTasks[ trigger ]!!.add( TriggeredTask( task, targetDevice ) )
+        // Add triggered task.
+        val triggeredTask = TriggeredTask( task, targetDevice )
+        val triggeredTaskAdded = triggeredTasks[ trigger ]!!.add( triggeredTask )
+        if ( triggeredTaskAdded )
+        {
+            event( Event.TriggeredTaskAdded( triggeredTask ) )
+        }
+
+        return triggeredTaskAdded
     }
 
     /**
@@ -156,6 +199,16 @@ class StudyProtocol(
             .toSet()
     }
 
+    override fun addTask( task: TaskDescriptor ): Boolean
+    {
+        val added = super.addTask( task )
+        if ( added )
+        {
+            event( Event.TaskAdded( task ) )
+        }
+        return added
+    }
+
     /**
      * Remove a task currently present in the study protocol, including removing it from any [Trigger]'s which initiate it.
      *
@@ -164,15 +217,18 @@ class StudyProtocol(
      */
     override fun removeTask( task: TaskDescriptor ): Boolean
     {
-        val isRemoved = taskConfiguration.removeTask( task )
+        // Remove task from triggers.
+        triggeredTasks.map { it.value }.forEach {
+            val triggeredTasks = it.filter { triggered -> triggered.task == task }
+            it.removeAll( triggeredTasks )
+            triggeredTasks.forEach { event( Event.TriggeredTaskRemoved( it ) ) }
+        }
 
-        // Also remove task from triggers.
+        // Remove task itself.
+        val isRemoved = taskConfiguration.removeTask( task )
         if ( isRemoved )
         {
-            triggeredTasks.map { it.value }.forEach {
-                val triggeredTasks = it.filter { triggered -> triggered.task == task }
-                it.removeAll( triggeredTasks )
-            }
+            event( Event.TaskRemoved( task ) )
         }
 
         return isRemoved
@@ -212,8 +268,5 @@ class StudyProtocol(
     /**
      * Get a serializable snapshot of the current state of this [StudyProtocol].
      */
-    fun getSnapshot(): StudyProtocolSnapshot
-    {
-        return StudyProtocolSnapshot.fromProtocol( this )
-    }
+    override fun getSnapshot(): StudyProtocolSnapshot = StudyProtocolSnapshot.fromProtocol( this )
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolComposition.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolComposition.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.protocols.domain
 
+import dk.cachet.carp.common.ddd.AggregateRoot
 import dk.cachet.carp.protocols.domain.devices.DeviceConfiguration
 import dk.cachet.carp.protocols.domain.tasks.TaskConfiguration
 
@@ -11,4 +12,5 @@ abstract class StudyProtocolComposition internal constructor(
     protected val deviceConfiguration: DeviceConfiguration,
     protected val taskConfiguration: TaskConfiguration
 ) : DeviceConfiguration by deviceConfiguration,
-    TaskConfiguration by taskConfiguration
+    TaskConfiguration by taskConfiguration,
+    AggregateRoot<StudyProtocol, StudyProtocolSnapshot, StudyProtocol.Event>()

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolSnapshot.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolSnapshot.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.protocols.domain
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.ddd.Snapshot
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.DeviceDescriptorSerializer
@@ -25,7 +26,7 @@ data class StudyProtocolSnapshot(
     val tasks: List<@Serializable( TaskDescriptorSerializer::class ) TaskDescriptor>,
     val triggers: Map<Int, @Serializable( TriggerSerializer::class ) Trigger>,
     val triggeredTasks: List<TriggeredTask>
-)
+) : Snapshot<StudyProtocol>()
 {
     @Serializable
     data class DeviceConnection( val roleName: String, val connectedToRoleName: String )
@@ -122,4 +123,6 @@ data class StudyProtocolSnapshot(
 
         return result
     }
+
+    override fun toObject(): StudyProtocol = StudyProtocol.fromSnapshot( this )
 }

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
@@ -65,6 +65,7 @@ class StudyProtocolTest
         val isAdded: Boolean = protocol.addTrigger( trigger )
         assertTrue( isAdded )
         assertTrue( protocol.triggers.contains( trigger ) )
+        assertEquals( StudyProtocol.Event.TriggerAdded( trigger ), protocol.consumeEvents().last() )
     }
 
     @Test
@@ -79,6 +80,8 @@ class StudyProtocolTest
         val isAdded: Boolean = protocol.addTrigger( trigger )
         assertFalse( isAdded )
         assertEquals( 1, protocol.triggers.count() )
+        val triggerEvents = protocol.consumeEvents().filterIsInstance<StudyProtocol.Event.TriggerAdded>()
+        assertEquals( 1, triggerEvents.count() )
     }
 
     @Test
@@ -91,6 +94,8 @@ class StudyProtocolTest
         {
             protocol.addTrigger( trigger )
         }
+        val triggerEvents = protocol.consumeEvents().filterIsInstance<StudyProtocol.Event.TriggerAdded>()
+        assertEquals( 0, triggerEvents.count() )
     }
 
     @Test
@@ -107,6 +112,8 @@ class StudyProtocolTest
         {
             protocol.addTrigger( trigger )
         }
+        val triggerEvents = protocol.consumeEvents().filterIsInstance<StudyProtocol.Event.TriggerAdded>()
+        assertEquals( 0, triggerEvents.count() )
     }
 
     @Test
@@ -122,6 +129,7 @@ class StudyProtocolTest
         val isAdded: Boolean = protocol.addTriggeredTask( trigger, task, device )
         assertTrue( isAdded )
         assertTrue( protocol.getTriggeredTasks( trigger ).contains( TriggeredTask( task, device ) ) )
+        assertEquals( StudyProtocol.Event.TriggeredTaskAdded( TriggeredTask( task, device ) ), protocol.consumeEvents().last() )
     }
 
     @Test
@@ -137,6 +145,8 @@ class StudyProtocolTest
         val isAdded = protocol.addTriggeredTask( trigger, task, device )
         assertFalse( isAdded )
         assertEquals( 1, protocol.getTriggeredTasks( trigger ).count() )
+        val triggeredTaskEvents = protocol.consumeEvents().filterIsInstance<StudyProtocol.Event.TriggeredTaskAdded>()
+        assertEquals( 1, triggeredTaskEvents.count() )
     }
 
     @Test
@@ -151,6 +161,8 @@ class StudyProtocolTest
         val trigger = StubTrigger( device )
         protocol.addTriggeredTask( trigger, task, device )
         assertTrue( protocol.triggers.contains( trigger ) )
+        val triggerEvents = protocol.consumeEvents().filterIsInstance<StudyProtocol.Event.TriggerAdded>()
+        assertEquals( StudyProtocol.Event.TriggerAdded( trigger ), triggerEvents.single() )
     }
 
     @Test
@@ -165,6 +177,8 @@ class StudyProtocolTest
         val task = StubTaskDescriptor()
         protocol.addTriggeredTask( trigger, task, device )
         assertTrue( protocol.tasks.contains( task ) )
+        val taskEvents = protocol.consumeEvents().filterIsInstance<StudyProtocol.Event.TaskAdded>()
+        assertEquals( StudyProtocol.Event.TaskAdded( task ), taskEvents.single() )
     }
 
     @Test
@@ -185,6 +199,7 @@ class StudyProtocolTest
         {
             protocol.addTriggeredTask( trigger, task, StubDeviceDescriptor() )
         }
+        assertEquals( 0, protocol.consumeEvents().filterIsInstance<StudyProtocol.Event.TriggeredTaskAdded>().count() )
     }
 
     @Test
@@ -289,6 +304,7 @@ class StudyProtocolTest
         protocol.removeTask( task )
         assertEquals( 0, protocol.getTriggeredTasks( trigger1 ).count() )
         assertEquals( 0, protocol.getTriggeredTasks( trigger2 ).count() )
+        assertEquals( 2, protocol.consumeEvents().filterIsInstance<StudyProtocol.Event.TriggeredTaskRemoved>().count() )
     }
 
     @Test

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -116,8 +116,11 @@ class Study(
     {
         check( protocolSnapshot != null ) { "A study protocol needs to be defined for a study to go live." }
 
-        isLive = true
-        event( Event.StateChanged( isLive ) )
+        if ( !isLive )
+        {
+            isLive = true
+            event( Event.StateChanged( isLive ) )
+        }
     }
 
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.studies.domain
 
 import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.ddd.Snapshot
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
@@ -18,7 +19,7 @@ data class StudySnapshot(
     val protocolSnapshot: StudyProtocolSnapshot?,
     val isLive: Boolean,
     val participations: Set<DeanonymizedParticipation>
-)
+) : Snapshot<Study>()
 {
     companion object
     {
@@ -40,4 +41,6 @@ data class StudySnapshot(
                 participations = study.participations.toSet() )
         }
     }
+
+    override fun toObject(): Study = Study.fromSnapshot( this )
 }


### PR DESCRIPTION
To simplify implementing repository interfaces using a relational database, more detailed information about changes to aggregate roots need to be tracked. This PR includes a base class which supports tracking events within aggregate roots, which can be consumed once these changes need to be persisted into a repository.

Alternatively, in case a document store is needed, this base `AggregateRoot` class also provides generic access to convert aggregate roots into snapshots and vice versa (`AggregateRoot.getSnapshot` and `Snapshot.toObject`). The idea is this might potentially be used to have a singular implementation to store/update any aggregate root in a document store.

Lastly, snapshots and aggregate root events should really be `Immutable`. To enforce a correct immutable implementation, the `Immutable` base class is applied to them.

Right now, the aggregate root base class has only been applied to `Study`. In case this approach seems workable, I can apply them to all other aggregate roots in the project (e.g., `StudyDeployment`, `StudyProtocol`, ...).