### PR TITLE
Notify backend of successful deployment

### DIFF
--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/ClientManager.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/ClientManager.kt
@@ -50,13 +50,17 @@ class ClientManager<TMasterDevice : MasterDeviceDescriptor<TRegistration, *>, TR
      * @param deviceRoleName The role which the client device this runtime is intended for plays as part of the deployment identified by [studyDeploymentId].
      *
      * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
-     * [deviceRoleName] is not present in the deployment or is already registered,
+     * [deviceRoleName] is not present in the deployment or is already registered by a different device,
+     * a study with the same [studyDeploymentId] and [deviceRoleName] has already been added to this client,
      * or the [deviceRegistration] of this client is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device.
      * @return The [StudyRuntime] through which data collection for the newly added study can be managed.
      */
     suspend fun addStudy( studyDeploymentId: UUID, deviceRoleName: String ): StudyRuntime
     {
         // TODO: Can/should it be reinforced here that only study runtimes for a matching master device type can be created?
+
+        val alreadyAdded = studies.any { it.studyDeploymentId == studyDeploymentId && it.device.roleName == deviceRoleName }
+        require( !alreadyAdded ) { "A study with the same study deployment ID and device role name has already been added." }
 
         // Create the study runtime.
         // IllegalArgumentException's will be thrown here when deployment or role name does not exist, or device is already registered.

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/ClientManagerTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/ClientManagerTest.kt
@@ -45,7 +45,7 @@ class ClientManagerTest
     }
 
     @Test
-    fun add_study_fails_for_device_role_name_already_in_use() = runBlockingTest {
+    fun add_study_fails_for_study_which_was_already_added() = runBlockingTest {
         // Create deployment service and client manager.
         val ( deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val clientManager = createSmartphoneManager( deploymentService )

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
@@ -53,15 +53,13 @@ class StudyRuntimeTest
         val runtime = StudyRuntime.initialize( deploymentService, deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
 
         // Dependent devices are not yet registered.
-        val status = runtime.tryDeployment()
-        assertFalse( status.isReadyForDeployment )
-        assertFalse( status.isDeployed )
+        var wasDeployed = runtime.tryDeployment()
+        assertFalse( wasDeployed )
 
         // Once dependent devices are registered, deployment succeeds.
         deploymentService.registerDevice( deploymentStatus.studyDeploymentId, deviceSmartphoneDependsOn.roleName, deviceSmartphoneDependsOn.createRegistration() )
-        val succeededStatus = runtime.tryDeployment()
-        assertTrue( succeededStatus.isReadyForDeployment )
-        assertTrue( succeededStatus.isDeployed )
+        wasDeployed = runtime.tryDeployment()
+        assertTrue( wasDeployed )
     }
 
     @Test

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -50,6 +50,15 @@ interface DeploymentService
     suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
 
     /**
+     * Unregister the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].
+     *
+     * @throws IllegalArgumentException when:
+     * - a deployment with [studyDeploymentId] does not exist
+     * - [deviceRoleName] is not present in the deployment
+     */
+    suspend fun unregisterDevice( studyDeploymentId: UUID, deviceRoleName: String ): StudyDeploymentStatus
+
+    /**
      * Get the deployment configuration for the master device with [masterDeviceRoleName] in the study deployment with [studyDeploymentId].
      *
      * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -44,7 +44,7 @@ interface DeploymentService
      * @param registration A matching configuration for the device with [deviceRoleName].
      *
      * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
-     * [deviceRoleName] is not present in the deployment or is already registered,
+     * [deviceRoleName] is not present in the deployment or is already registered and a different [registration] is specified than a previous request,
      * or [registration] is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device.
      */
     suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -70,14 +70,16 @@ interface DeploymentService
 
     /**
      * Indicate to stakeholders in the study deployment with [studyDeploymentId] that the device with [masterDeviceRoleName] was deployed successfully,
+     * using the deployment with the specified [deploymentChecksum],
      * i.e., that the study deployment was loaded on the device and that the necessary runtime is available to run it.
      *
      * @throws IllegalArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [masterDeviceRoleName] is not present in the deployment
+     * - the [deploymentChecksum] does not match the checksum of the expected deployment. The deployment might be outdated.
      * @throws IllegalStateException when the deployment cannot be deployed yet.
      */
-    suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String ): StudyDeploymentStatus
+    suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ): StudyDeploymentStatus
 
     /**
      * Let the person with the specified [identity] participate in the study deployment with [studyDeploymentId],

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -61,8 +61,10 @@ interface DeploymentService
     /**
      * Get the deployment configuration for the master device with [masterDeviceRoleName] in the study deployment with [studyDeploymentId].
      *
-     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
-     * or [masterDeviceRoleName] is not present in the deployment, or not yet registered.
+     * @throws IllegalArgumentException when:
+     * - a deployment with [studyDeploymentId] does not exist
+     * - [masterDeviceRoleName] is not present in the deployment
+     * @throws IllegalStateException when the deployment for the requested master device is not yet available.
      */
     suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
 
@@ -70,8 +72,10 @@ interface DeploymentService
      * Indicate to stakeholders in the study deployment with [studyDeploymentId] that the device with [masterDeviceRoleName] was deployed successfully,
      * i.e., that the study deployment was loaded on the device and that the necessary runtime is available to run it.
      *
-     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
-     * or [masterDeviceRoleName] is not present in the deployment or cannot be deployed yet.
+     * @throws IllegalArgumentException when:
+     * - a deployment with [studyDeploymentId] does not exist
+     * - [masterDeviceRoleName] is not present in the deployment
+     * @throws IllegalStateException when the deployment cannot be deployed yet.
      */
     suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String ): StudyDeploymentStatus
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -58,6 +58,15 @@ interface DeploymentService
     suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
 
     /**
+     * Indicate to stakeholders in the study deployment with [studyDeploymentId] that the device with [masterDeviceRoleName] was deployed successfully,
+     * i.e., that the study deployment was loaded on the device and that the necessary runtime is available to run it.
+     *
+     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
+     * or [masterDeviceRoleName] is not present in the deployment or cannot be deployed yet.
+     */
+    suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String ): StudyDeploymentStatus
+
+    /**
      * Let the person with the specified [identity] participate in the study deployment with [studyDeploymentId],
      * using the master devices with the specified [deviceRoleNames].
      * In case no account is associated to the specified [identity], a new account is created.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -127,19 +127,21 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
 
     /**
      * Indicate to stakeholders in the study deployment with [studyDeploymentId] that the device with [masterDeviceRoleName] was deployed successfully,
+     * using the deployment with the specified [deploymentChecksum],
      * i.e., that the study deployment was loaded on the device and that the necessary runtime is available to run it.
      *
      * @throws IllegalArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [masterDeviceRoleName] is not present in the deployment
+     * - the [deploymentChecksum] does not match the checksum of the expected deployment. The deployment might be outdated.
      * @throws IllegalStateException when the deployment cannot be deployed yet.
      */
-    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String ): StudyDeploymentStatus
+    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ): StudyDeploymentStatus
     {
         val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
         val device = getRegisteredMasterDevice( deployment, masterDeviceRoleName )
 
-        deployment.deviceDeployed( device )
+        deployment.deviceDeployed( device, deploymentChecksum )
         repository.update( deployment )
 
         return deployment.getStatus()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -112,8 +112,10 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
     /**
      * Get the deployment configuration for the master device with [masterDeviceRoleName] in the study deployment with [studyDeploymentId].
      *
-     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
-     * or [masterDeviceRoleName] is not present in the deployment, or not yet registered.
+     * @throws IllegalArgumentException when:
+     * - a deployment with [studyDeploymentId] does not exist
+     * - [masterDeviceRoleName] is not present in the deployment
+     * @throws IllegalStateException when the deployment for the requested master device is not yet available.
      */
     override suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
     {
@@ -127,8 +129,10 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      * Indicate to stakeholders in the study deployment with [studyDeploymentId] that the device with [masterDeviceRoleName] was deployed successfully,
      * i.e., that the study deployment was loaded on the device and that the necessary runtime is available to run it.
      *
-     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
-     * or [masterDeviceRoleName] is not present in the deployment or cannot be deployed yet.
+     * @throws IllegalArgumentException when:
+     * - a deployment with [studyDeploymentId] does not exist
+     * - [masterDeviceRoleName] is not present in the deployment
+     * @throws IllegalStateException when the deployment cannot be deployed yet.
      */
     override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String ): StudyDeploymentStatus
     {

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.DeploymentRepository
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
+import dk.cachet.carp.deployment.domain.RegistrableDevice
 import dk.cachet.carp.deployment.domain.StudyDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.deployment.domain.users.AccountService
@@ -13,6 +14,7 @@ import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.InvalidConfigurationError
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
+import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
 
@@ -21,6 +23,7 @@ import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
  * Application service which allows deploying [StudyProtocol]'s, registering participations,
  * and retrieving [MasterDeviceDeployment]'s for participating master devices as defined in the protocol.
  */
+@Suppress( "TooManyFunctions" ) // TODO: Can this be decomposed a bit?
 class DeploymentServiceHost( private val repository: DeploymentRepository, private val accountService: AccountService ) : DeploymentService
 {
     /**
@@ -47,8 +50,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      */
     override suspend fun getStudyDeploymentStatus( studyDeploymentId: UUID ): StudyDeploymentStatus
     {
-        val deployment: StudyDeployment? = repository.getStudyDeploymentBy( studyDeploymentId )
-        require( deployment != null )
+        val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
 
         return deployment.getStatus()
     }
@@ -66,11 +68,8 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      */
     override suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
     {
-        val deployment: StudyDeployment? = repository.getStudyDeploymentBy( studyDeploymentId )
-        require( deployment != null )
-
-        val device = deployment.registrableDevices.firstOrNull { it.device.roleName == deviceRoleName }
-            ?: throw IllegalArgumentException( "The specified device role name could not be found in the study deployment." )
+        val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
+        val device: RegistrableDevice = getRegistrableDevice( deployment, deviceRoleName )
 
         // Early out when the device is already registered.
         val priorRegistration = deployment.registeredDevices[ device.device ]
@@ -89,6 +88,28 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
     }
 
     /**
+     * Unregister the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].
+     *
+     * @throws IllegalArgumentException when:
+     * - a deployment with [studyDeploymentId] does not exist
+     * - [deviceRoleName] is not present in the deployment
+     */
+    override suspend fun unregisterDevice( studyDeploymentId: UUID, deviceRoleName: String ): StudyDeploymentStatus
+    {
+        val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
+        val device: AnyDeviceDescriptor = getRegistrableDevice( deployment, deviceRoleName ).device
+
+        val isRegistered = device in deployment.registeredDevices.keys
+        if ( isRegistered )
+        {
+            deployment.unregisterDevice( device )
+            repository.update( deployment )
+        }
+
+        return deployment.getStatus()
+    }
+
+    /**
      * Get the deployment configuration for the master device with [masterDeviceRoleName] in the study deployment with [studyDeploymentId].
      *
      * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
@@ -96,9 +117,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      */
     override suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
     {
-        val deployment: StudyDeployment? = repository.getStudyDeploymentBy( studyDeploymentId )
-        require( deployment != null )
-
+        val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
         val device = getRegisteredMasterDevice( deployment, masterDeviceRoleName )
 
         return deployment.getDeviceDeploymentFor( device )
@@ -113,24 +132,13 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      */
     override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String ): StudyDeploymentStatus
     {
-        val deployment: StudyDeployment? = repository.getStudyDeploymentBy( studyDeploymentId )
-        require( deployment != null )
-
+        val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
         val device = getRegisteredMasterDevice( deployment, masterDeviceRoleName )
 
         deployment.deviceDeployed( device )
         repository.update( deployment )
 
         return deployment.getStatus()
-    }
-
-    private fun getRegisteredMasterDevice( deployment: StudyDeployment, masterDeviceRoleName: String ): AnyMasterDeviceDescriptor
-    {
-        val registeredDevice = deployment.registeredDevices.entries.firstOrNull { it.key.roleName == masterDeviceRoleName }?.toPair()
-            ?: throw IllegalArgumentException( "The specified device role name is not part of this study deployment or is not yet registered." )
-
-        return registeredDevice.first as? AnyMasterDeviceDescriptor
-            ?: throw IllegalArgumentException( "The specified device is not a master device and therefore does not have a deployment configuration." )
     }
 
     /**
@@ -147,8 +155,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      */
     override suspend fun addParticipation( studyDeploymentId: UUID, deviceRoleNames: Set<String>, identity: AccountIdentity, invitation: StudyInvitation ): Participation
     {
-        val studyDeployment = repository.getStudyDeploymentBy( studyDeploymentId )
-        require( studyDeployment != null )
+        val studyDeployment = getStudyDeployment( studyDeploymentId )
         val masterDeviceRoleNames = studyDeployment.protocol.masterDevices.map { it.roleName }
         require( masterDeviceRoleNames.containsAll( deviceRoleNames ) )
 
@@ -203,4 +210,28 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      */
     override suspend fun getParticipationInvitations( accountId: UUID ): Set<ParticipationInvitation> =
         repository.getInvitations( accountId )
+
+
+    private fun getStudyDeployment( studyDeploymentId: UUID ): StudyDeployment
+    {
+        val deployment: StudyDeployment? = repository.getStudyDeploymentBy( studyDeploymentId )
+        require( deployment != null ) { "A deployment with ID '$studyDeploymentId' does not exist." }
+
+        return deployment
+    }
+
+    private fun getRegistrableDevice( deployment: StudyDeployment, deviceRoleName: String ): RegistrableDevice
+    {
+        return deployment.registrableDevices.firstOrNull { it.device.roleName == deviceRoleName }
+            ?: throw IllegalArgumentException( "A device with the role name '$deviceRoleName' could not be found in the study deployment." )
+    }
+
+    private fun getRegisteredMasterDevice( deployment: StudyDeployment, masterDeviceRoleName: String ): AnyMasterDeviceDescriptor
+    {
+        val registeredDevice = deployment.registeredDevices.entries.firstOrNull { it.key.roleName == masterDeviceRoleName }?.toPair()
+            ?: throw IllegalArgumentException( "The specified device role name is not part of this study deployment or is not yet registered." )
+
+        return registeredDevice.first as? AnyMasterDeviceDescriptor
+            ?: throw IllegalArgumentException( "The specified device is not a master device and therefore does not have a deployment configuration." )
+    }
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
@@ -47,9 +47,11 @@ sealed class DeviceDeploymentStatus
         @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor,
         override val requiresRegistration: Boolean,
-        override val requiresDeployment: Boolean,
-        override val isReadyForDeployment: Boolean
+        override val requiresDeployment: Boolean
     ) : DeviceDeploymentStatus(), NotDeployed
+    {
+        override val isReadyForDeployment = false
+    }
 
     /**
      * Device deployment status for when a device has been registered.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
@@ -9,31 +9,68 @@ import kotlinx.serialization.Serializable
  * Describes the status of a device, part of a study deployment.
  */
 @Serializable
-data class DeviceDeploymentStatus(
+sealed class DeviceDeploymentStatus
+{
     /**
      * The description of the device.
      */
     @Serializable( DeviceDescriptorSerializer::class )
-    val device: AnyDeviceDescriptor,
+    abstract val device: AnyDeviceDescriptor
     /**
      * Determines whether registering the device is required for the deployment to start running.
      */
-    val requiresRegistration: Boolean,
-    /**
-     * Determines whether the device is currently registered.
-     */
-    val isRegistered: Boolean,
+    abstract val requiresRegistration: Boolean
     /**
      * Determines whether the device requires a device deployment by retrieving [MasterDeviceDeployment].
      * Not all master devices necessarily need deployment; chained master devices do not.
      */
-    val requiresDeployment: Boolean,
+    abstract val requiresDeployment: Boolean
+
+
     /**
-     * Determines whether the device has been registered successfully and is ready for deployment.
+     * A device deployment status which has not been deployed yet.
      */
-    val isReadyForDeployment: Boolean,
+    interface NotDeployed
+    {
+        /**
+         * Determines whether the device has been registered successfully and is ready for deployment.
+         */
+        val isReadyForDeployment: Boolean
+    }
+
+
     /**
-     * True if the device has retrieved its [MasterDeviceDeployment] and was able to load all the necessary plugins to execute the study.
+     * Device deployment status for when a device has not been registered.
      */
-    val isDeployed: Boolean
-)
+    @Serializable
+    data class Unregistered(
+        @Serializable( DeviceDescriptorSerializer::class )
+        override val device: AnyDeviceDescriptor,
+        override val requiresRegistration: Boolean,
+        override val requiresDeployment: Boolean,
+        override val isReadyForDeployment: Boolean
+    ) : DeviceDeploymentStatus(), NotDeployed
+
+    /**
+     * Device deployment status for when a device has been registered.
+     */
+    @Serializable
+    data class Registered(
+        @Serializable( DeviceDescriptorSerializer::class )
+        override val device: AnyDeviceDescriptor,
+        override val requiresRegistration: Boolean,
+        override val requiresDeployment: Boolean,
+        override val isReadyForDeployment: Boolean
+    ) : DeviceDeploymentStatus(), NotDeployed
+
+    /**
+     * Device deployment status when the device has retrieved its [MasterDeviceDeployment] and was able to load all the necessary plugins to execute the study.
+     */
+    @Serializable
+    data class Deployed(
+        @Serializable( DeviceDescriptorSerializer::class )
+        override val device: AnyDeviceDescriptor,
+        override val requiresRegistration: Boolean,
+        override val requiresDeployment: Boolean
+    ) : DeviceDeploymentStatus()
+}

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
@@ -28,7 +28,7 @@ sealed class DeviceDeploymentStatus
 
 
     /**
-     * A device deployment status which has not been deployed yet.
+     * A device deployment status which indicates the correct deployment has not been deployed yet.
      */
     interface NotDeployed
     {
@@ -75,4 +75,16 @@ sealed class DeviceDeploymentStatus
         override val requiresRegistration: Boolean,
         override val requiresDeployment: Boolean
     ) : DeviceDeploymentStatus()
+
+    /**
+     * Device deployment status when the device has previously been deployed correctly, but due to changes in device registrations needs to be redeployed.
+     */
+    @Serializable
+    data class NeedsRedeployment(
+        @Serializable( DeviceDescriptorSerializer::class )
+        override val device: AnyDeviceDescriptor,
+        override val requiresRegistration: Boolean,
+        override val requiresDeployment: Boolean,
+        override val isReadyForDeployment: Boolean
+    ) : DeviceDeploymentStatus(), NotDeployed
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployment.domain
 
+import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.DeviceDescriptorSerializer
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
@@ -61,4 +62,9 @@ data class MasterDeviceDeployment(
          */
         val destinationDeviceRoleName: String
     )
+
+    /**
+     * Get the checksum which needs to be passed to [DeploymentService] to identify this device deployment.
+     */
+    fun getChecksum(): Int = hashCode()
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -283,7 +283,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
      * Get the deployment configuration for the specified [device] in this study deployment.
      *
      * @throws IllegalArgumentException when the passed [device] is not part of the protocol of this study deployment.
-     * @throws IllegalArgumentException when the passed [device] is not ready to receive a [MasterDeviceDeployment] yet.
+     * @throws IllegalStateException when a [MasterDeviceDeployment] for the passed [device] is not yet available.
      */
     fun getDeviceDeploymentFor( device: AnyMasterDeviceDescriptor ): MasterDeviceDeployment
     {
@@ -292,7 +292,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
 
         // Verify whether the specified device is ready to be deployed.
         val canDeploy = canObtainDeviceDeployment( device )
-        require( canDeploy ) { "The specified device is awaiting registration of itself or other devices before it can be deployed." }
+        check( canDeploy ) { "The specified device is awaiting registration of itself or other devices before it can be deployed." }
 
         val configuration: DeviceRegistration = _registeredDevices[ device ]!! // Must be non-null, otherwise canObtainDeviceDeployment would fail.
 
@@ -331,9 +331,8 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
     /**
      * Indicate that the specified [device] was deployed successfully.
      *
-     * @throws IllegalArgumentException when the passed [device]:
-     * - is not part of the protocol of this study deployment
-     * - could not have possibly received a [MasterDeviceDeployment] yet.
+     * @throws IllegalArgumentException when the passed [device] is not part of the protocol of this study deployment.
+     * @throws IllegalStateException when the passed [device] cannot be deployed yet.
      */
     fun deviceDeployed( device: AnyMasterDeviceDescriptor )
     {
@@ -342,7 +341,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
 
         // Verify whether the specified device is ready to be deployed.
         val canDeploy = canObtainDeviceDeployment( device )
-        require( canDeploy ) { "The specified device is awaiting registration of itself or other devices before it can be deployed." }
+        check( canDeploy ) { "The specified device is awaiting registration of itself or other devices before it can be deployed." }
 
         if ( _deployedDevices.add( device ) )
         {

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -119,7 +119,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
                 when {
                     isDeployed -> DeviceDeploymentStatus.Deployed( it.device, it.requiresRegistration, requiresDeployment )
                     isRegistered -> DeviceDeploymentStatus.Registered( it.device, it.requiresRegistration, requiresDeployment, isReadyForDeployment )
-                    else -> DeviceDeploymentStatus.Unregistered( it.device, it.requiresRegistration, requiresDeployment, isReadyForDeployment )
+                    else -> DeviceDeploymentStatus.Unregistered( it.device, it.requiresRegistration, requiresDeployment )
                 }
             }
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -110,11 +110,17 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
     {
         val devicesStatus: List<DeviceDeploymentStatus> =
             _registrableDevices.map {
-                val isRegistered = _registeredDevices.contains( it.device )
                 val requiresDeployment = isTopLevelMasterDevice( it.device )
+
+                val isRegistered = _registeredDevices.contains( it.device )
                 val isReadyForDeployment = canObtainDeviceDeployment( it.device )
                 val isDeployed = false // TODO: For now, deployment manager is not yet notified of successful deployment.
-                DeviceDeploymentStatus( it.device, it.requiresRegistration, isRegistered, requiresDeployment, isReadyForDeployment, isDeployed )
+
+                when {
+                    isDeployed -> DeviceDeploymentStatus.Deployed( it.device, it.requiresRegistration, requiresDeployment )
+                    isRegistered -> DeviceDeploymentStatus.Registered( it.device, it.requiresRegistration, requiresDeployment, isReadyForDeployment )
+                    else -> DeviceDeploymentStatus.Unregistered( it.device, it.requiresRegistration, requiresDeployment, isReadyForDeployment )
+                }
             }
 
         return StudyDeploymentStatus( id, devicesStatus )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
@@ -17,6 +17,7 @@ data class StudyDeploymentSnapshot(
     val studyDeploymentId: UUID,
     val studyProtocolSnapshot: StudyProtocolSnapshot,
     val registeredDevices: Map<String, @Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>,
+    val deployedDevices: Set<String>,
     val participations: Set<AccountParticipation>
 ) : Snapshot<StudyDeployment>()
 {
@@ -33,6 +34,7 @@ data class StudyDeploymentSnapshot(
                 studyDeployment.id,
                 studyDeployment.protocolSnapshot,
                 studyDeployment.registeredDevices.mapKeys { it.key.roleName },
+                studyDeployment.deployedDevices.map { it.roleName }.toSet(),
                 studyDeployment.participations )
         }
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
@@ -16,8 +16,10 @@ import kotlinx.serialization.Serializable
 data class StudyDeploymentSnapshot(
     val studyDeploymentId: UUID,
     val studyProtocolSnapshot: StudyProtocolSnapshot,
-    val registeredDevices: Map<String, @Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>,
+    val registeredDevices: Set<String>,
+    val deviceRegistrationHistory: Map<String, List<@Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>>,
     val deployedDevices: Set<String>,
+    val invalidatedDeployedDevices: Set<String>,
     val participations: Set<AccountParticipation>
 ) : Snapshot<StudyDeployment>()
 {
@@ -33,8 +35,10 @@ data class StudyDeploymentSnapshot(
             return StudyDeploymentSnapshot(
                 studyDeployment.id,
                 studyDeployment.protocolSnapshot,
-                studyDeployment.registeredDevices.mapKeys { it.key.roleName },
+                studyDeployment.registeredDevices.map { it.key.roleName }.toSet(),
+                studyDeployment.deviceRegistrationHistory.mapKeys { it.key.roleName },
                 studyDeployment.deployedDevices.map { it.roleName }.toSet(),
+                studyDeployment.invalidatedDeployedDevices.map { it.roleName }.toSet(),
                 studyDeployment.participations )
         }
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
@@ -22,7 +22,7 @@ data class StudyDeploymentStatus(
      * Returns all [AnyDeviceDescriptor]'s in [devicesStatus] which require registration.
      */
     fun getRemainingDevicesToRegister(): Set<AnyDeviceDescriptor> =
-        devicesStatus.filter { it.requiresRegistration && it !is DeviceDeploymentStatus.Registered }.map { it.device }.toSet()
+        devicesStatus.filter { it.requiresRegistration && it is DeviceDeploymentStatus.Unregistered }.map { it.device }.toSet()
 
     /**
      * Returns all [AnyMasterDeviceDescriptor] which are ready for deployment and have not yet been deployed.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
@@ -19,17 +19,17 @@ data class StudyDeploymentStatus(
 )
 {
     /**
-     * Returns all [DeviceDescriptor]'s in [devicesStatus] which require registration.
+     * Returns all [AnyDeviceDescriptor]'s in [devicesStatus] which require registration.
      */
     fun getRemainingDevicesToRegister(): Set<AnyDeviceDescriptor> =
-        devicesStatus.filter { it.requiresRegistration && !it.isRegistered }.map { it.device }.toSet()
+        devicesStatus.filter { it.requiresRegistration && it !is DeviceDeploymentStatus.Registered }.map { it.device }.toSet()
 
     /**
      * Returns all [AnyMasterDeviceDescriptor] which are ready for deployment and have not yet been deployed.
      */
     fun getRemainingDevicesReadyToDeploy(): Set<AnyMasterDeviceDescriptor> =
         devicesStatus
-            .filter { it.isReadyForDeployment && !it.isDeployed }
+            .filter { it is DeviceDeploymentStatus.NotDeployed && it.isReadyForDeployment }
             .map { it.device }
             .filterIsInstance<AnyMasterDeviceDescriptor>()
             .toSet()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
@@ -25,7 +25,7 @@ data class StudyDeploymentStatus(
         devicesStatus.filter { it.requiresRegistration && it is DeviceDeploymentStatus.Unregistered }.map { it.device }.toSet()
 
     /**
-     * Returns all [AnyMasterDeviceDescriptor] which are ready for deployment and have not yet been deployed.
+     * Returns all [AnyMasterDeviceDescriptor] which are ready for deployment and are not deployed with the correct deployment yet.
      */
     fun getRemainingDevicesReadyToDeploy(): Set<AnyMasterDeviceDescriptor> =
         devicesStatus

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -52,9 +52,9 @@ sealed class DeploymentServiceRequest
         ServiceInvoker<DeploymentService, MasterDeviceDeployment> by createServiceInvoker( DeploymentService::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName )
 
     @Serializable
-    data class DeploymentSuccessful( val studyDeploymentId: UUID, val masterDeviceRoleName: String ) :
+    data class DeploymentSuccessful( val studyDeploymentId: UUID, val masterDeviceRoleName: String, val deploymentChecksum: Int ) :
         DeploymentServiceRequest(),
-        ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName )
+        ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deploymentChecksum )
 
     @Serializable
     data class AddParticipation( val studyDeploymentId: UUID, val deviceRoleNames: Set<String>, val identity: AccountIdentity, val invitation: StudyInvitation ) :

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -47,6 +47,11 @@ sealed class DeploymentServiceRequest
         ServiceInvoker<DeploymentService, MasterDeviceDeployment> by createServiceInvoker( DeploymentService::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName )
 
     @Serializable
+    data class DeploymentSuccessful( val studyDeploymentId: UUID, val masterDeviceRoleName: String ) :
+        DeploymentServiceRequest(),
+        ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName )
+
+    @Serializable
     data class AddParticipation( val studyDeploymentId: UUID, val deviceRoleNames: Set<String>, val identity: AccountIdentity, val invitation: StudyInvitation ) :
         DeploymentServiceRequest(),
         ServiceInvoker<DeploymentService, Participation> by createServiceInvoker( DeploymentService::addParticipation, studyDeploymentId, deviceRoleNames, identity, invitation )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -42,6 +42,11 @@ sealed class DeploymentServiceRequest
         ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::registerDevice, studyDeploymentId, deviceRoleName, registration )
 
     @Serializable
+    data class UnregisterDevice( val studyDeploymentId: UUID, val deviceRoleName: String ) :
+        DeploymentServiceRequest(),
+        ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::unregisterDevice, studyDeploymentId, deviceRoleName )
+
+    @Serializable
     data class GetDeviceDeploymentFor( val studyDeploymentId: UUID, val masterDeviceRoleName: String ) :
         DeploymentServiceRequest(),
         ServiceInvoker<DeploymentService, MasterDeviceDeployment> by createServiceInvoker( DeploymentService::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -18,6 +18,7 @@ class DeploymentServiceMock(
     private val getStudyDeploymentStatusResult: StudyDeploymentStatus = emptyStatus,
     private val registerDeviceResult: StudyDeploymentStatus = emptyStatus,
     private val getDeviceDeploymentForResult: MasterDeviceDeployment = emptyMasterDeviceDeployment,
+    private val deploymentSuccessfulResult: StudyDeploymentStatus = emptyStatus,
     private val getParticipationInvitationResult: Set<ParticipationInvitation> = setOf()
 ) : Mock<DeploymentService>(), DeploymentService
 {
@@ -54,6 +55,12 @@ class DeploymentServiceMock(
     {
         trackSuspendCall( DeploymentService::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName )
         return getDeviceDeploymentForResult
+    }
+
+    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String ): StudyDeploymentStatus
+    {
+        trackSuspendCall( DeploymentService::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName )
+        return deploymentSuccessfulResult
     }
 
     override suspend fun addParticipation( studyDeploymentId: UUID, deviceRoleNames: Set<String>, identity: AccountIdentity, invitation: StudyInvitation ): Participation

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -64,9 +64,9 @@ class DeploymentServiceMock(
         return getDeviceDeploymentForResult
     }
 
-    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String ): StudyDeploymentStatus
+    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ): StudyDeploymentStatus
     {
-        trackSuspendCall( DeploymentService::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName )
+        trackSuspendCall( DeploymentService::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deploymentChecksum )
         return deploymentSuccessfulResult
     }
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -17,6 +17,7 @@ class DeploymentServiceMock(
     private val createStudyDeploymentResult: StudyDeploymentStatus = emptyStatus,
     private val getStudyDeploymentStatusResult: StudyDeploymentStatus = emptyStatus,
     private val registerDeviceResult: StudyDeploymentStatus = emptyStatus,
+    private val unregisterDeviceResult: StudyDeploymentStatus = emptyStatus,
     private val getDeviceDeploymentForResult: MasterDeviceDeployment = emptyMasterDeviceDeployment,
     private val deploymentSuccessfulResult: StudyDeploymentStatus = emptyStatus,
     private val getParticipationInvitationResult: Set<ParticipationInvitation> = setOf()
@@ -49,6 +50,12 @@ class DeploymentServiceMock(
     {
         trackSuspendCall( DeploymentService::registerDevice, studyDeploymentId, deviceRoleName, registration )
         return registerDeviceResult
+    }
+
+    override suspend fun unregisterDevice( studyDeploymentId: UUID, deviceRoleName: String ): StudyDeploymentStatus
+    {
+        trackSuspendCall( DeploymentService::unregisterDevice, studyDeploymentId, deviceRoleName )
+        return unregisterDeviceResult
     }
 
     override suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
@@ -23,6 +23,19 @@ abstract class DeploymentServiceTest
 
 
     @Test
+    fun unregisterDevice_succeeds() = runBlockingTest {
+        val ( deploymentService, _ ) = createService()
+        val deviceRolename = "Test device"
+        val studyDeploymentId = addTestDeployment( deploymentService, deviceRolename )
+        var status = deploymentService.getStudyDeploymentStatus( studyDeploymentId )
+        val device = status.getRemainingDevicesToRegister().first()
+        deploymentService.registerDevice( studyDeploymentId, deviceRolename, device.createRegistration { } )
+
+        status = deploymentService.unregisterDevice( studyDeploymentId, deviceRolename )
+        assertEquals( device, status.getRemainingDevicesToRegister().single() )
+    }
+
+    @Test
     fun addParticipation_has_matching_studyDeploymentId() = runBlockingTest {
         val ( deploymentService, _ ) = createService()
         val deviceRoleName = "Test device"

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -105,7 +105,8 @@ fun createComplexDeployment(): StudyDeployment
     deployment.addParticipation( account, participation )
 
     // Deploy a device.
-    deployment.deviceDeployed( master )
+    val deviceDeployment = deployment.getDeviceDeploymentFor( master )
+    deployment.deviceDeployed( master, deviceDeployment.getChecksum() )
 
     // Remove events since tests building on top of this are not interested in how this object was constructed.
     deployment.consumeEvents()

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -107,6 +107,9 @@ fun createComplexDeployment(): StudyDeployment
     // Deploy a device.
     deployment.deviceDeployed( master )
 
+    // Remove events since tests building on top of this are not interested in how this object was constructed.
+    deployment.consumeEvents()
+
     return deployment
 }
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -8,6 +8,7 @@ import dk.cachet.carp.deployment.domain.triggers.StubTrigger
 import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.StudyProtocol
+import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
 import dk.cachet.carp.protocols.domain.devices.DeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
@@ -95,12 +96,16 @@ fun createComplexDeployment(): StudyDeployment
     val deployment = studyDeploymentFor( protocol )
 
     // Add device registration.
-    deployment.registerDevice( deployment.registrableDevices.first().device, DefaultDeviceRegistration( "test" ) )
+    val master = deployment.registrableDevices.first().device as AnyMasterDeviceDescriptor
+    deployment.registerDevice( master, DefaultDeviceRegistration( "test" ) )
 
     // Add a participation.
     val account = Account.withUsernameIdentity( "test" )
     val participation = Participation( deployment.id )
     deployment.addParticipation( account, participation )
+
+    // Deploy a device.
+    deployment.deviceDeployed( master )
 
     return deployment
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
@@ -72,7 +72,8 @@ interface DeploymentRepositoryTest
         assertEquals( deployment.getSnapshot(), retrieved?.getSnapshot() ) // StudyDeployment does not implement equals, but snapshot does.
 
         // Verify whether deploying a device is updated.
-        deployment.deviceDeployed( masterDevice )
+        val deviceDeployment = deployment.getDeviceDeploymentFor( masterDevice )
+        deployment.deviceDeployed( masterDevice, deviceDeployment.getChecksum() )
         repo.update( deployment )
         retrieved = repo.getStudyDeploymentBy( deployment.id )
         assertEquals( deployment.getSnapshot(), retrieved?.getSnapshot() )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
@@ -63,12 +63,19 @@ interface DeploymentRepositoryTest
         val protocol = createSingleMasterWithConnectedDeviceProtocol()
         val deployment = studyDeploymentFor( protocol )
         repo.add( deployment )
+        val masterDevice = protocol.masterDevices.first()
 
-        deployment.registerDevice( protocol.masterDevices.first(), DefaultDeviceRegistration( "0" ) )
+        // Verify whether registering a device is updated.
+        deployment.registerDevice( masterDevice, DefaultDeviceRegistration( "0" ) )
         repo.update( deployment )
-        val retrieved = repo.getStudyDeploymentBy( deployment.id )
-        assertNotNull( retrieved )
-        assertEquals( deployment.getSnapshot(), retrieved.getSnapshot() ) // StudyDeployment does not implement equals, but snapshot does.
+        var retrieved = repo.getStudyDeploymentBy( deployment.id )
+        assertEquals( deployment.getSnapshot(), retrieved?.getSnapshot() ) // StudyDeployment does not implement equals, but snapshot does.
+
+        // Verify whether deploying a device is updated.
+        deployment.deviceDeployed( masterDevice )
+        repo.update( deployment )
+        retrieved = repo.getStudyDeploymentBy( deployment.id )
+        assertEquals( deployment.getSnapshot(), retrieved?.getSnapshot() )
     }
 
     @Test

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
@@ -393,7 +393,7 @@ class StudyDeploymentTest
         val master = protocol.masterDevices.first { it.roleName == "Master" }
         val deployment = studyDeploymentFor( protocol )
 
-        assertFailsWith<IllegalArgumentException> { deployment.getDeviceDeploymentFor( master ) }
+        assertFailsWith<IllegalStateException> { deployment.getDeviceDeploymentFor( master ) }
     }
 
     @Test
@@ -443,7 +443,7 @@ class StudyDeploymentTest
         protocol.addMasterDevice( device )
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
-        assertFailsWith<IllegalArgumentException> { deployment.deviceDeployed( device ) }
+        assertFailsWith<IllegalStateException> { deployment.deviceDeployed( device ) }
         assertEquals( 0, deployment.consumeEvents().filterIsInstance<StudyDeployment.Event.DeviceDeployed>().count() )
     }
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -24,6 +24,7 @@ class DeploymentServiceRequestsTest
             DeploymentServiceRequest.GetStudyDeploymentStatus( UUID.randomUUID() ),
             DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration( "Device ID" ) ),
             DeploymentServiceRequest.GetDeviceDeploymentFor( UUID.randomUUID(), "Test role" ),
+            DeploymentServiceRequest.DeploymentSuccessful( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.AddParticipation( UUID.randomUUID(), setOf( "Phone" ), UsernameAccountIdentity( "Test" ), StudyInvitation.empty() ),
             DeploymentServiceRequest.GetParticipationInvitations( UUID.randomUUID() )
         )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -25,7 +25,7 @@ class DeploymentServiceRequestsTest
             DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration( "Device ID" ) ),
             DeploymentServiceRequest.UnregisterDevice( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.GetDeviceDeploymentFor( UUID.randomUUID(), "Test role" ),
-            DeploymentServiceRequest.DeploymentSuccessful( UUID.randomUUID(), "Test role" ),
+            DeploymentServiceRequest.DeploymentSuccessful( UUID.randomUUID(), "Test role", 0 ),
             DeploymentServiceRequest.AddParticipation( UUID.randomUUID(), setOf( "Phone" ), UsernameAccountIdentity( "Test" ), StudyInvitation.empty() ),
             DeploymentServiceRequest.GetParticipationInvitations( UUID.randomUUID() )
         )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -23,6 +23,7 @@ class DeploymentServiceRequestsTest
             DeploymentServiceRequest.CreateStudyDeployment( createEmptyProtocol().getSnapshot() ),
             DeploymentServiceRequest.GetStudyDeploymentStatus( UUID.randomUUID() ),
             DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration( "Device ID" ) ),
+            DeploymentServiceRequest.UnregisterDevice( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.GetDeviceDeploymentFor( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.DeploymentSuccessful( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.AddParticipation( UUID.randomUUID(), setOf( "Phone" ), UsernameAccountIdentity( "Test" ), StudyInvitation.empty() ),

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentSnapshotTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentSnapshotTest.kt
@@ -43,7 +43,8 @@ class StudyDeploymentSnapshotTest
         val serialized = serializeDeploymentSnapshotIncludingUnknownRegistration()
         val parsed = StudyDeploymentSnapshot.fromJson( serialized )
 
-        assertEquals( 1, parsed.registeredDevices.values.filterIsInstance<CustomDeviceRegistration>().count() )
+        val allRegistrations = parsed.deviceRegistrationHistory.values.flatten()
+        assertEquals( 1, allRegistrations.filterIsInstance<CustomDeviceRegistration>().count() )
     }
 
     /**

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentTest.kt
@@ -42,6 +42,9 @@ class StudyDeploymentTest
         val commonParticipations =
             deployment.participations.intersect( fromSnapshot.participations )
         assertEquals( deployment.participations.count(), commonParticipations.count() )
+        val commonDeployedDevices =
+            deployment.deployedDevices.intersect( fromSnapshot.deployedDevices )
+        assertEquals( deployment.deployedDevices.count(), commonDeployedDevices.count() )
     }
 
     @Test

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyDeploymentTest.kt
@@ -1,6 +1,5 @@
 package dk.cachet.carp.deployment.infrastructure
 
-import dk.cachet.carp.deployment.domain.createComplexDeployment
 import dk.cachet.carp.deployment.domain.createEmptyProtocol
 import dk.cachet.carp.deployment.domain.StubMasterDeviceDescriptor
 import dk.cachet.carp.deployment.domain.STUBS_SERIAL_MODULE
@@ -26,26 +25,6 @@ class StudyDeploymentTest
         JSON = createDeploymentSerializer( STUBS_SERIAL_MODULE )
     }
 
-    @Test
-    fun creating_study_deployment_fromSnapshot_obtained_by_getSnapshot_is_the_same()
-    {
-        val deployment = createComplexDeployment()
-
-        val snapshot = deployment.getSnapshot()
-        val fromSnapshot = StudyDeployment.fromSnapshot( snapshot )
-
-        assertEquals( deployment.id, fromSnapshot.id )
-        assertEquals( deployment.protocolSnapshot, fromSnapshot.protocolSnapshot )
-        val commonRegisteredDevices =
-            deployment.registeredDevices.asIterable().intersect( fromSnapshot.registeredDevices.asIterable() )
-        assertEquals( deployment.registeredDevices.count(), commonRegisteredDevices.count() )
-        val commonParticipations =
-            deployment.participations.intersect( fromSnapshot.participations )
-        assertEquals( deployment.participations.count(), commonParticipations.count() )
-        val commonDeployedDevices =
-            deployment.deployedDevices.intersect( fromSnapshot.deployedDevices )
-        assertEquals( deployment.deployedDevices.count(), commonDeployedDevices.count() )
-    }
 
     @Test
     fun cant_initialize_deployment_with_invalid_snapshot()


### PR DESCRIPTION
**Done:**
- Let `DeviceDeploymentStatus` reflect state machine (https://github.com/cph-cachet/carp.core-kotlin/issues/115) **(done in https://github.com/cph-cachet/carp.core-kotlin/pull/117/commits/9bff252672e132ca79c8d31fb425a09d1d16a931)**
- `DeploymentService.registerDevice` can now be called multiple times in a row. (https://github.com/cph-cachet/carp.core-kotlin/pull/117/commits/b359aa0dc45e55b7064985c031e3d5d15264e515)
- Add `DeploymentService.unregisterDevice` endpoint. This can be used, e.g., in case a previous deployment failed and you want to try out deploying on a new device. Unregistering a device may invalidate previously retrieved deployments.
- Add `DeviceDeploymentStatus.NeedsRedeployment` in case the deployment of a device was invalidated.
- Add `DeploymentService.deploymentSuccessful` endpoint. This takes as a parameter a `deploymentChecksum` to verify whether the device deployment which was deployed is 'up to date'.
- Bugfix: `getRemainingDevicesToRegister` would return deployed devices. (https://github.com/cph-cachet/carp.core-kotlin/pull/117/commits/ba6141af33f0e17b4d731161bbc02aa0ee57f0ed)
- Changed `IllegalArgumentException` to `IllegalStateException` when a device is not yet ready to be deployed for `DeploymentService` `getDeviceDeploymentFor` and `deploymentSuccessful` endpoints.

**Skipped for now:**
- Should we prevent multiple deployments of a master device? (part of this is solved, but https://github.com/cph-cachet/carp.core-kotlin/issues/57#issuecomment-610571345)
- While implementing this, it became clear we might need to think more about what it means for devices to be 'dependent' and thus when deployments are invalidated. We can look at this in detail later: https://github.com/cph-cachet/carp.core-kotlin/issues/118