### PR TITLE
Finish basic deployment status

### DIFF
--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
@@ -120,8 +120,8 @@ class StudyRuntime private constructor(
             isDeployed = true
         }
         // Handle race conditions with competing clients modifying device registrations, invalidating this deployment.
-        catch ( arg: IllegalArgumentException ) { }
-        catch ( arg: IllegalStateException ) { }
+        catch ( ignore: IllegalArgumentException ) { }
+        catch ( ignore: IllegalStateException ) { }
 
         return isDeployed
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -39,13 +39,13 @@ interface DeploymentService
     /**
      * Register the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].
      *
-     * @param studyDeploymentId The id of the [StudyDeployment] to register the device for.
-     * @param deviceRoleName The role name of the device in the deployment to register.
      * @param registration A matching configuration for the device with [deviceRoleName].
      *
-     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
-     * [deviceRoleName] is not present in the deployment or is already registered and a different [registration] is specified than a previous request,
-     * or [registration] is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device.
+     * @throws IllegalArgumentException when:
+     * - a deployment with [studyDeploymentId] does not exist
+     * - [deviceRoleName] is not present in the deployment or is already registered and a different [registration] is specified than a previous request
+     * - [registration] is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device
+     * @throws IllegalStateException when this deployment has stopped.
      */
     suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
 
@@ -55,6 +55,7 @@ interface DeploymentService
      * @throws IllegalArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [deviceRoleName] is not present in the deployment
+     * @throws IllegalStateException when this deployment has stopped.
      */
     suspend fun unregisterDevice( studyDeploymentId: UUID, deviceRoleName: String ): StudyDeploymentStatus
 
@@ -77,9 +78,17 @@ interface DeploymentService
      * - a deployment with [studyDeploymentId] does not exist
      * - [masterDeviceRoleName] is not present in the deployment
      * - the [deploymentChecksum] does not match the checksum of the expected deployment. The deployment might be outdated.
-     * @throws IllegalStateException when the deployment cannot be deployed yet.
+     * @throws IllegalStateException when the deployment cannot be deployed yet, or the deployment has stopped.
      */
     suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ): StudyDeploymentStatus
+
+    /**
+     * Stop the study deployment with the specified [studyDeploymentId].
+     * No further changes to this deployment will be allowed and no more data will be collected.
+     *
+     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist.
+     */
+    suspend fun stop( studyDeploymentId: UUID ): StudyDeploymentStatus
 
     /**
      * Let the person with the specified [identity] participate in the study deployment with [studyDeploymentId],
@@ -88,10 +97,12 @@ interface DeploymentService
      * An [invitation] (and account details) is delivered to the person managing the [identity],
      * or should be handed out manually to the relevant participant by the person managing the specified [identity].
      *
-     * @throws IllegalArgumentException in case there is no study deployment with [studyDeploymentId],
-     * or when any of the [deviceRoleNames] is not part of the study protocol deployment.
-     * @throws IllegalStateException in case the specified [identity] was already invited to participate in this deployment
-     * and a different [invitation] is specified than a previous request.
+     * @throws IllegalArgumentException when:
+     * - there is no study deployment with [studyDeploymentId]
+     * - any of the [deviceRoleNames] are not part of the study protocol deployment
+     * @throws IllegalStateException when:
+     * - the specified [identity] was already invited to participate in this deployment and a different [invitation] is specified than a previous request
+     * - this deployment has stopped
      */
     suspend fun addParticipation( studyDeploymentId: UUID, deviceRoleNames: Set<String>, identity: AccountIdentity, invitation: StudyInvitation ): Participation
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -3,7 +3,6 @@ package dk.cachet.carp.deployment.application
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
-import dk.cachet.carp.deployment.domain.StudyDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
@@ -30,11 +29,16 @@ interface DeploymentService
     /**
      * Get the status for a study deployment with the given [studyDeploymentId].
      *
-     * @param studyDeploymentId The id of the [StudyDeployment] to return [StudyDeploymentStatus] for.
-     *
      * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist.
      */
     suspend fun getStudyDeploymentStatus( studyDeploymentId: UUID ): StudyDeploymentStatus
+
+    /**
+     * Get the statuses for a set of deployments with the specified [studyDeploymentIds].
+     *
+     * @throws IllegalArgumentException when [studyDeploymentIds] contains an ID for which no deployment exists.
+     */
+    suspend fun getStudyDeploymentStatuses( studyDeploymentIds: Set<UUID> ): List<StudyDeploymentStatus>
 
     /**
      * Register the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -38,7 +38,7 @@ interface DeploymentService
      *
      * @throws IllegalArgumentException when [studyDeploymentIds] contains an ID for which no deployment exists.
      */
-    suspend fun getStudyDeploymentStatuses( studyDeploymentIds: Set<UUID> ): List<StudyDeploymentStatus>
+    suspend fun getStudyDeploymentStatusList( studyDeploymentIds: Set<UUID> ): List<StudyDeploymentStatus>
 
     /**
      * Register the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -257,7 +257,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
     private fun getStudyDeployment( studyDeploymentId: UUID ): StudyDeployment
     {
         val deployment: StudyDeployment? = repository.getStudyDeploymentBy( studyDeploymentId )
-        require( deployment != null ) { "A deployment with ID '$studyDeploymentId' does not exist." }
+        requireNotNull( deployment ) { "A deployment with ID '$studyDeploymentId' does not exist." }
 
         return deployment
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -56,6 +56,20 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
     }
 
     /**
+     * Get the statuses for a set of deployments with the specified [studyDeploymentIds].
+     *
+     * @throws IllegalArgumentException when [studyDeploymentIds] contains an ID for which no deployment exists.
+     */
+    override suspend fun getStudyDeploymentStatuses( studyDeploymentIds: Set<UUID> ): List<StudyDeploymentStatus>
+    {
+        val deployments = repository.getStudyDeploymentsBy( studyDeploymentIds )
+        require( deployments.count() == studyDeploymentIds.count() )
+            { "No deployment exists for one of the specified studyDeploymentIds." }
+
+        return deployments.map{ it.getStatus() }
+    }
+
+    /**
      * Register the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].
      *
      * @param registration A matching configuration for the device with [deviceRoleName].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -172,8 +172,11 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
     {
         val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
 
-        deployment.stop()
-        repository.update( deployment )
+        if ( !deployment.hasStopped )
+        {
+            deployment.stop()
+            repository.update( deployment )
+        }
 
         return deployment.getStatus()
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -60,7 +60,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      *
      * @throws IllegalArgumentException when [studyDeploymentIds] contains an ID for which no deployment exists.
      */
-    override suspend fun getStudyDeploymentStatuses( studyDeploymentIds: Set<UUID> ): List<StudyDeploymentStatus>
+    override suspend fun getStudyDeploymentStatusList( studyDeploymentIds: Set<UUID> ): List<StudyDeploymentStatus>
     {
         val deployments = repository.getStudyDeploymentsBy( studyDeploymentIds )
         require( deployments.count() == studyDeploymentIds.count() )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -58,13 +58,13 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
     /**
      * Register the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].
      *
-     * @param studyDeploymentId The id of the [StudyDeployment] to register the device for.
-     * @param deviceRoleName The role name of the device in the deployment to register.
      * @param registration A matching configuration for the device with [deviceRoleName].
      *
-     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist,
-     * [deviceRoleName] is not present in the deployment or is already registered and a different [registration] is specified than a previous request,
-     * or [registration] is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device.
+     * @throws IllegalArgumentException when:
+     * - a deployment with [studyDeploymentId] does not exist
+     * - [deviceRoleName] is not present in the deployment or is already registered and a different [registration] is specified than a previous request
+     * - [registration] is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device
+     * @throws IllegalStateException when this deployment has stopped.
      */
     override suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
     {
@@ -93,6 +93,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      * @throws IllegalArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [deviceRoleName] is not present in the deployment
+     * @throws IllegalStateException when this deployment has stopped.
      */
     override suspend fun unregisterDevice( studyDeploymentId: UUID, deviceRoleName: String ): StudyDeploymentStatus
     {
@@ -134,7 +135,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
      * - a deployment with [studyDeploymentId] does not exist
      * - [masterDeviceRoleName] is not present in the deployment
      * - the [deploymentChecksum] does not match the checksum of the expected deployment. The deployment might be outdated.
-     * @throws IllegalStateException when the deployment cannot be deployed yet.
+     * @throws IllegalStateException when the deployment cannot be deployed yet, or the deployment has stopped.
      */
     override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ): StudyDeploymentStatus
     {
@@ -148,16 +149,34 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
     }
 
     /**
+     * Stop the study deployment with the specified [studyDeploymentId].
+     * No further changes to this deployment will be allowed and no more data will be collected.
+     *
+     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist.
+     */
+    override suspend fun stop( studyDeploymentId: UUID ): StudyDeploymentStatus
+    {
+        val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
+
+        deployment.stop()
+        repository.update( deployment )
+
+        return deployment.getStatus()
+    }
+
+    /**
      * Let the person with the specified [identity] participate in the study deployment with [studyDeploymentId],
      * using the master devices with the specified [deviceRoleNames].
      * In case no account is associated to the specified [identity], a new account is created.
      * An [invitation] (and account details) is delivered to the person managing the [identity],
      * or should be handed out manually to the relevant participant by the person managing the specified [identity].
      *
-     * @throws IllegalArgumentException in case there is no study deployment with [studyDeploymentId],
-     * or when any of the [deviceRoleNames] is not part of the study protocol deployment.
-     * @throws IllegalStateException in case the specified [identity] was already invited to participate in this deployment
-     * and a different [invitation] is specified than a previous request.
+     * @throws IllegalArgumentException when:
+     * - there is no study deployment with [studyDeploymentId]
+     * - any of the [deviceRoleNames] are not part of the study protocol deployment
+     * @throws IllegalStateException when:
+     * - the specified [identity] was already invited to participate in this deployment and a different [invitation] is specified than a previous request
+     * - this deployment has stopped
      */
     override suspend fun addParticipation( studyDeploymentId: UUID, deviceRoleNames: Set<String>, identity: AccountIdentity, invitation: StudyInvitation ): Participation
     {

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -172,7 +172,7 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
     {
         val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
 
-        if ( !deployment.hasStopped )
+        if ( !deployment.isStopped )
         {
             deployment.stop()
             repository.update( deployment )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
@@ -15,10 +15,14 @@ interface DeploymentRepository
 
     /**
      * Return the [StudyDeployment] with the specified [id], or null when no study deployment is found.
-     *
-     * @param id The id of the [StudyDeployment] to search for.
      */
     fun getStudyDeploymentBy( id: UUID ): StudyDeployment?
+
+    /**
+     * Return all [StudyDeployment]s matching any of the specified [ids].
+     * Ids that are not found are ignored.
+     */
+    fun getStudyDeploymentsBy( ids: Set<UUID> ): List<StudyDeployment>
 
     /**
      * Update a [studyDeployment] which is already stored in this repository.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
@@ -16,7 +16,7 @@ interface DeploymentRepository
     /**
      * Return the [StudyDeployment] with the specified [id], or null when no study deployment is found.
      */
-    fun getStudyDeploymentBy( id: UUID ): StudyDeployment?
+    fun getStudyDeploymentBy( id: UUID ): StudyDeployment? = getStudyDeploymentsBy( setOf( id ) ).firstOrNull()
 
     /**
      * Return all [StudyDeployment]s matching any of the specified [ids].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
@@ -45,6 +45,7 @@ sealed class DeviceDeploymentStatus
         override val requiresDeployment: Boolean
     ) : DeviceDeploymentStatus(), NotDeployed
     {
+        // Devices always need to be registered before they can be deployed.
         override val isReadyForDeployment = false
     }
 
@@ -65,9 +66,12 @@ sealed class DeviceDeploymentStatus
     @Serializable
     data class Deployed(
         @Serializable( DeviceDescriptorSerializer::class )
-        override val device: AnyDeviceDescriptor,
-        override val requiresDeployment: Boolean
+        override val device: AnyDeviceDescriptor
     ) : DeviceDeploymentStatus()
+    {
+        // All devices that can be deployed need to be deployed.
+        override val requiresDeployment = true
+    }
 
     /**
      * Device deployment status when the device has previously been deployed correctly, but due to changes in device registrations needs to be redeployed.
@@ -76,7 +80,10 @@ sealed class DeviceDeploymentStatus
     data class NeedsRedeployment(
         @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor,
-        override val requiresDeployment: Boolean,
         override val isReadyForDeployment: Boolean
     ) : DeviceDeploymentStatus(), NotDeployed
+    {
+        // Only devices that can be deployed ever need to be redeployed, and all those require deployment.
+        override val requiresDeployment = true
+    }
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
@@ -17,10 +17,6 @@ sealed class DeviceDeploymentStatus
     @Serializable( DeviceDescriptorSerializer::class )
     abstract val device: AnyDeviceDescriptor
     /**
-     * Determines whether registering the device is required for the deployment to start running.
-     */
-    abstract val requiresRegistration: Boolean
-    /**
      * Determines whether the device requires a device deployment by retrieving [MasterDeviceDeployment].
      * Not all master devices necessarily need deployment; chained master devices do not.
      */
@@ -46,7 +42,6 @@ sealed class DeviceDeploymentStatus
     data class Unregistered(
         @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor,
-        override val requiresRegistration: Boolean,
         override val requiresDeployment: Boolean
     ) : DeviceDeploymentStatus(), NotDeployed
     {
@@ -60,7 +55,6 @@ sealed class DeviceDeploymentStatus
     data class Registered(
         @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor,
-        override val requiresRegistration: Boolean,
         override val requiresDeployment: Boolean,
         override val isReadyForDeployment: Boolean
     ) : DeviceDeploymentStatus(), NotDeployed
@@ -72,7 +66,6 @@ sealed class DeviceDeploymentStatus
     data class Deployed(
         @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor,
-        override val requiresRegistration: Boolean,
         override val requiresDeployment: Boolean
     ) : DeviceDeploymentStatus()
 
@@ -83,7 +76,6 @@ sealed class DeviceDeploymentStatus
     data class NeedsRedeployment(
         @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor,
-        override val requiresRegistration: Boolean,
         override val requiresDeployment: Boolean,
         override val isReadyForDeployment: Boolean
     ) : DeviceDeploymentStatus(), NotDeployed

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/RegistrableDevice.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/RegistrableDevice.kt
@@ -16,7 +16,7 @@ data class RegistrableDevice(
     @Serializable( DeviceDescriptorSerializer::class )
     val device: AnyDeviceDescriptor,
     /**
-     * Determines whether registering the device is required for the deployment to start running.
+     * Determines whether this device requires deployment after it has been registered.
      */
-    val requiresRegistration: Boolean
+    val requiresDeployment: Boolean
 )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -36,7 +36,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
         data class DeploymentInvalidated( val device: AnyMasterDeviceDescriptor ) : Event()
         // TODO: Immutable base class does not allow this to be defined as `object Stopped : Event()`.
         //       It requires a data class, but that does not make sense since an object would still be immutable.
-        data class Stopped( val ignoreThis: Unit = Unit ) : Event()
+        data class Stopped( private val ignoreThis: Unit = Unit ) : Event()
         data class ParticipationAdded( val accountParticipation: AccountParticipation ) : Event()
     }
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -161,10 +161,12 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
     {
         val devicesStatus: List<DeviceDeploymentStatus> = _registrableDevices.map { getDeviceStatus( it.device ) }
         val allDevicesDeployed: Boolean = devicesStatus.all { it is DeviceDeploymentStatus.Deployed }
+        val anyRegistration: Boolean = deviceRegistrationHistory.any()
 
         return when {
             allDevicesDeployed -> StudyDeploymentStatus.DeploymentReady( id, devicesStatus )
-            else -> StudyDeploymentStatus.DeployingDevices( id, devicesStatus )
+            anyRegistration -> StudyDeploymentStatus.DeployingDevices( id, devicesStatus )
+            else -> StudyDeploymentStatus.Invited( id, devicesStatus )
         }
     }
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -160,8 +160,12 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
     fun getStatus(): StudyDeploymentStatus
     {
         val devicesStatus: List<DeviceDeploymentStatus> = _registrableDevices.map { getDeviceStatus( it.device ) }
+        val allDevicesDeployed: Boolean = devicesStatus.all { it is DeviceDeploymentStatus.Deployed }
 
-        return StudyDeploymentStatus( id, devicesStatus )
+        return when {
+            allDevicesDeployed -> StudyDeploymentStatus.DeploymentReady( id, devicesStatus )
+            else -> StudyDeploymentStatus.DeployingDevices( id, devicesStatus )
+        }
     }
 
     /**

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -167,8 +167,8 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
                 val needsRedeployment = it.device in invalidatedDeployedDevices
 
                 when {
-                    needsRedeployment -> DeviceDeploymentStatus.NeedsRedeployment( it.device, it.requiresDeployment, isReadyForDeployment )
-                    isDeployed -> DeviceDeploymentStatus.Deployed( it.device, it.requiresDeployment )
+                    needsRedeployment -> DeviceDeploymentStatus.NeedsRedeployment( it.device, isReadyForDeployment )
+                    isDeployed -> DeviceDeploymentStatus.Deployed( it.device )
                     isRegistered -> DeviceDeploymentStatus.Registered( it.device, it.requiresDeployment, isReadyForDeployment )
                     else -> DeviceDeploymentStatus.Unregistered( it.device, it.requiresDeployment )
                 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
@@ -20,7 +20,7 @@ data class StudyDeploymentSnapshot(
     val deviceRegistrationHistory: Map<String, List<@Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>>,
     val deployedDevices: Set<String>,
     val invalidatedDeployedDevices: Set<String>,
-    val hasStopped: Boolean,
+    val isStopped: Boolean,
     val participations: Set<AccountParticipation>
 ) : Snapshot<StudyDeployment>()
 {
@@ -40,7 +40,7 @@ data class StudyDeploymentSnapshot(
                 studyDeployment.deviceRegistrationHistory.mapKeys { it.key.roleName },
                 studyDeployment.deployedDevices.map { it.roleName }.toSet(),
                 studyDeployment.invalidatedDeployedDevices.map { it.roleName }.toSet(),
-                studyDeployment.hasStopped,
+                studyDeployment.isStopped,
                 studyDeployment.participations )
         }
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
@@ -20,6 +20,7 @@ data class StudyDeploymentSnapshot(
     val deviceRegistrationHistory: Map<String, List<@Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>>,
     val deployedDevices: Set<String>,
     val invalidatedDeployedDevices: Set<String>,
+    val hasStopped: Boolean,
     val participations: Set<AccountParticipation>
 ) : Snapshot<StudyDeployment>()
 {
@@ -39,6 +40,7 @@ data class StudyDeploymentSnapshot(
                 studyDeployment.deviceRegistrationHistory.mapKeys { it.key.roleName },
                 studyDeployment.deployedDevices.map { it.roleName }.toSet(),
                 studyDeployment.invalidatedDeployedDevices.map { it.roleName }.toSet(),
+                studyDeployment.hasStopped,
                 studyDeployment.participations )
         }
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
@@ -10,14 +10,34 @@ import kotlinx.serialization.Serializable
  * Describes the status of a [StudyDeployment]: registered devices, last received data, whether consent has been given, etc.
  */
 @Serializable
-data class StudyDeploymentStatus(
-    val studyDeploymentId: UUID,
+sealed class StudyDeploymentStatus
+{
+    abstract val studyDeploymentId: UUID
     /**
      * The list of all devices part of this study deployment and their status.
      */
-    val devicesStatus: List<DeviceDeploymentStatus>
-)
-{
+    abstract val devicesStatus: List<DeviceDeploymentStatus>
+
+
+    /**
+     * Study deployment status for as long as there are remaining master devices to deploy.
+     */
+    @Serializable
+    data class DeployingDevices(
+        override val studyDeploymentId: UUID,
+        override val devicesStatus: List<DeviceDeploymentStatus>
+    ) : StudyDeploymentStatus()
+
+    /**
+     * Study deployment status once all master devices have been successfully deployed.
+     */
+    @Serializable
+    data class DeploymentReady(
+        override val studyDeploymentId: UUID,
+        override val devicesStatus: List<DeviceDeploymentStatus>
+    ) : StudyDeploymentStatus()
+
+
     /**
      * Returns all [AnyDeviceDescriptor]'s in [devicesStatus] which still require registration.
      */

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
@@ -29,8 +29,7 @@ sealed class StudyDeploymentStatus
     ) : StudyDeploymentStatus()
 
     /**
-     * Study deployment status once participants have started registering devices,
-     * but remaining master devices still need to be deployed.
+     * Participants have started registering devices, but remaining master devices still need to be deployed.
      */
     @Serializable
     data class DeployingDevices(
@@ -39,10 +38,19 @@ sealed class StudyDeploymentStatus
     ) : StudyDeploymentStatus()
 
     /**
-     * Study deployment status once all master devices have been successfully deployed.
+     * All master devices have been successfully deployed.
      */
     @Serializable
     data class DeploymentReady(
+        override val studyDeploymentId: UUID,
+        override val devicesStatus: List<DeviceDeploymentStatus>
+    ) : StudyDeploymentStatus()
+
+    /**
+     * The study deployment has been stopped and no more data should be collected.
+     */
+    @Serializable
+    data class Stopped(
         override val studyDeploymentId: UUID,
         override val devicesStatus: List<DeviceDeploymentStatus>
     ) : StudyDeploymentStatus()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
@@ -33,4 +33,11 @@ data class StudyDeploymentStatus(
             .map { it.device }
             .filterIsInstance<AnyMasterDeviceDescriptor>()
             .toSet()
+
+    /**
+     * Get the status of a [device] in this study deployment.
+     */
+    fun getDeviceStatus( device: AnyDeviceDescriptor ): DeviceDeploymentStatus =
+        devicesStatus.firstOrNull { it.device == device }
+            ?: throw IllegalArgumentException( "The given device was not found in this study deployment." )
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
@@ -19,10 +19,10 @@ data class StudyDeploymentStatus(
 )
 {
     /**
-     * Returns all [AnyDeviceDescriptor]'s in [devicesStatus] which require registration.
+     * Returns all [AnyDeviceDescriptor]'s in [devicesStatus] which still require registration.
      */
     fun getRemainingDevicesToRegister(): Set<AnyDeviceDescriptor> =
-        devicesStatus.filter { it.requiresRegistration && it is DeviceDeploymentStatus.Unregistered }.map { it.device }.toSet()
+        devicesStatus.filterIsInstance<DeviceDeploymentStatus.Unregistered>().map { it.device }.toSet()
 
     /**
      * Returns all [AnyMasterDeviceDescriptor] which are ready for deployment and are not deployed with the correct deployment yet.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
@@ -20,7 +20,17 @@ sealed class StudyDeploymentStatus
 
 
     /**
-     * Study deployment status for as long as there are remaining master devices to deploy.
+     * Initial study deployment status, indicating the invited participants have not yet acted on the invitation.
+     */
+    @Serializable
+    data class Invited(
+        override val studyDeploymentId: UUID,
+        override val devicesStatus: List<DeviceDeploymentStatus>
+    ) : StudyDeploymentStatus()
+
+    /**
+     * Study deployment status once participants have started registering devices,
+     * but remaining master devices still need to be deployed.
      */
     @Serializable
     data class DeployingDevices(

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -15,6 +15,9 @@ import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistrationSerializer
 import kotlinx.serialization.Serializable
 
+private typealias Service = DeploymentService
+private typealias Invoker<T> = ServiceInvoker<DeploymentService, T>
+
 
 /**
  * Serializable application service requests to [DeploymentService] which can be executed on demand.
@@ -25,12 +28,12 @@ sealed class DeploymentServiceRequest
     @Serializable
     data class CreateStudyDeployment( val protocol: StudyProtocolSnapshot ) :
         DeploymentServiceRequest(),
-        ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::createStudyDeployment, protocol )
+        Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::createStudyDeployment, protocol )
 
     @Serializable
     data class GetStudyDeploymentStatus( val studyDeploymentId: UUID ) :
         DeploymentServiceRequest(),
-        ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::getStudyDeploymentStatus, studyDeploymentId )
+        Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::getStudyDeploymentStatus, studyDeploymentId )
 
     @Serializable
     data class RegisterDevice(
@@ -39,30 +42,35 @@ sealed class DeploymentServiceRequest
         @Serializable( DeviceRegistrationSerializer::class )
         val registration: DeviceRegistration
     ) : DeploymentServiceRequest(),
-        ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::registerDevice, studyDeploymentId, deviceRoleName, registration )
+        Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::registerDevice, studyDeploymentId, deviceRoleName, registration )
 
     @Serializable
     data class UnregisterDevice( val studyDeploymentId: UUID, val deviceRoleName: String ) :
         DeploymentServiceRequest(),
-        ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::unregisterDevice, studyDeploymentId, deviceRoleName )
+        Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::unregisterDevice, studyDeploymentId, deviceRoleName )
 
     @Serializable
     data class GetDeviceDeploymentFor( val studyDeploymentId: UUID, val masterDeviceRoleName: String ) :
         DeploymentServiceRequest(),
-        ServiceInvoker<DeploymentService, MasterDeviceDeployment> by createServiceInvoker( DeploymentService::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName )
+        Invoker<MasterDeviceDeployment> by createServiceInvoker( Service::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName )
 
     @Serializable
     data class DeploymentSuccessful( val studyDeploymentId: UUID, val masterDeviceRoleName: String, val deploymentChecksum: Int ) :
         DeploymentServiceRequest(),
-        ServiceInvoker<DeploymentService, StudyDeploymentStatus> by createServiceInvoker( DeploymentService::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deploymentChecksum )
+        Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deploymentChecksum )
+
+    @Serializable
+    data class Stop( val studyDeploymentId: UUID ) :
+        DeploymentServiceRequest(),
+        Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::stop, studyDeploymentId )
 
     @Serializable
     data class AddParticipation( val studyDeploymentId: UUID, val deviceRoleNames: Set<String>, val identity: AccountIdentity, val invitation: StudyInvitation ) :
         DeploymentServiceRequest(),
-        ServiceInvoker<DeploymentService, Participation> by createServiceInvoker( DeploymentService::addParticipation, studyDeploymentId, deviceRoleNames, identity, invitation )
+        Invoker<Participation> by createServiceInvoker( Service::addParticipation, studyDeploymentId, deviceRoleNames, identity, invitation )
 
     @Serializable
     data class GetParticipationInvitations( val accountId: UUID ) :
         DeploymentServiceRequest(),
-        ServiceInvoker<DeploymentService, Set<ParticipationInvitation>> by createServiceInvoker( DeploymentService::getParticipationInvitations, accountId )
+        Invoker<Set<ParticipationInvitation>> by createServiceInvoker( Service::getParticipationInvitations, accountId )
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -36,9 +36,9 @@ sealed class DeploymentServiceRequest
         Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::getStudyDeploymentStatus, studyDeploymentId )
 
     @Serializable
-    data class GetStudyDeploymentStatuses( val studyDeploymentIds: Set<UUID> ) :
+    data class GetStudyDeploymentStatusList( val studyDeploymentIds: Set<UUID> ) :
         DeploymentServiceRequest(),
-        Invoker<List<StudyDeploymentStatus>> by createServiceInvoker( Service::getStudyDeploymentStatuses, studyDeploymentIds )
+        Invoker<List<StudyDeploymentStatus>> by createServiceInvoker( Service::getStudyDeploymentStatusList, studyDeploymentIds )
 
     @Serializable
     data class RegisterDevice(

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -36,6 +36,11 @@ sealed class DeploymentServiceRequest
         Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::getStudyDeploymentStatus, studyDeploymentId )
 
     @Serializable
+    data class GetStudyDeploymentStatuses( val studyDeploymentIds: Set<UUID> ) :
+        DeploymentServiceRequest(),
+        Invoker<List<StudyDeploymentStatus>> by createServiceInvoker( Service::getStudyDeploymentStatuses, studyDeploymentIds )
+
+    @Serializable
     data class RegisterDevice(
         val studyDeploymentId: UUID,
         val deviceRoleName: String,

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
@@ -29,14 +29,6 @@ class InMemoryDeploymentRepository : DeploymentRepository
     }
 
     /**
-     * Return the [StudyDeployment] with the specified [id], or null when no study deployment is found.
-     *
-     * @param id The id of the [StudyDeployment] to search for.
-     */
-    override fun getStudyDeploymentBy( id: UUID ): StudyDeployment? =
-        studyDeployments[ id ]?.let { StudyDeployment.fromSnapshot( it ) }
-
-    /**
      * Return all [StudyDeployment]s matching any of the specified [ids].
      * Ids that are not found are ignored.
      */

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.deployment.infrastructure
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.DeploymentRepository
 import dk.cachet.carp.deployment.domain.StudyDeployment
+import dk.cachet.carp.deployment.domain.StudyDeploymentSnapshot
 import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 
 
@@ -11,7 +12,7 @@ import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
  */
 class InMemoryDeploymentRepository : DeploymentRepository
 {
-    private val studyDeployments: MutableMap<UUID, StudyDeployment> = mutableMapOf()
+    private val studyDeployments: MutableMap<UUID, StudyDeploymentSnapshot> = mutableMapOf()
     private val participationInvitations: MutableMap<UUID, MutableSet<ParticipationInvitation>> = mutableMapOf()
 
 
@@ -24,7 +25,7 @@ class InMemoryDeploymentRepository : DeploymentRepository
     {
         require( !studyDeployments.contains( studyDeployment.id ) ) { "The repository already contains a study deployment with ID '${studyDeployment.id}'." }
 
-        studyDeployments[ studyDeployment.id ] = studyDeployment
+        studyDeployments[ studyDeployment.id ] = studyDeployment.getSnapshot()
     }
 
     /**
@@ -32,7 +33,8 @@ class InMemoryDeploymentRepository : DeploymentRepository
      *
      * @param id The id of the [StudyDeployment] to search for.
      */
-    override fun getStudyDeploymentBy( id: UUID ): StudyDeployment? = studyDeployments[ id ]
+    override fun getStudyDeploymentBy( id: UUID ): StudyDeployment? =
+        studyDeployments[ id ]?.let { StudyDeployment.fromSnapshot( it ) }
 
     /**
      * Update a [studyDeployment] which is already stored in this repository.
@@ -44,7 +46,7 @@ class InMemoryDeploymentRepository : DeploymentRepository
     {
         require( studyDeployments.contains( studyDeployment.id ) ) { "The repository does not contain an existing study deployment with ID '${studyDeployment.id}'." }
 
-        studyDeployments[ studyDeployment.id ] = studyDeployment
+        studyDeployments[ studyDeployment.id ] = studyDeployment.getSnapshot()
     }
 
     /**

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
@@ -37,6 +37,16 @@ class InMemoryDeploymentRepository : DeploymentRepository
         studyDeployments[ id ]?.let { StudyDeployment.fromSnapshot( it ) }
 
     /**
+     * Return all [StudyDeployment]s matching any of the specified [ids].
+     * Ids that are not found are ignored.
+     */
+    override fun getStudyDeploymentsBy( ids: Set<UUID> ): List<StudyDeployment> =
+        studyDeployments
+            .filterKeys { it in ids }
+            .map { StudyDeployment.fromSnapshot( it.value ) }
+            .toList()
+
+    /**
      * Update a [studyDeployment] which is already stored in this repository.
      *
      * @param studyDeployment The updated version of the study deployment to store.

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -12,6 +12,8 @@ import dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
 import dk.cachet.carp.test.Mock
 
+private typealias Service = DeploymentService
+
 
 class DeploymentServiceMock(
     private val createStudyDeploymentResult: StudyDeploymentStatus = emptyStatus,
@@ -20,8 +22,9 @@ class DeploymentServiceMock(
     private val unregisterDeviceResult: StudyDeploymentStatus = emptyStatus,
     private val getDeviceDeploymentForResult: MasterDeviceDeployment = emptyMasterDeviceDeployment,
     private val deploymentSuccessfulResult: StudyDeploymentStatus = emptyStatus,
+    private val stopResult: StudyDeploymentStatus = emptyStatus,
     private val getParticipationInvitationResult: Set<ParticipationInvitation> = setOf()
-) : Mock<DeploymentService>(), DeploymentService
+) : Mock<Service>(), Service
 {
     companion object
     {
@@ -34,51 +37,39 @@ class DeploymentServiceMock(
     }
 
 
-    override suspend fun createStudyDeployment( protocol: StudyProtocolSnapshot ): StudyDeploymentStatus
-    {
-        trackSuspendCall( DeploymentService::createStudyDeployment, protocol )
-        return createStudyDeploymentResult
-    }
+    override suspend fun createStudyDeployment( protocol: StudyProtocolSnapshot ) =
+        createStudyDeploymentResult
+        .also { trackSuspendCall( Service::createStudyDeployment, protocol ) }
 
-    override suspend fun getStudyDeploymentStatus( studyDeploymentId: UUID ): StudyDeploymentStatus
-    {
-        trackSuspendCall( DeploymentService::getStudyDeploymentStatus, studyDeploymentId )
-        return getStudyDeploymentStatusResult
-    }
+    override suspend fun getStudyDeploymentStatus( studyDeploymentId: UUID ) =
+        getStudyDeploymentStatusResult
+        .also { trackSuspendCall( Service::getStudyDeploymentStatus, studyDeploymentId ) }
 
-    override suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
-    {
-        trackSuspendCall( DeploymentService::registerDevice, studyDeploymentId, deviceRoleName, registration )
-        return registerDeviceResult
-    }
+    override suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ) =
+        registerDeviceResult
+        .also { trackSuspendCall( Service::registerDevice, studyDeploymentId, deviceRoleName, registration ) }
 
-    override suspend fun unregisterDevice( studyDeploymentId: UUID, deviceRoleName: String ): StudyDeploymentStatus
-    {
-        trackSuspendCall( DeploymentService::unregisterDevice, studyDeploymentId, deviceRoleName )
-        return unregisterDeviceResult
-    }
+    override suspend fun unregisterDevice( studyDeploymentId: UUID, deviceRoleName: String ) =
+        unregisterDeviceResult
+        .also { trackSuspendCall( Service::unregisterDevice, studyDeploymentId, deviceRoleName ) }
 
-    override suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
-    {
-        trackSuspendCall( DeploymentService::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName )
-        return getDeviceDeploymentForResult
-    }
+    override suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ) =
+        getDeviceDeploymentForResult
+        .also { trackSuspendCall( Service::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName ) }
 
-    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ): StudyDeploymentStatus
-    {
-        trackSuspendCall( DeploymentService::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deploymentChecksum )
-        return deploymentSuccessfulResult
-    }
+    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ) =
+        deploymentSuccessfulResult
+        .also { trackSuspendCall( Service::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deploymentChecksum ) }
 
-    override suspend fun addParticipation( studyDeploymentId: UUID, deviceRoleNames: Set<String>, identity: AccountIdentity, invitation: StudyInvitation ): Participation
-    {
-        trackSuspendCall( DeploymentService::addParticipation, studyDeploymentId, deviceRoleNames, identity, invitation )
-        return Participation( studyDeploymentId )
-    }
+    override suspend fun stop( studyDeploymentId: UUID ) =
+        stopResult
+        .also { trackSuspendCall( Service::stop, studyDeploymentId ) }
 
-    override suspend fun getParticipationInvitations( accountId: UUID ): Set<ParticipationInvitation>
-    {
-        trackSuspendCall( DeploymentService::getParticipationInvitations, accountId )
-        return getParticipationInvitationResult
-    }
+    override suspend fun addParticipation( studyDeploymentId: UUID, deviceRoleNames: Set<String>, identity: AccountIdentity, invitation: StudyInvitation ) =
+        Participation( studyDeploymentId )
+        .also { trackSuspendCall( Service::addParticipation, studyDeploymentId, deviceRoleNames, identity, invitation ) }
+
+    override suspend fun getParticipationInvitations( accountId: UUID ) =
+        getParticipationInvitationResult
+        .also { trackSuspendCall( Service::getParticipationInvitations, accountId ) }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -18,12 +18,13 @@ private typealias Service = DeploymentService
 class DeploymentServiceMock(
     private val createStudyDeploymentResult: StudyDeploymentStatus = emptyStatus,
     private val getStudyDeploymentStatusResult: StudyDeploymentStatus = emptyStatus,
+    private val getStudyDeploymentStatusesResult: List<StudyDeploymentStatus> = emptyList(),
     private val registerDeviceResult: StudyDeploymentStatus = emptyStatus,
     private val unregisterDeviceResult: StudyDeploymentStatus = emptyStatus,
     private val getDeviceDeploymentForResult: MasterDeviceDeployment = emptyMasterDeviceDeployment,
     private val deploymentSuccessfulResult: StudyDeploymentStatus = emptyStatus,
     private val stopResult: StudyDeploymentStatus = emptyStatus,
-    private val getParticipationInvitationResult: Set<ParticipationInvitation> = setOf()
+    private val getParticipationInvitationResult: Set<ParticipationInvitation> = emptySet()
 ) : Mock<Service>(), Service
 {
     companion object
@@ -44,6 +45,10 @@ class DeploymentServiceMock(
     override suspend fun getStudyDeploymentStatus( studyDeploymentId: UUID ) =
         getStudyDeploymentStatusResult
         .also { trackSuspendCall( Service::getStudyDeploymentStatus, studyDeploymentId ) }
+
+    override suspend fun getStudyDeploymentStatuses( studyDeploymentIds: Set<UUID> ) =
+        getStudyDeploymentStatusesResult
+        .also { trackSuspendCall( Service::getStudyDeploymentStatuses, studyDeploymentIds ) }
 
     override suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ) =
         registerDeviceResult

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -25,7 +25,7 @@ class DeploymentServiceMock(
 {
     companion object
     {
-        private val emptyStatus: StudyDeploymentStatus = StudyDeploymentStatus(
+        private val emptyStatus: StudyDeploymentStatus = StudyDeploymentStatus.DeployingDevices(
             UUID( "00000000-0000-0000-0000-000000000000"),
             listOf() )
         private val emptyMasterDeviceDeployment: MasterDeviceDeployment = MasterDeviceDeployment(

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -18,7 +18,7 @@ private typealias Service = DeploymentService
 class DeploymentServiceMock(
     private val createStudyDeploymentResult: StudyDeploymentStatus = emptyStatus,
     private val getStudyDeploymentStatusResult: StudyDeploymentStatus = emptyStatus,
-    private val getStudyDeploymentStatusesResult: List<StudyDeploymentStatus> = emptyList(),
+    private val getStudyDeploymentStatusListResult: List<StudyDeploymentStatus> = emptyList(),
     private val registerDeviceResult: StudyDeploymentStatus = emptyStatus,
     private val unregisterDeviceResult: StudyDeploymentStatus = emptyStatus,
     private val getDeviceDeploymentForResult: MasterDeviceDeployment = emptyMasterDeviceDeployment,
@@ -46,9 +46,9 @@ class DeploymentServiceMock(
         getStudyDeploymentStatusResult
         .also { trackSuspendCall( Service::getStudyDeploymentStatus, studyDeploymentId ) }
 
-    override suspend fun getStudyDeploymentStatuses( studyDeploymentIds: Set<UUID> ) =
-        getStudyDeploymentStatusesResult
-        .also { trackSuspendCall( Service::getStudyDeploymentStatuses, studyDeploymentIds ) }
+    override suspend fun getStudyDeploymentStatusList( studyDeploymentIds: Set<UUID> ) =
+        getStudyDeploymentStatusListResult
+        .also { trackSuspendCall( Service::getStudyDeploymentStatusList, studyDeploymentIds ) }
 
     override suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ) =
         registerDeviceResult

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
@@ -28,11 +28,11 @@ abstract class DeploymentServiceTest
         val deviceRolename = "Test device"
         val studyDeploymentId = addTestDeployment( deploymentService, deviceRolename )
         var status = deploymentService.getStudyDeploymentStatus( studyDeploymentId )
-        val device = status.getRemainingDevicesToRegister().first()
+        val device = status.getRemainingDevicesToRegister().first { it.roleName == deviceRolename }
         deploymentService.registerDevice( studyDeploymentId, deviceRolename, device.createRegistration { } )
 
         status = deploymentService.unregisterDevice( studyDeploymentId, deviceRolename )
-        assertEquals( device, status.getRemainingDevicesToRegister().single() )
+        assertTrue( device in status.getRemainingDevicesToRegister() )
     }
 
     @Test
@@ -138,7 +138,7 @@ abstract class DeploymentServiceTest
 
     /**
      * Create a deployment to be used in tests in the given [deploymentService]
-     * with a protocol containing a single master device with the specified [deviceRoleName].
+     * with a protocol containing a single master device with the specified [deviceRoleName] and a connected device.
      */
     private suspend fun addTestDeployment( deploymentService: DeploymentService, deviceRoleName: String ): UUID
     {

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
@@ -43,23 +43,23 @@ abstract class DeploymentServiceTest
     }
 
     @Test
-    fun getStudyDeploymentStatuses_succeeds() = runBlockingTest {
+    fun getStudyDeploymentStatusList_succeeds() = runBlockingTest {
         val ( deploymentService, _ ) = createService()
         val snapshot = createSingleMasterWithConnectedDeviceProtocol().getSnapshot()
         val status1 = deploymentService.createStudyDeployment( snapshot )
         val status2 = deploymentService.createStudyDeployment( snapshot )
 
         // Actual testing of the status responses should already be covered adequately in StudyDeployment tests.
-        deploymentService.getStudyDeploymentStatuses( setOf( status1.studyDeploymentId, status2.studyDeploymentId ) )
+        deploymentService.getStudyDeploymentStatusList( setOf( status1.studyDeploymentId, status2.studyDeploymentId ) )
     }
 
     @Test
-    fun getStudyDeploymentStatuses_fails_when_containing_an_unknown_studyDeploymentId() = runBlockingTest {
+    fun getStudyDeploymentStatusList_fails_when_containing_an_unknown_studyDeploymentId() = runBlockingTest {
         val ( deploymentService, _ ) = createService()
         val studyDeploymentId = addTestDeployment( deploymentService, "Test device" )
 
         val deploymentIds = setOf( studyDeploymentId, unknownId )
-        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatuses( deploymentIds ) }
+        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatusList( deploymentIds ) }
     }
 
     @Test

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.deployment.application
 
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
+import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.deployment.domain.createSingleMasterWithConnectedDeviceProtocol
 import dk.cachet.carp.deployment.domain.users.AccountService
 import dk.cachet.carp.deployment.domain.users.Participation
@@ -33,6 +34,46 @@ abstract class DeploymentServiceTest
 
         status = deploymentService.unregisterDevice( studyDeploymentId, deviceRolename )
         assertTrue( device in status.getRemainingDevicesToRegister() )
+    }
+
+    @Test
+    fun stop_succeeds() = runBlockingTest {
+        val ( deploymentService, _ ) = createService()
+        val studyDeploymentId = addTestDeployment( deploymentService, "Test device" )
+
+        val status = deploymentService.stop( studyDeploymentId )
+        assertTrue( status is StudyDeploymentStatus.Stopped )
+    }
+
+    @Test
+    fun stop_fails_for_unknown_studyDeploymentId() = runBlockingTest {
+        val ( deploymentService, _ ) = createService()
+
+        val unknownId = UUID.randomUUID()
+        assertFailsWith<IllegalArgumentException> { deploymentService.stop( unknownId ) }
+    }
+
+    @Test
+    fun modifications_after_stop_not_allowed() = runBlockingTest {
+        val ( deploymentService, _ ) = createService()
+        val studyDeploymentId = addTestDeployment( deploymentService, "Master", "Connected" )
+        val status = deploymentService.getStudyDeploymentStatus( studyDeploymentId )
+        val master = status.getRemainingDevicesToRegister().first { it.roleName == "Master" }
+        val connected = status.getRemainingDevicesToRegister().first { it.roleName == "Connected" }
+        deploymentService.registerDevice( studyDeploymentId, master.roleName, master.createRegistration() )
+        deploymentService.stop( studyDeploymentId )
+
+        assertFailsWith<IllegalStateException>
+            { deploymentService.registerDevice( studyDeploymentId, connected.roleName, connected.createRegistration() ) }
+        assertFailsWith<IllegalStateException>
+            { deploymentService.unregisterDevice( studyDeploymentId, master.roleName ) }
+        val deviceDeployment = deploymentService.getDeviceDeploymentFor( studyDeploymentId, master.roleName )
+        assertFailsWith<IllegalStateException>
+            { deploymentService.deploymentSuccessful( studyDeploymentId, master.roleName, deviceDeployment.getChecksum() ) }
+        val accountId = AccountIdentity.fromUsername( "Test" )
+        val invitation = StudyInvitation.empty()
+        assertFailsWith<IllegalStateException>
+            { deploymentService.addParticipation( studyDeploymentId, setOf( "Master" ), accountId, invitation ) }
     }
 
     @Test
@@ -137,12 +178,17 @@ abstract class DeploymentServiceTest
 
 
     /**
-     * Create a deployment to be used in tests in the given [deploymentService]
-     * with a protocol containing a single master device with the specified [deviceRoleName] and a connected device.
+     * Create a deployment to be used in tests in the given [deploymentService] with a protocol
+     * containing a single master device with the specified [masterDeviceRoleName]
+     * and a connected device, of which the [connectedDeviceRoleName] can optionally be defined.
      */
-    private suspend fun addTestDeployment( deploymentService: DeploymentService, deviceRoleName: String ): UUID
+    private suspend fun addTestDeployment(
+        deploymentService: DeploymentService,
+        masterDeviceRoleName: String,
+        connectedDeviceRoleName: String = "Connected"
+    ): UUID
     {
-        val protocol = createSingleMasterWithConnectedDeviceProtocol( deviceRoleName )
+        val protocol = createSingleMasterWithConnectedDeviceProtocol( masterDeviceRoleName, connectedDeviceRoleName )
         val snapshot = protocol.getSnapshot()
         val status = deploymentService.createStudyDeployment( snapshot )
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -108,6 +108,8 @@ fun createComplexDeployment(): StudyDeployment
     val deviceDeployment = deployment.getDeviceDeploymentFor( master )
     deployment.deviceDeployed( master, deviceDeployment.getChecksum() )
 
+    deployment.stop()
+
     // Remove events since tests building on top of this are not interested in how this object was constructed.
     deployment.consumeEvents()
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
@@ -223,6 +223,7 @@ class StudyDeploymentTest
         assertEquals( 0, deployment.deployedDevices.count() )
         assertEquals( setOf( master1 ), deployment.invalidatedDeployedDevices )
         val studyStatus = deployment.getStatus()
+        assertTrue( studyStatus is StudyDeploymentStatus.DeployingDevices )
         val master1Status = studyStatus.getDeviceStatus( master1 )
         assertTrue( master1Status is DeviceDeploymentStatus.NeedsRedeployment )
         assertEquals( StudyDeployment.Event.DeploymentInvalidated( master1 ), deployment.consumeEvents().last() )
@@ -292,6 +293,7 @@ class StudyDeploymentTest
         assertEquals( 2, status.devicesStatus.count() )
         assertTrue { status.devicesStatus.any { it.device == master } }
         assertTrue { status.devicesStatus.any { it.device == connected } }
+        assertTrue( status is StudyDeploymentStatus.DeployingDevices )
         val toRegister = status.getRemainingDevicesToRegister()
         val expectedToRegister = setOf( master, connected )
         assertEquals( expectedToRegister.count(), toRegister.count() )
@@ -301,6 +303,7 @@ class StudyDeploymentTest
         // After registering master device, master device is ready for deployment.
         deployment.registerDevice( master, DefaultDeviceRegistration( "0" ) )
         val readyStatus = deployment.getStatus()
+        assertTrue( readyStatus is StudyDeploymentStatus.DeployingDevices )
         assertEquals( 1, readyStatus.getRemainingDevicesToRegister().count() ) // Connected device is still unregistered.
         assertEquals( setOf( master ), readyStatus.getRemainingDevicesReadyToDeploy() )
 
@@ -308,6 +311,7 @@ class StudyDeploymentTest
         val deviceDeployment = deployment.getDeviceDeploymentFor( master )
         deployment.deviceDeployed( master, deviceDeployment.getChecksum() )
         val studyStatus = deployment.getStatus()
+        assertTrue( studyStatus is StudyDeploymentStatus.DeployingDevices )
         val deviceStatus = studyStatus.getDeviceStatus( master )
         assertTrue( deviceStatus is DeviceDeploymentStatus.Deployed )
     }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
@@ -293,7 +293,7 @@ class StudyDeploymentTest
         assertEquals( 2, status.devicesStatus.count() )
         assertTrue { status.devicesStatus.any { it.device == master } }
         assertTrue { status.devicesStatus.any { it.device == connected } }
-        assertTrue( status is StudyDeploymentStatus.DeployingDevices )
+        assertTrue( status is StudyDeploymentStatus.Invited )
         val toRegister = status.getRemainingDevicesToRegister()
         val expectedToRegister = setOf( master, connected )
         assertEquals( expectedToRegister.count(), toRegister.count() )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
@@ -274,7 +274,7 @@ class StudyDeploymentTest
         assertEquals(
             deployment.invalidatedDeployedDevices.count(),
             deployment.invalidatedDeployedDevices.intersect( fromSnapshot.invalidatedDeployedDevices ).count() )
-        assertEquals( deployment.hasStopped, fromSnapshot.hasStopped )
+        assertEquals( deployment.isStopped, fromSnapshot.isStopped )
         assertEquals(
             deployment.participations.count(),
             deployment.participations.intersect( fromSnapshot.participations ).count() )
@@ -488,7 +488,7 @@ class StudyDeploymentTest
         assertTrue( deployment.getStatus() is StudyDeploymentStatus.DeploymentReady )
 
         deployment.stop()
-        assertTrue( deployment.hasStopped )
+        assertTrue( deployment.isStopped )
         assertTrue( deployment.getStatus() is StudyDeploymentStatus.Stopped )
         assertEquals( 1, deployment.consumeEvents().filterIsInstance<StudyDeployment.Event.Stopped>().count() )
     }
@@ -505,7 +505,7 @@ class StudyDeploymentTest
         assertTrue( deployment.getStatus() is StudyDeploymentStatus.DeployingDevices )
 
         deployment.stop()
-        assertTrue( deployment.hasStopped )
+        assertTrue( deployment.isStopped )
         assertTrue( deployment.getStatus() is StudyDeploymentStatus.Stopped )
         assertEquals( 1, deployment.consumeEvents().filterIsInstance<StudyDeployment.Event.Stopped>().count() )
     }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
@@ -200,7 +200,7 @@ class StudyDeploymentTest
         assertEquals( 1, deployment.deviceRegistrationHistory[ device ]?.count() )
         assertEquals( registration, deployment.deviceRegistrationHistory[ device ]?.last() )
         assertEquals( StudyDeployment.Event.DeviceUnregistered( device ), deployment.consumeEvents().last() )
-        assertTrue( deployment.getStatus().devicesStatus.single() is DeviceDeploymentStatus.Unregistered )
+        assertTrue( deployment.getStatus().getDeviceStatus( device ) is DeviceDeploymentStatus.Unregistered )
     }
 
     @Test
@@ -223,7 +223,7 @@ class StudyDeploymentTest
         assertEquals( 0, deployment.deployedDevices.count() )
         assertEquals( setOf( master1 ), deployment.invalidatedDeployedDevices )
         val studyStatus = deployment.getStatus()
-        val master1Status = studyStatus.devicesStatus.first { it.device == master1 }
+        val master1Status = studyStatus.getDeviceStatus( master1 )
         assertTrue( master1Status is DeviceDeploymentStatus.NeedsRedeployment )
         assertEquals( StudyDeployment.Event.DeploymentInvalidated( master1 ), deployment.consumeEvents().last() )
     }
@@ -308,7 +308,7 @@ class StudyDeploymentTest
         val deviceDeployment = deployment.getDeviceDeploymentFor( master )
         deployment.deviceDeployed( master, deviceDeployment.getChecksum() )
         val studyStatus = deployment.getStatus()
-        val deviceStatus = studyStatus.devicesStatus.first { it.device == master }
+        val deviceStatus = studyStatus.getDeviceStatus( master )
         assertTrue( deviceStatus is DeviceDeploymentStatus.Deployed )
     }
 
@@ -323,7 +323,7 @@ class StudyDeploymentTest
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
         val status: StudyDeploymentStatus = deployment.getStatus()
-        val chainedStatus = status.devicesStatus.first { it.device == chained }
+        val chainedStatus = status.getDeviceStatus( chained )
         assertFalse { chainedStatus.requiresDeployment }
     }
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -22,7 +22,7 @@ class DeploymentServiceRequestsTest
         val requests: List<DeploymentServiceRequest> = listOf(
             DeploymentServiceRequest.CreateStudyDeployment( createEmptyProtocol().getSnapshot() ),
             DeploymentServiceRequest.GetStudyDeploymentStatus( UUID.randomUUID() ),
-            DeploymentServiceRequest.GetStudyDeploymentStatuses( setOf( UUID.randomUUID() ) ),
+            DeploymentServiceRequest.GetStudyDeploymentStatusList( setOf( UUID.randomUUID() ) ),
             DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration( "Device ID" ) ),
             DeploymentServiceRequest.UnregisterDevice( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.GetDeviceDeploymentFor( UUID.randomUUID(), "Test role" ),

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -26,6 +26,7 @@ class DeploymentServiceRequestsTest
             DeploymentServiceRequest.UnregisterDevice( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.GetDeviceDeploymentFor( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.DeploymentSuccessful( UUID.randomUUID(), "Test role", 0 ),
+            DeploymentServiceRequest.Stop( UUID.randomUUID() ),
             DeploymentServiceRequest.AddParticipation( UUID.randomUUID(), setOf( "Phone" ), UsernameAccountIdentity( "Test" ), StudyInvitation.empty() ),
             DeploymentServiceRequest.GetParticipationInvitations( UUID.randomUUID() )
         )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -22,6 +22,7 @@ class DeploymentServiceRequestsTest
         val requests: List<DeploymentServiceRequest> = listOf(
             DeploymentServiceRequest.CreateStudyDeployment( createEmptyProtocol().getSnapshot() ),
             DeploymentServiceRequest.GetStudyDeploymentStatus( UUID.randomUUID() ),
+            DeploymentServiceRequest.GetStudyDeploymentStatuses( setOf( UUID.randomUUID() ) ),
             DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration( "Device ID" ) ),
             DeploymentServiceRequest.UnregisterDevice( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.GetDeviceDeploymentFor( UUID.randomUUID(), "Test role" ),

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -129,4 +129,13 @@ interface StudyService
      * @throws IllegalArgumentException when a study with [studyId] does not exist.
      */
     suspend fun getParticipantGroupStatuses( studyId: UUID ): List<ParticipantGroupStatus>
+
+    /**
+     * Stop the study deployment in the study with the given [studyId]
+     * of the participant group with the specified [groupId] (equivalent to the studyDeploymentId).
+     * No further changes to this deployment will be allowed and no more data will be collected.
+     *
+     * @throws IllegalArgumentException when a study with [studyId] or participant group with [groupId] does not exist.
+     */
+    suspend fun stopParticipantGroup( studyId: UUID, groupId: UUID ): ParticipantGroupStatus
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -128,7 +128,7 @@ interface StudyService
      *
      * @throws IllegalArgumentException when a study with [studyId] does not exist.
      */
-    suspend fun getParticipantGroupStatuses( studyId: UUID ): List<ParticipantGroupStatus>
+    suspend fun getParticipantGroupStatusList( studyId: UUID ): List<ParticipantGroupStatus>
 
     /**
      * Stop the study deployment in the study with the given [studyId]

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -122,4 +122,11 @@ interface StudyService
      * @throws IllegalStateException when the study is not yet ready for deployment.
      */
     suspend fun deployParticipantGroup( studyId: UUID, group: Set<AssignParticipantDevices> ): ParticipantGroupStatus
+
+    /**
+     * Get the status of all deployed participant groups in the study with the specified [studyId].
+     *
+     * @throws IllegalArgumentException when a study with [studyId] does not exist.
+     */
+    suspend fun getParticipantGroupStatuses( studyId: UUID ): List<ParticipantGroupStatus>
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
+import dk.cachet.carp.studies.domain.ParticipantGroupStatus
 import dk.cachet.carp.studies.domain.StudyDetails
 import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudyStatus
@@ -120,5 +121,5 @@ interface StudyService
      *  - not all devices part of the study have been assigned a participant
      * @throws IllegalStateException when the study is not yet ready for deployment.
      */
-    suspend fun deployParticipantGroup( studyId: UUID, group: Set<AssignParticipantDevices> ): StudyStatus
+    suspend fun deployParticipantGroup( studyId: UUID, group: Set<AssignParticipantDevices> ): ParticipantGroupStatus
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
@@ -70,7 +70,7 @@ class StudyServiceHost(
     override suspend fun setInternalDescription( studyId: UUID, name: String, description: String ): StudyStatus
     {
         val study = repository.getById( studyId )
-        require( study != null )
+        requireNotNull( study )
 
         study.name = name
         study.description = description
@@ -87,7 +87,7 @@ class StudyServiceHost(
     override suspend fun getStudyDetails( studyId: UUID ): StudyDetails
     {
         val study: Study? = repository.getById( studyId )
-        require( study != null )
+        requireNotNull( study )
 
         return StudyDetails(
             study.id,
@@ -110,7 +110,7 @@ class StudyServiceHost(
     override suspend fun getStudyStatus( studyId: UUID ): StudyStatus
     {
         val study = repository.getById( studyId )
-        require( study != null )
+        requireNotNull( study )
 
         return study.getStatus()
     }
@@ -159,7 +159,7 @@ class StudyServiceHost(
     override suspend fun setInvitation( studyId: UUID, invitation: StudyInvitation ): StudyStatus
     {
         val study: Study? = repository.getById( studyId )
-        require( study != null )
+        requireNotNull( study )
 
         study.invitation = invitation
         repository.update( study )
@@ -178,7 +178,7 @@ class StudyServiceHost(
     override suspend fun setProtocol( studyId: UUID, protocol: StudyProtocolSnapshot ): StudyStatus
     {
         val study: Study? = repository.getById( studyId )
-        require( study != null )
+        requireNotNull( study )
 
         // Configure study to use the protocol.
         try { study.protocolSnapshot = protocol }
@@ -198,7 +198,7 @@ class StudyServiceHost(
     override suspend fun goLive( studyId: UUID ): StudyStatus
     {
         val study: Study? = repository.getById( studyId )
-        require( study != null )
+        requireNotNull( study )
 
         study.goLive()
         repository.update( study )
@@ -223,7 +223,7 @@ class StudyServiceHost(
 
         // Verify whether the study is ready for deployment.
         val study: Study? = repository.getById( studyId )
-        require( study != null ) { "Study with the specified studyId is not found." }
+        requireNotNull( study ) { "Study with the specified studyId is not found." }
         check( study.canDeployToParticipants ) { "Study is not yet ready to be deployed to participants." }
         val protocolSnapshot = study.protocolSnapshot!!
 
@@ -271,7 +271,7 @@ class StudyServiceHost(
     override suspend fun getParticipantGroupStatuses( studyId: UUID ): List<ParticipantGroupStatus>
     {
         val study: Study? = repository.getById( studyId )
-        require( study != null ) { "Study with the specified studyId is not found." }
+        requireNotNull( study ) { "Study with the specified studyId is not found." }
 
         // Get study deployment statuses.
         // TODO: Participations are more logically stored per `studyDeploymentId`, rather than having to filter like this.
@@ -297,7 +297,7 @@ class StudyServiceHost(
         // We don't really need to verify whether the study exists since groupId is equivalent to studyDeploymentId.
         // However, for future-proofing, if they were to differ, it is good to already enforce the dependence on studyId.
         val study: Study? = repository.getById( studyId )
-        require( study != null ) { "Study with the specified studyId is not found." }
+        requireNotNull( study ) { "Study with the specified studyId is not found." }
         val participations = study.participations.filter { it.participation.studyDeploymentId == groupId }
         require( participations.count() > 0 ) { "Study deployment with the specified groupId not found." }
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
@@ -268,7 +268,7 @@ class StudyServiceHost(
      *
      * @throws IllegalArgumentException when a study with [studyId] does not exist.
      */
-    override suspend fun getParticipantGroupStatuses( studyId: UUID ): List<ParticipantGroupStatus>
+    override suspend fun getParticipantGroupStatusList( studyId: UUID ): List<ParticipantGroupStatus>
     {
         val study: Study? = repository.getById( studyId )
         requireNotNull( study ) { "Study with the specified studyId is not found." }
@@ -276,7 +276,7 @@ class StudyServiceHost(
         // Get study deployment statuses.
         // TODO: Participations are more logically stored per `studyDeploymentId`, rather than having to filter like this.
         val studyDeploymentIds = study.participations.map { it.participation.studyDeploymentId }.toSet()
-        val studyDeploymentStatuses = deploymentService.getStudyDeploymentStatuses( studyDeploymentIds )
+        val studyDeploymentStatuses = deploymentService.getStudyDeploymentStatusList( studyDeploymentIds )
 
         // Map each study deployment status to a deanonymized participant group status.
         return studyDeploymentStatuses.map {

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/ParticipantGroupStatus.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/ParticipantGroupStatus.kt
@@ -1,0 +1,30 @@
+package dk.cachet.carp.studies.domain
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
+import dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+
+@Serializable
+data class ParticipantGroupStatus(
+    /**
+     * The deployment status associated with this participant group.
+     */
+    val studyDeploymentStatus: StudyDeploymentStatus,
+    /**
+     * The participants and assigned anonymized participation IDs that are part of this deployment.
+     * TODO: This redundantly stores `studyDeploymentId` inside of the Participation.
+     *       Rather than adding another class, e.g., `ParticipantGroupMember`,
+     *       I think we should simply remove the ID and store participations per `studyDeploymentId` in `Study`.
+     */
+    val participants: Set<DeanonymizedParticipation>
+)
+{
+    /**
+     * The ID of this participant group, which is equivalent to the ID of the associated study deployment.
+     */
+    @Transient
+    val id: UUID get() = studyDeploymentStatus.studyDeploymentId
+}

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/ParticipantGroupStatus.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/ParticipantGroupStatus.kt
@@ -1,12 +1,17 @@
 package dk.cachet.carp.studies.domain
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.deployment.domain.StudyDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
+import dk.cachet.carp.studies.domain.users.Participant
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 
+/**
+ * A group of one or more [Participant]s participating in a [StudyDeployment].
+ */
 @Serializable
 data class ParticipantGroupStatus(
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -193,6 +193,19 @@ class Study(
     }
 
     /**
+     * Get all [DeanonymizedParticipation]s for a specific [studyDeploymentId].
+     *
+     * @throws IllegalArgumentException when the given [studyDeploymentId] is not part of this study.
+     */
+    fun getParticipations( studyDeploymentId: UUID ): Set<DeanonymizedParticipation>
+    {
+        val participations = _participations.filter { it.participation.studyDeploymentId == studyDeploymentId }.toSet()
+        require( participations.isNotEmpty() ) { "The specified study deployment ID is not part of this study." }
+
+        return participations
+    }
+
+    /**
      * Get a serializable snapshot of the current state of this [Study].
      */
     override fun getSnapshot(): StudySnapshot = StudySnapshot.fromStudy( this )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -55,7 +55,10 @@ class Study(
             study.creationDate = snapshot.creationDate
             study.protocolSnapshot = snapshot.protocolSnapshot
             study.isLive = snapshot.isLive
-            study._participations.addAll( snapshot.participations )
+            for ( p in snapshot.participations )
+            {
+                study._participations[ p.key ] = p.value.toMutableSet()
+            }
 
             return study
         }
@@ -172,24 +175,28 @@ class Study(
     val canDeployToParticipants: Boolean get() = isLive
 
     /**
-     * The set of participants and the specific study deployments they participate in for this study.
+     * Per study deployment ID, the set of participants that participate in it.
+     * TODO: Maybe this should be kept private and be replaced with clearer helper functions (e.g., getStudyDeploymentIds).
      */
-    val participations: Set<DeanonymizedParticipation>
+    val participations: Map<UUID, Set<DeanonymizedParticipation>>
         get() = _participations
 
-    private val _participations: MutableSet<DeanonymizedParticipation> = mutableSetOf()
+    private val _participations: MutableMap<UUID, MutableSet<DeanonymizedParticipation>> = mutableMapOf()
 
     /**
      * Specify that a [Participation] has been created for a [Participant] in this study.
      *
      * @throws IllegalStateException when the study is not yet ready for deployment.
      */
-    fun addParticipation( participation: DeanonymizedParticipation )
+    fun addParticipation( studyDeploymentId: UUID, participation: DeanonymizedParticipation )
     {
         check( canDeployToParticipants ) { "The study is not yet ready for deployment." }
 
-        _participations.add( participation )
-        event( Event.ParticipationAdded( participation ) )
+        val participations = _participations.getOrPut( studyDeploymentId ) { mutableSetOf() }
+        if ( participations.add( participation ) )
+        {
+            event( Event.ParticipationAdded( participation ) )
+        }
     }
 
     /**
@@ -199,7 +206,7 @@ class Study(
      */
     fun getParticipations( studyDeploymentId: UUID ): Set<DeanonymizedParticipation>
     {
-        val participations = _participations.filter { it.participation.studyDeploymentId == studyDeploymentId }.toSet()
+        val participations: Set<DeanonymizedParticipation> = _participations.getOrElse( studyDeploymentId ) { emptySet() }
         require( participations.isNotEmpty() ) { "The specified study deployment ID is not part of this study." }
 
         return participations

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
@@ -19,7 +19,7 @@ data class StudySnapshot(
     val creationDate: DateTime,
     val protocolSnapshot: StudyProtocolSnapshot?,
     val isLive: Boolean,
-    val participations: Set<DeanonymizedParticipation>
+    val participations: Map<UUID, Set<DeanonymizedParticipation>>
 ) : Snapshot<Study>()
 {
     companion object
@@ -31,6 +31,12 @@ data class StudySnapshot(
          */
         fun fromStudy( study: Study ): StudySnapshot
         {
+            val clonedParticipations: MutableMap<UUID, Set<DeanonymizedParticipation>> = mutableMapOf()
+            for ( p in study.participations )
+            {
+                clonedParticipations[ p.key ] = p.value.toSet()
+            }
+
             return StudySnapshot(
                 studyId = study.id,
                 ownerId = study.owner.id,
@@ -40,7 +46,7 @@ data class StudySnapshot(
                 creationDate = study.creationDate,
                 protocolSnapshot = study.protocolSnapshot,
                 isLive = study.isLive,
-                participations = study.participations.toSet() )
+                participations = clonedParticipations )
         }
     }
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/DeanonymizedParticipation.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/DeanonymizedParticipation.kt
@@ -9,4 +9,4 @@ import kotlinx.serialization.Serializable
  * Links a [Participant] (and its associated meta-data) to an anonymized [Participation] in a study deployment.
  */
 @Serializable
-data class DeanonymizedParticipation( val participantId: UUID, val participation: Participation )
+data class DeanonymizedParticipation( val participantId: UUID, val participationId: UUID )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -7,12 +7,16 @@ import dk.cachet.carp.common.ddd.ServiceInvoker
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.studies.application.StudyService
+import dk.cachet.carp.studies.domain.ParticipantGroupStatus
 import dk.cachet.carp.studies.domain.StudyDetails
 import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudyStatus
 import dk.cachet.carp.studies.domain.users.AssignParticipantDevices
 import dk.cachet.carp.studies.domain.users.Participant
 import kotlinx.serialization.Serializable
+
+private typealias Service = StudyService
+private typealias Invoker<T> = ServiceInvoker<StudyService, T>
 
 
 /**
@@ -24,55 +28,55 @@ sealed class StudyServiceRequest
     @Serializable
     data class CreateStudy( val owner: StudyOwner, val name: String, val description: String = "", val invitation: StudyInvitation? = null ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, StudyStatus> by createServiceInvoker( StudyService::createStudy, owner, name, description, invitation )
+        Invoker<StudyStatus> by createServiceInvoker( Service::createStudy, owner, name, description, invitation )
 
     @Serializable
     data class SetInternalDescription( val studyId: UUID, val name: String, val description: String ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, StudyStatus> by createServiceInvoker( StudyService::setInternalDescription, studyId, name, description )
+        Invoker<StudyStatus> by createServiceInvoker( Service::setInternalDescription, studyId, name, description )
 
     @Serializable
     data class GetStudyDetails( val studyId: UUID ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, StudyDetails> by createServiceInvoker( StudyService::getStudyDetails, studyId )
+        Invoker<StudyDetails> by createServiceInvoker( Service::getStudyDetails, studyId )
 
     @Serializable
     data class GetStudyStatus( val studyId: UUID ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, StudyStatus> by createServiceInvoker( StudyService::getStudyStatus, studyId )
+        Invoker<StudyStatus> by createServiceInvoker( Service::getStudyStatus, studyId )
 
     @Serializable
     data class GetStudiesOverview( val owner: StudyOwner ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, List<StudyStatus>> by createServiceInvoker( StudyService::getStudiesOverview, owner )
+        Invoker<List<StudyStatus>> by createServiceInvoker( Service::getStudiesOverview, owner )
 
     @Serializable
     data class AddParticipant( val studyId: UUID, val email: EmailAddress ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, Participant> by createServiceInvoker( StudyService::addParticipant, studyId, email )
+        Invoker<Participant> by createServiceInvoker( Service::addParticipant, studyId, email )
 
     @Serializable
     data class GetParticipants( val studyId: UUID ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, List<Participant>> by createServiceInvoker( StudyService::getParticipants, studyId )
+        Invoker<List<Participant>> by createServiceInvoker( Service::getParticipants, studyId )
 
     @Serializable
     data class SetInvitation( val studyId: UUID, val invitation: StudyInvitation ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, StudyStatus> by createServiceInvoker( StudyService::setInvitation, studyId, invitation )
+        Invoker<StudyStatus> by createServiceInvoker( Service::setInvitation, studyId, invitation )
 
     @Serializable
     data class SetProtocol( val studyId: UUID, val protocol: StudyProtocolSnapshot ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, StudyStatus> by createServiceInvoker( StudyService::setProtocol, studyId, protocol )
+        Invoker<StudyStatus> by createServiceInvoker( Service::setProtocol, studyId, protocol )
 
     @Serializable
     data class GoLive( val studyId: UUID ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, StudyStatus> by createServiceInvoker( StudyService::goLive, studyId )
+        Invoker<StudyStatus> by createServiceInvoker( Service::goLive, studyId )
 
     @Serializable
     data class DeployParticipantGroup( val studyId: UUID, val group: Set<AssignParticipantDevices> ) :
         StudyServiceRequest(),
-        ServiceInvoker<StudyService, StudyStatus> by createServiceInvoker( StudyService::deployParticipantGroup, studyId, group )
+        Invoker<ParticipantGroupStatus> by createServiceInvoker( Service::deployParticipantGroup, studyId, group )
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -84,4 +84,9 @@ sealed class StudyServiceRequest
     data class GetParticipantGroupStatuses( val studyId: UUID ) :
         StudyServiceRequest(),
         Invoker<List<ParticipantGroupStatus>> by createServiceInvoker( Service::getParticipantGroupStatuses, studyId )
+
+    @Serializable
+    data class StopParticipantGroup( val studyId: UUID, val groupId: UUID ) :
+        StudyServiceRequest(),
+        Invoker<ParticipantGroupStatus> by createServiceInvoker( Service::stopParticipantGroup, studyId, groupId )
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -81,9 +81,9 @@ sealed class StudyServiceRequest
         Invoker<ParticipantGroupStatus> by createServiceInvoker( Service::deployParticipantGroup, studyId, group )
 
     @Serializable
-    data class GetParticipantGroupStatuses( val studyId: UUID ) :
+    data class GetParticipantGroupStatusList( val studyId: UUID ) :
         StudyServiceRequest(),
-        Invoker<List<ParticipantGroupStatus>> by createServiceInvoker( Service::getParticipantGroupStatuses, studyId )
+        Invoker<List<ParticipantGroupStatus>> by createServiceInvoker( Service::getParticipantGroupStatusList, studyId )
 
     @Serializable
     data class StopParticipantGroup( val studyId: UUID, val groupId: UUID ) :

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -79,4 +79,9 @@ sealed class StudyServiceRequest
     data class DeployParticipantGroup( val studyId: UUID, val group: Set<AssignParticipantDevices> ) :
         StudyServiceRequest(),
         Invoker<ParticipantGroupStatus> by createServiceInvoker( Service::deployParticipantGroup, studyId, group )
+
+    @Serializable
+    data class GetParticipantGroupStatuses( val studyId: UUID ) :
+        StudyServiceRequest(),
+        Invoker<List<ParticipantGroupStatus>> by createServiceInvoker( Service::getParticipantGroupStatuses, studyId )
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
@@ -34,7 +34,7 @@ class StudyServiceMock(
     private val setProtocolResult: StudyStatus = studyStatus,
     private val goLiveResult: StudyStatus = studyStatus,
     private val deployParticipantResult: ParticipantGroupStatus = groupStatus,
-    private val getParticipantGroupStatusesResult: List<ParticipantGroupStatus> = emptyList(),
+    private val getParticipantGroupStatusListResult: List<ParticipantGroupStatus> = emptyList(),
     private val stopParticipantGroupResult: ParticipantGroupStatus = groupStatus
 ) : Mock<Service>(), Service
 {
@@ -97,9 +97,9 @@ class StudyServiceMock(
         deployParticipantResult
         .also { trackSuspendCall( Service::deployParticipantGroup, studyId, group ) }
 
-    override suspend fun getParticipantGroupStatuses( studyId: UUID ) =
-        getParticipantGroupStatusesResult
-        .also { trackSuspendCall( Service::getParticipantGroupStatuses, studyId ) }
+    override suspend fun getParticipantGroupStatusList( studyId: UUID ) =
+        getParticipantGroupStatusListResult
+        .also { trackSuspendCall( Service::getParticipantGroupStatusList, studyId ) }
 
     override suspend fun stopParticipantGroup( studyId: UUID, groupId: UUID ) =
         stopParticipantGroupResult

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
@@ -27,14 +27,15 @@ class StudyServiceMock(
         "Description", StudyInvitation.empty(), createComplexStudy().protocolSnapshot
     ),
     private val getStudyStatusResult: StudyStatus = studyStatus,
-    private val getStudiesOverviewResult: List<StudyStatus> = listOf(),
+    private val getStudiesOverviewResult: List<StudyStatus> = emptyList(),
     private val addParticipantResult: Participant = Participant( AccountIdentity.fromEmailAddress( "test@test.com" ) ),
-    private val getParticipantsResult: List<Participant> = listOf(),
+    private val getParticipantsResult: List<Participant> = emptyList(),
     private val setInvitationResult: StudyStatus = studyStatus,
     private val setProtocolResult: StudyStatus = studyStatus,
     private val goLiveResult: StudyStatus = studyStatus,
     private val deployParticipantResult: ParticipantGroupStatus =
-        ParticipantGroupStatus( StudyDeploymentStatus.Invited( UUID.randomUUID(), listOf() ), setOf() )
+        ParticipantGroupStatus( StudyDeploymentStatus.Invited( UUID.randomUUID(), emptyList() ), emptySet() ),
+    private val getParticipantGroupStatusesResult: List<ParticipantGroupStatus> = emptyList()
 ) : Mock<Service>(), Service
 {
     companion object
@@ -91,4 +92,8 @@ class StudyServiceMock(
     override suspend fun deployParticipantGroup( studyId: UUID, group: Set<AssignParticipantDevices> ) =
         deployParticipantResult
         .also { trackSuspendCall( Service::deployParticipantGroup, studyId, group ) }
+
+    override suspend fun getParticipantGroupStatuses( studyId: UUID ) =
+        getParticipantGroupStatusesResult
+        .also { trackSuspendCall( Service::getParticipantGroupStatuses, studyId ) }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
@@ -4,8 +4,10 @@ import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
+import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
+import dk.cachet.carp.studies.domain.ParticipantGroupStatus
 import dk.cachet.carp.studies.domain.StudyDetails
 import dk.cachet.carp.studies.domain.users.StudyOwner
 import dk.cachet.carp.studies.domain.StudyStatus
@@ -13,6 +15,8 @@ import dk.cachet.carp.studies.domain.createComplexStudy
 import dk.cachet.carp.studies.domain.users.AssignParticipantDevices
 import dk.cachet.carp.studies.domain.users.Participant
 import dk.cachet.carp.test.Mock
+
+private typealias Service = StudyService
 
 
 class StudyServiceMock(
@@ -29,8 +33,9 @@ class StudyServiceMock(
     private val setInvitationResult: StudyStatus = studyStatus,
     private val setProtocolResult: StudyStatus = studyStatus,
     private val goLiveResult: StudyStatus = studyStatus,
-    private val deployParticipantResult: StudyStatus = studyStatus
-) : Mock<StudyService>(), StudyService
+    private val deployParticipantResult: ParticipantGroupStatus =
+        ParticipantGroupStatus( StudyDeploymentStatus.Invited( UUID.randomUUID(), listOf() ), setOf() )
+) : Mock<Service>(), Service
 {
     companion object
     {
@@ -43,69 +48,47 @@ class StudyServiceMock(
     }
 
 
-    override suspend fun createStudy( owner: StudyOwner, name: String, description: String, invitation: StudyInvitation? ): StudyStatus
-    {
-        trackSuspendCall( StudyService::createStudy, owner, name, description, invitation )
-        return createStudyResult
-    }
+    override suspend fun createStudy( owner: StudyOwner, name: String, description: String, invitation: StudyInvitation? ) =
+        createStudyResult
+        .also { trackSuspendCall( Service::createStudy, owner, name, description, invitation ) }
 
-    override suspend fun setInternalDescription( studyId: UUID, name: String, description: String ): StudyStatus
-    {
-        trackSuspendCall( StudyService::setInternalDescription, studyId, name, description )
-        return updateInternalDescriptionResult
-    }
+    override suspend fun setInternalDescription( studyId: UUID, name: String, description: String ) =
+        updateInternalDescriptionResult
+        .also { trackSuspendCall( Service::setInternalDescription, studyId, name, description ) }
 
-    override suspend fun getStudyDetails( studyId: UUID ): StudyDetails
-    {
-        trackSuspendCall( StudyService::getStudyDetails, studyId )
-        return getStudyDetailsResult
-    }
+    override suspend fun getStudyDetails( studyId: UUID ) =
+        getStudyDetailsResult
+        .also { trackSuspendCall( Service::getStudyDetails, studyId ) }
 
-    override suspend fun getStudyStatus( studyId: UUID ): StudyStatus
-    {
-        trackSuspendCall( StudyService::getStudyStatus, studyId )
-        return getStudyStatusResult
-    }
+    override suspend fun getStudyStatus( studyId: UUID ) =
+        getStudyStatusResult
+        .also { trackSuspendCall( Service::getStudyStatus, studyId ) }
 
-    override suspend fun getStudiesOverview( owner: StudyOwner ): List<StudyStatus>
-    {
-        trackSuspendCall( StudyService::getStudiesOverview, owner )
-        return getStudiesOverviewResult
-    }
+    override suspend fun getStudiesOverview( owner: StudyOwner ) =
+        getStudiesOverviewResult
+        .also { trackSuspendCall( Service::getStudiesOverview, owner ) }
 
-    override suspend fun addParticipant( studyId: UUID, email: EmailAddress ): Participant
-    {
-        trackSuspendCall( StudyService::addParticipant, studyId, email )
-        return addParticipantResult
-    }
+    override suspend fun addParticipant( studyId: UUID, email: EmailAddress ) =
+        addParticipantResult
+        .also { trackSuspendCall( Service::addParticipant, studyId, email ) }
 
-    override suspend fun getParticipants( studyId: UUID ): List<Participant>
-    {
-        trackSuspendCall( StudyService::getParticipants, studyId )
-        return getParticipantsResult
-    }
+    override suspend fun getParticipants( studyId: UUID ) =
+        getParticipantsResult
+        .also { trackSuspendCall( Service::getParticipants, studyId ) }
 
-    override suspend fun setInvitation( studyId: UUID, invitation: StudyInvitation ): StudyStatus
-    {
-        trackSuspendCall( StudyService::setInvitation, studyId, invitation )
-        return setInvitationResult
-    }
+    override suspend fun setInvitation( studyId: UUID, invitation: StudyInvitation ) =
+        setInvitationResult
+        .also { trackSuspendCall( Service::setInvitation, studyId, invitation ) }
 
-    override suspend fun setProtocol( studyId: UUID, protocol: StudyProtocolSnapshot ): StudyStatus
-    {
-        trackSuspendCall( StudyService::setProtocol, studyId, protocol )
-        return setProtocolResult
-    }
+    override suspend fun setProtocol( studyId: UUID, protocol: StudyProtocolSnapshot ) =
+        setProtocolResult
+        .also { trackSuspendCall( Service::setProtocol, studyId, protocol ) }
 
-    override suspend fun goLive( studyId: UUID ): StudyStatus
-    {
-        trackSuspendCall( StudyService::goLive, studyId )
-        return goLiveResult
-    }
+    override suspend fun goLive( studyId: UUID ) =
+        goLiveResult
+        .also { trackSuspendCall( Service::goLive, studyId ) }
 
-    override suspend fun deployParticipantGroup( studyId: UUID, group: Set<AssignParticipantDevices> ): StudyStatus
-    {
-        trackSuspendCall( StudyService::deployParticipantGroup, studyId, group )
-        return deployParticipantResult
-    }
+    override suspend fun deployParticipantGroup( studyId: UUID, group: Set<AssignParticipantDevices> ) =
+        deployParticipantResult
+        .also { trackSuspendCall( Service::deployParticipantGroup, studyId, group ) }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
@@ -33,9 +33,9 @@ class StudyServiceMock(
     private val setInvitationResult: StudyStatus = studyStatus,
     private val setProtocolResult: StudyStatus = studyStatus,
     private val goLiveResult: StudyStatus = studyStatus,
-    private val deployParticipantResult: ParticipantGroupStatus =
-        ParticipantGroupStatus( StudyDeploymentStatus.Invited( UUID.randomUUID(), emptyList() ), emptySet() ),
-    private val getParticipantGroupStatusesResult: List<ParticipantGroupStatus> = emptyList()
+    private val deployParticipantResult: ParticipantGroupStatus = groupStatus,
+    private val getParticipantGroupStatusesResult: List<ParticipantGroupStatus> = emptyList(),
+    private val stopParticipantGroupResult: ParticipantGroupStatus = groupStatus
 ) : Mock<Service>(), Service
 {
     companion object
@@ -46,6 +46,10 @@ class StudyServiceMock(
             canSetStudyProtocol = false,
             canDeployToParticipants = false,
             canGoLive = true )
+
+        private val groupStatus = ParticipantGroupStatus(
+            StudyDeploymentStatus.Invited( UUID.randomUUID(), emptyList() ),
+            emptySet() )
     }
 
 
@@ -96,4 +100,8 @@ class StudyServiceMock(
     override suspend fun getParticipantGroupStatuses( studyId: UUID ) =
         getParticipantGroupStatusesResult
         .also { trackSuspendCall( Service::getParticipantGroupStatuses, studyId ) }
+
+    override suspend fun stopParticipantGroup( studyId: UUID, groupId: UUID ) =
+        stopParticipantGroupResult
+        .also { trackSuspendCall( Service::stopParticipantGroup, studyId, groupId ) }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
@@ -15,6 +15,9 @@ import dk.cachet.carp.test.runBlockingTest
 import kotlin.test.*
 
 
+private val unknownId: UUID = UUID.randomUUID()
+
+
 /**
  * Tests for implementations of [StudyService].
  */
@@ -90,7 +93,6 @@ interface StudyServiceTest
     fun getStudyDetails_fails_for_unknown_studyId() = runBlockingTest {
         val ( service, _ ) = createService()
 
-        val unknownId = UUID.randomUUID()
         assertFailsWith<IllegalArgumentException> { service.getStudyDetails( unknownId ) }
     }
 
@@ -107,7 +109,7 @@ interface StudyServiceTest
     fun getStudyStatus_fails_for_unknown_studyId() = runBlockingTest {
         val ( service, _ ) = createService()
 
-        assertFailsWith<IllegalArgumentException> { service.getStudyStatus( UUID.randomUUID() ) }
+        assertFailsWith<IllegalArgumentException> { service.getStudyStatus( unknownId ) }
     }
 
     @Test
@@ -139,7 +141,6 @@ interface StudyServiceTest
     fun addParticipant_fails_for_unknown_studyId() = runBlockingTest {
         val ( service, _ ) = createService()
 
-        val unknownId = UUID.randomUUID()
         val email = EmailAddress( "test@test.com" )
         assertFailsWith<IllegalArgumentException> { service.addParticipant( unknownId, email ) }
     }
@@ -161,7 +162,6 @@ interface StudyServiceTest
     fun getParticipants_fails_for_unknown_studyId() = runBlockingTest {
         val ( service, _ ) = createService()
 
-        val unknownId = UUID.randomUUID()
         assertFailsWith<IllegalArgumentException> { service.getParticipants( unknownId ) }
     }
 
@@ -180,7 +180,7 @@ interface StudyServiceTest
     @Test
     fun setInvitation_fails_for_unknown_studyId() = runBlockingTest {
         val ( service, _ ) = createService()
-        val unknownId = UUID.randomUUID()
+
         assertFailsWith<IllegalArgumentException> { service.setInvitation( unknownId, StudyInvitation.empty() ) }
     }
 
@@ -202,7 +202,7 @@ interface StudyServiceTest
     @Test
     fun setProtocol_fails_for_unknown_studyId() = runBlockingTest {
         val ( service, _ ) = createService()
-        val unknownId = UUID.randomUUID()
+
         assertFailsWith<IllegalArgumentException> { service.setProtocol( unknownId, createDeployableProtocol() ) }
     }
 
@@ -261,7 +261,7 @@ interface StudyServiceTest
     @Test
     fun goLive_fails_for_unknown_studyId() = runBlockingTest {
         val ( service, _ ) = createService()
-        val unknownId = UUID.randomUUID()
+
         assertFailsWith<IllegalArgumentException> { service.goLive( unknownId ) }
     }
 
@@ -283,13 +283,16 @@ interface StudyServiceTest
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
         val groupStatus = service.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         assertEquals( participant.id, groupStatus.participants.single().participantId )
+        val participantGroups = service.getParticipantGroupStatuses( studyId )
+        val participantIdInGroup = participantGroups.single().participants.single().participantId
+        assertEquals( participant.id, participantIdInGroup )
     }
 
     @Test
     fun deployParticipantGroup_fails_for_unknown_studyId() = runBlockingTest {
         val ( service, _ ) = createService()
-        val unknownId = UUID.randomUUID()
         val assignParticipant = AssignParticipantDevices( UUID.randomUUID(), setOf( "Test device" ) )
+
         assertFailsWith<IllegalArgumentException> { service.deployParticipantGroup( unknownId, setOf( assignParticipant ) ) }
     }
 
@@ -307,8 +310,7 @@ interface StudyServiceTest
         val ( studyId, protocolSnapshot ) = createLiveStudy( service )
 
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
-        val unknownParticipantId = UUID.randomUUID()
-        val assignParticipant = AssignParticipantDevices( unknownParticipantId, deviceRoles )
+        val assignParticipant = AssignParticipantDevices( unknownId, deviceRoles )
         assertFailsWith<IllegalArgumentException> { service.deployParticipantGroup( studyId, setOf( assignParticipant ) ) }
     }
 
@@ -330,6 +332,13 @@ interface StudyServiceTest
 
         val assignParticipant = AssignParticipantDevices( participant.id, setOf() )
         assertFailsWith<IllegalArgumentException> { service.deployParticipantGroup( studyId, setOf( assignParticipant ) ) }
+    }
+
+    @Test
+    fun getParticipantGroupStatuses_fails_for_unknown_studyId() = runBlockingTest {
+        val ( service, _ ) = createService()
+
+        assertFailsWith<IllegalArgumentException> { service.getParticipantGroupStatuses( unknownId ) }
     }
 
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
@@ -284,7 +284,7 @@ interface StudyServiceTest
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
         val groupStatus = service.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         assertEquals( participant.id, groupStatus.participants.single().participantId )
-        val participantGroups = service.getParticipantGroupStatuses( studyId )
+        val participantGroups = service.getParticipantGroupStatusList( studyId )
         val participantIdInGroup = participantGroups.single().participants.single().participantId
         assertEquals( participant.id, participantIdInGroup )
     }
@@ -339,7 +339,7 @@ interface StudyServiceTest
     fun getParticipantGroupStatuses_fails_for_unknown_studyId() = runBlockingTest {
         val ( service, _ ) = createService()
 
-        assertFailsWith<IllegalArgumentException> { service.getParticipantGroupStatuses( unknownId ) }
+        assertFailsWith<IllegalArgumentException> { service.getParticipantGroupStatusList( unknownId ) }
     }
 
     @Test

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
@@ -281,7 +281,8 @@ interface StudyServiceTest
 
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
-        service.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus = service.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        assertEquals( participant.id, groupStatus.participants.single().participantId )
     }
 
     @Test

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.studies.domain
 
 import dk.cachet.carp.common.UUID
-import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.StudyProtocol
@@ -28,8 +27,9 @@ fun createComplexStudy(): Study
     study.goLive()
 
     // Add a participation.
-    val participation = DeanonymizedParticipation( UUID.randomUUID(), Participation( UUID.randomUUID() ) )
-    study.addParticipation( participation )
+    val participation = DeanonymizedParticipation( UUID.randomUUID(), UUID.randomUUID() )
+    val studyDeploymentId = UUID.randomUUID()
+    study.addParticipation( studyDeploymentId, participation )
 
     return study
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyRepositoryTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyRepositoryTest.kt
@@ -36,6 +36,7 @@ interface StudyRepositoryTest
         val study = addStudy( repo )
 
         val foundStudy = repo.getById( study.id )
+        assertNotSame( study, foundStudy ) // Should be new object instance.
         assertEquals( study.getSnapshot(), foundStudy?.getSnapshot() )
     }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.studies.domain
 
 import dk.cachet.carp.common.UUID
-import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.StudyProtocol
@@ -167,8 +166,8 @@ class StudyTest
         assertTrue( study.canDeployToParticipants )
 
         val studyDeploymentId = UUID.randomUUID()
-        val participation = DeanonymizedParticipation( UUID.randomUUID(), Participation( studyDeploymentId ) )
-        study.addParticipation( participation )
+        val participation = DeanonymizedParticipation( UUID.randomUUID(), UUID.randomUUID() )
+        study.addParticipation( studyDeploymentId, participation )
         assertEquals( Study.Event.ParticipationAdded( participation ), study.consumeEvents().last() )
         assertEquals( participation, study.getParticipations( studyDeploymentId ).single() )
     }
@@ -181,8 +180,9 @@ class StudyTest
 
         assertFalse( study.canDeployToParticipants )
 
-        val participation = DeanonymizedParticipation( UUID.randomUUID(), Participation( UUID.randomUUID() ) )
-        assertFailsWith<IllegalStateException> { study.addParticipation( participation ) }
+        val participation = DeanonymizedParticipation( UUID.randomUUID(), UUID.randomUUID() )
+        val studyDeploymentId = UUID.randomUUID()
+        assertFailsWith<IllegalStateException> { study.addParticipation( studyDeploymentId, participation ) }
         val participationEvents = study.consumeEvents().filterIsInstance<Study.Event.ParticipationAdded>()
         assertEquals( 0, participationEvents.count() )
     }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
@@ -166,9 +166,11 @@ class StudyTest
 
         assertTrue( study.canDeployToParticipants )
 
-        val participation = DeanonymizedParticipation( UUID.randomUUID(), Participation( UUID.randomUUID() ) )
+        val studyDeploymentId = UUID.randomUUID()
+        val participation = DeanonymizedParticipation( UUID.randomUUID(), Participation( studyDeploymentId ) )
         study.addParticipation( participation )
         assertEquals( Study.Event.ParticipationAdded( participation ), study.consumeEvents().last() )
+        assertEquals( participation, study.getParticipations( studyDeploymentId ).single() )
     }
 
     @Test
@@ -183,6 +185,16 @@ class StudyTest
         assertFailsWith<IllegalStateException> { study.addParticipation( participation ) }
         val participationEvents = study.consumeEvents().filterIsInstance<Study.Event.ParticipationAdded>()
         assertEquals( 0, participationEvents.count() )
+    }
+
+    @Test
+    fun getParticipations_fails_for_unknown_studyDeploymentId()
+    {
+        val study = createStudy()
+        setDeployableProtocol( study )
+
+        val unknownId = UUID.randomUUID()
+        assertFailsWith<IllegalArgumentException> { study.getParticipations( unknownId ) }
     }
 
     private fun createStudy(): Study = Study( StudyOwner(), "Test study" )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/DeanonymizedParticipationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/DeanonymizedParticipationTest.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.UUID
-import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,7 +14,7 @@ class DeanonymizedParticipationTest
     @Test
     fun can_serialize_and_deserialize_deanonymized_participation_using_JSON()
     {
-        val participation = DeanonymizedParticipation( UUID.randomUUID(), Participation( UUID.randomUUID() ) )
+        val participation = DeanonymizedParticipation( UUID.randomUUID(), UUID.randomUUID() )
 
         val serialized: String = JSON.stringify( DeanonymizedParticipation.serializer(), participation )
         val parsed: DeanonymizedParticipation = JSON.parse( DeanonymizedParticipation.serializer(), serialized )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
@@ -1,0 +1,29 @@
+package dk.cachet.carp.studies.infrastructure
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
+import dk.cachet.carp.deployment.domain.users.Participation
+import dk.cachet.carp.studies.domain.ParticipantGroupStatus
+import dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
+import kotlin.test.*
+
+
+/**
+ * Tests for [ParticipantGroupStatus] relying on core infrastructure.
+ */
+class ParticipantGroupStatusTest
+{
+    @Test
+    fun can_serialize_and_deserialize_ParticipantGroupStatus_using_JSON()
+    {
+        val studyDeploymentId = UUID.randomUUID()
+        val deploymentStatus = StudyDeploymentStatus.Invited( studyDeploymentId, listOf() )
+        val participants = setOf( DeanonymizedParticipation( UUID.randomUUID(), Participation( studyDeploymentId ) ) )
+        val groupStatus = ParticipantGroupStatus( deploymentStatus, participants )
+
+        val serialized: String = JSON.stringify( ParticipantGroupStatus.serializer(), groupStatus )
+        val parsed: ParticipantGroupStatus = JSON.parse( ParticipantGroupStatus.serializer(), serialized )
+
+        assertEquals( groupStatus, parsed )
+    }
+}

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
@@ -2,7 +2,6 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
-import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.studies.domain.ParticipantGroupStatus
 import dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
 import kotlin.test.*
@@ -18,7 +17,7 @@ class ParticipantGroupStatusTest
     {
         val studyDeploymentId = UUID.randomUUID()
         val deploymentStatus = StudyDeploymentStatus.Invited( studyDeploymentId, listOf() )
-        val participants = setOf( DeanonymizedParticipation( UUID.randomUUID(), Participation( studyDeploymentId ) ) )
+        val participants = setOf( DeanonymizedParticipation( UUID.randomUUID(), UUID.randomUUID() ) )
         val groupStatus = ParticipantGroupStatus( deploymentStatus, participants )
 
         val serialized: String = JSON.stringify( ParticipantGroupStatus.serializer(), groupStatus )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
@@ -34,7 +34,8 @@ class StudyServiceRequestsTest
             StudyServiceRequest.SetProtocol( studyId, StudyProtocol( ProtocolOwner(), "Test" ).getSnapshot() ),
             StudyServiceRequest.GoLive( studyId ),
             StudyServiceRequest.DeployParticipantGroup( studyId, setOf() ),
-            StudyServiceRequest.GetParticipantGroupStatuses( studyId )
+            StudyServiceRequest.GetParticipantGroupStatuses( studyId ),
+            StudyServiceRequest.StopParticipantGroup( studyId, UUID.randomUUID() )
         )
     }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
@@ -34,7 +34,7 @@ class StudyServiceRequestsTest
             StudyServiceRequest.SetProtocol( studyId, StudyProtocol( ProtocolOwner(), "Test" ).getSnapshot() ),
             StudyServiceRequest.GoLive( studyId ),
             StudyServiceRequest.DeployParticipantGroup( studyId, setOf() ),
-            StudyServiceRequest.GetParticipantGroupStatuses( studyId ),
+            StudyServiceRequest.GetParticipantGroupStatusList( studyId ),
             StudyServiceRequest.StopParticipantGroup( studyId, UUID.randomUUID() )
         )
     }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
@@ -33,7 +33,8 @@ class StudyServiceRequestsTest
             StudyServiceRequest.SetInvitation( studyId, StudyInvitation.empty() ),
             StudyServiceRequest.SetProtocol( studyId, StudyProtocol( ProtocolOwner(), "Test" ).getSnapshot() ),
             StudyServiceRequest.GoLive( studyId ),
-            StudyServiceRequest.DeployParticipantGroup( studyId, setOf() )
+            StudyServiceRequest.DeployParticipantGroup( studyId, setOf() ),
+            StudyServiceRequest.GetParticipantGroupStatuses( studyId )
         )
     }
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -79,6 +79,7 @@ complexity:
     threshold: 60
   LongParameterList:
     active: true
+    excludes: '**/commonTest/**,**/jvmTest/**,**/jsTest/**,**/test/**'
     threshold: 6
     ignoreDefaultParameters: false
   MethodOverloading:

--- a/detekt.yml
+++ b/detekt.yml
@@ -116,7 +116,7 @@ coroutines:
 empty-blocks:
   active: true
   EmptyCatchBlock:
-    active: false
+    active: true
     allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
   EmptyClassBlock:
     active: true

--- a/detekt.yml
+++ b/detekt.yml
@@ -116,7 +116,7 @@ coroutines:
 empty-blocks:
   active: true
   EmptyCatchBlock:
-    active: true
+    active: false
     allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
   EmptyClassBlock:
     active: true

--- a/typescript-declarations/@types/carp.deployment.core/index.d.ts
+++ b/typescript-declarations/@types/carp.deployment.core/index.d.ts
@@ -1,11 +1,118 @@
 declare module 'carp.deployment.core'
 {
+    import { kotlin } from 'kotlin'
+    import ArrayList = kotlin.collections.ArrayList
+    import HashSet = kotlin.collections.HashSet
     import { dk as cdk } from 'carp.common'
     import UUID = cdk.cachet.carp.common.UUID
 
 
+    namespace dk.cachet.carp.deployment.domain
+    {
+        class DeviceDeploymentStatus
+        {
+            static get Companion(): DeviceDeploymentStatus$Companion
+        }
+        interface DeviceDeploymentStatus$Companion { serializer(): any }
+
+        namespace DeviceDeploymentStatus
+        {
+            class Unregistered
+            {
+                constructor(
+                    device: any,
+                    requiresDeployment: Boolean,
+                    remainingDevicesToRegisterBeforeDeployment: HashSet<String> )
+
+                readonly device: any
+                readonly requiresDeployment: Boolean
+                readonly remainingDevicesToRegisterBeforeDeployment: HashSet<String>
+            }
+            class Registered
+            {
+                constructor(
+                    device: any,
+                    requiresDeployment: Boolean,
+                    remainingDevicesToRegisterBeforeDeployment: HashSet<String> )
+
+                readonly device: any
+                readonly requiresDeployment: Boolean
+                readonly remainingDevicesToRegisterBeforeDeployment: HashSet<String>
+            }
+            class Deployed
+            {
+                constructor( device: any )
+
+                readonly device: any
+                readonly requiresDeployment: Boolean
+            }
+            class NeedsRedeployment
+            {
+                constructor(
+                    device: any,
+                    remainingDevicesToRegisterBeforeDeployment: HashSet<String> )
+
+                readonly device: any
+                readonly requiresDeployment: Boolean
+                readonly remainingDevicesToRegisterBeforeDeployment: HashSet<String>
+            }
+        }
+
+
+        class StudyDeploymentStatus
+        {
+            static get Companion(): StudyDeploymentStatus$Companion
+        }
+        interface StudyDeploymentStatus$Companion { serializer(): any }
+
+        namespace StudyDeploymentStatus
+        {
+            class Invited
+            {
+                constructor( studyDeploymentId: UUID, devicesStatus: ArrayList<DeviceDeploymentStatus> )
+
+                readonly studyDeploymentId: UUID
+                readonly devicesStatus: ArrayList<DeviceDeploymentStatus>
+            }
+            class DeployingDevices
+            {
+                constructor( studyDeploymentId: UUID, devicesStatus: ArrayList<DeviceDeploymentStatus> )
+
+                readonly studyDeploymentId: UUID
+                readonly devicesStatus: ArrayList<DeviceDeploymentStatus>
+            }
+            class DeploymentReady
+            {
+                constructor( studyDeploymentId: UUID, devicesStatus: ArrayList<DeviceDeploymentStatus> )
+
+                readonly studyDeploymentId: UUID
+                readonly devicesStatus: ArrayList<DeviceDeploymentStatus>
+            }
+            class Stopped
+            {
+                constructor( studyDeploymentId: UUID, devicesStatus: ArrayList<DeviceDeploymentStatus> )
+
+                readonly studyDeploymentId: UUID
+                readonly devicesStatus: ArrayList<DeviceDeploymentStatus>
+            }
+        }
+    }
+
+
     namespace dk.cachet.carp.deployment.domain.users
     {
+        class Participation
+        {
+            constructor( studyDeploymentId: UUID, id?: UUID )
+
+            static get Companion(): Participation$Companion
+
+            readonly studyDeploymentId: UUID
+            readonly id: UUID
+        }
+        interface Participation$Companion { serializer(): any }
+
+
         class StudyInvitation
         {
             constructor( name: string, description: string )

--- a/typescript-declarations/@types/carp.deployment.core/index.d.ts
+++ b/typescript-declarations/@types/carp.deployment.core/index.d.ts
@@ -17,7 +17,14 @@ declare module 'carp.deployment.core'
 
         namespace DeviceDeploymentStatus
         {
-            class Unregistered
+            interface NotDeployed
+            {
+                readonly requiresDeployment: Boolean
+                readonly isReadyForDeployment: Boolean
+                readonly remainingDevicesToRegisterBeforeDeployment: HashSet<String>
+
+            }
+            class Unregistered implements NotDeployed
             {
                 constructor(
                     device: any,
@@ -26,9 +33,11 @@ declare module 'carp.deployment.core'
 
                 readonly device: any
                 readonly requiresDeployment: Boolean
+                readonly canObtainDeviceDeployment: Boolean
+                readonly isReadyForDeployment: Boolean
                 readonly remainingDevicesToRegisterBeforeDeployment: HashSet<String>
             }
-            class Registered
+            class Registered implements NotDeployed
             {
                 constructor(
                     device: any,
@@ -37,6 +46,8 @@ declare module 'carp.deployment.core'
 
                 readonly device: any
                 readonly requiresDeployment: Boolean
+                readonly canObtainDeviceDeployment: Boolean
+                readonly isReadyForDeployment: Boolean
                 readonly remainingDevicesToRegisterBeforeDeployment: HashSet<String>
             }
             class Deployed
@@ -45,8 +56,9 @@ declare module 'carp.deployment.core'
 
                 readonly device: any
                 readonly requiresDeployment: Boolean
+                readonly canObtainDeviceDeployment: Boolean
             }
-            class NeedsRedeployment
+            class NeedsRedeployment implements NotDeployed
             {
                 constructor(
                     device: any,
@@ -54,6 +66,8 @@ declare module 'carp.deployment.core'
 
                 readonly device: any
                 readonly requiresDeployment: Boolean
+                readonly canObtainDeviceDeployment: Boolean
+                readonly isReadyForDeployment: Boolean
                 readonly remainingDevicesToRegisterBeforeDeployment: HashSet<String>
             }
         }

--- a/typescript-declarations/@types/carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.studies.core/index.d.ts
@@ -13,12 +13,28 @@ declare module 'carp.studies.core'
     import { dk as pdk } from 'carp.protocols.core'
     import StudyProtocolSnapshot = pdk.cachet.carp.protocols.domain.StudyProtocolSnapshot
     import { dk as ddk } from 'carp.deployment.core'
+    import Participation = ddk.cachet.carp.deployment.domain.users.Participation
+    import StudyDeploymentStatus = ddk.cachet.carp.deployment.domain.StudyDeploymentStatus
     import StudyInvitation = ddk.cachet.carp.deployment.domain.users.StudyInvitation
 
 
     namespace dk.cachet.carp.studies.domain
     {
         import StudyOwner = dk.cachet.carp.studies.domain.users.StudyOwner
+        import DeanonymizedParticipation = dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
+
+
+        class ParticipantGroupStatus
+        {
+            constructor( studyDeploymentStatus: StudyDeploymentStatus, participants: HashSet<DeanonymizedParticipation> )
+
+            static get Companion(): ParticipantGroupStatus$Companion
+
+            readonly studyDeploymentStatus: StudyDeploymentStatus
+            readonly participants: HashSet<DeanonymizedParticipation>
+        }
+        interface ParticipantGroupStatus$Companion { serializer(): any }
+
 
         class StudyDetails
         {
@@ -39,6 +55,7 @@ declare module 'carp.studies.core'
             readonly protocolSnapshot: StudyProtocolSnapshot | null
         }
         interface StudyDetails$Companion { serializer(): any }
+
 
         abstract class StudyStatus
         {
@@ -98,6 +115,18 @@ declare module 'carp.studies.core'
         function participantIds_nvx6bb$( assignedGroup: ArrayList<AssignParticipantDevices> ): HashSet<UUID>
         function deviceRoles_nvx6bb$( assignedGroup: ArrayList<AssignParticipantDevices> ): HashSet<string>
         interface AssignParticipantDevices$Companion { serializer(): any }
+
+
+        class DeanonymizedParticipation
+        {
+            constructor( participantId: UUID, participation: Participation )
+
+            static get Companion(): DeanonymizedParticipation$Companion
+
+            readonly participantId: UUID
+            readonly participation: Participation
+        }
+        interface DeanonymizedParticipation$Companion { serializer(): any }
 
 
         class Participant

--- a/typescript-declarations/@types/carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.studies.core/index.d.ts
@@ -119,12 +119,12 @@ declare module 'carp.studies.core'
 
         class DeanonymizedParticipation
         {
-            constructor( participantId: UUID, participation: Participation )
+            constructor( participantId: UUID, participationId: UUID )
 
             static get Companion(): DeanonymizedParticipation$Companion
 
             readonly participantId: UUID
-            readonly participation: Participation
+            readonly participationId: UUID
         }
         interface DeanonymizedParticipation$Companion { serializer(): any }
 

--- a/typescript-declarations/@types/carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.studies.core/index.d.ts
@@ -211,7 +211,7 @@ declare module 'carp.studies.core'
             {
                 constructor( studyId: UUID, group: HashSet<AssignParticipantDevices> )
             }
-            class GetParticipantGroupStatuses extends StudyServiceRequest
+            class GetParticipantGroupStatusList extends StudyServiceRequest
             {
                 constructor( studyId: UUID )
             }

--- a/typescript-declarations/@types/carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.studies.core/index.d.ts
@@ -215,6 +215,10 @@ declare module 'carp.studies.core'
             {
                 constructor( studyId: UUID )
             }
+            class StopParticipantGroup extends StudyServiceRequest
+            {
+                constructor( studyId: UUID, groupId: UUID )
+            }
         }
 
         function createStudiesSerializer_stpyu4$(): Json

--- a/typescript-declarations/@types/carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.studies.core/index.d.ts
@@ -211,6 +211,10 @@ declare module 'carp.studies.core'
             {
                 constructor( studyId: UUID, group: HashSet<AssignParticipantDevices> )
             }
+            class GetParticipantGroupStatuses extends StudyServiceRequest
+            {
+                constructor( studyId: UUID )
+            }
         }
 
         function createStudiesSerializer_stpyu4$(): Json

--- a/typescript-declarations/tests/VerifyModule.ts
+++ b/typescript-declarations/tests/VerifyModule.ts
@@ -25,7 +25,10 @@ export default class VerifyModule
     constructor( moduleName: string, instances: Array<any> )
     {
         this.moduleName = moduleName
-        this.instances = new Map( instances.map( i => [ i.constructor.name, i ] ) )
+        this.instances = new Map( instances.map( i => {
+            if ( i instanceof Array ) return [ i[0], i[1] ] // Type name specified manually.
+            else return [ i.constructor.name, i ] // Type name inferred from constructor.
+        } ) )
     }
 
     async verify(): Promise<void>
@@ -121,7 +124,7 @@ export default class VerifyModule
                     const scopeToCheck = element.static
                         ? scope
                         : element.kind == 'get'
-                            ? this.getInstance( scope.$metadata$.simpleName )
+                            ? this.getInstance( scope.name )
                             : scope.prototype
                     this.verifyIdentifier( identifier, scopeToCheck )
                 }

--- a/typescript-declarations/tests/carp.deployment.core.ts
+++ b/typescript-declarations/tests/carp.deployment.core.ts
@@ -3,6 +3,7 @@ import VerifyModule from './VerifyModule'
 import { kotlin } from 'kotlin'
 import ArrayList = kotlin.collections.ArrayList
 import HashSet = kotlin.collections.HashSet
+import toSet = kotlin.collections.toSet_us0mfu$
 import { dk as dkc } from 'carp.common'
 import UUID = dkc.cachet.carp.common.UUID
 import { dk } from 'carp.deployment.core'
@@ -20,10 +21,11 @@ describe( "carp.deployment.core", () => {
             StudyInvitation.Companion.empty(),
             StudyInvitation.Companion,
             DeviceDeploymentStatus.Companion,
-            new DeviceDeploymentStatus.Unregistered( null, true, new HashSet<String>() ),
-            new DeviceDeploymentStatus.Registered( null, true, new HashSet<String>() ),
+            new DeviceDeploymentStatus.Unregistered( null, true, toSet( [] ) ),
+            new DeviceDeploymentStatus.Registered( null, true, toSet( [] ) ),
             new DeviceDeploymentStatus.Deployed( null ),
-            new DeviceDeploymentStatus.NeedsRedeployment( null, new HashSet<String>() ),
+            new DeviceDeploymentStatus.NeedsRedeployment( null, toSet( [] ) ),
+            [ "NotDeployed", new DeviceDeploymentStatus.Unregistered( null, true, toSet( [] ) ) ],
             StudyDeploymentStatus.Companion,
             new StudyDeploymentStatus.Invited( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ) ),
             new StudyDeploymentStatus.DeployingDevices( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ) ),

--- a/typescript-declarations/tests/carp.deployment.core.ts
+++ b/typescript-declarations/tests/carp.deployment.core.ts
@@ -1,14 +1,34 @@
 import VerifyModule from './VerifyModule'
 
+import { kotlin } from 'kotlin'
+import ArrayList = kotlin.collections.ArrayList
+import HashSet = kotlin.collections.HashSet
+import { dk as dkc } from 'carp.common'
+import UUID = dkc.cachet.carp.common.UUID
 import { dk } from 'carp.deployment.core'
+import Participation = dk.cachet.carp.deployment.domain.users.Participation
 import StudyInvitation = dk.cachet.carp.deployment.domain.users.StudyInvitation
+import DeviceDeploymentStatus = dk.cachet.carp.deployment.domain.DeviceDeploymentStatus
+import StudyDeploymentStatus = dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 
 
 describe( "carp.deployment.core", () => {
     it( "verify module declarations", async () => {
         const instances = [
+            new Participation( UUID.Companion.randomUUID() ),
+            Participation.Companion,
             StudyInvitation.Companion.empty(),
-            StudyInvitation.Companion
+            StudyInvitation.Companion,
+            DeviceDeploymentStatus.Companion,
+            new DeviceDeploymentStatus.Unregistered( null, true, new HashSet<String>() ),
+            new DeviceDeploymentStatus.Registered( null, true, new HashSet<String>() ),
+            new DeviceDeploymentStatus.Deployed( null ),
+            new DeviceDeploymentStatus.NeedsRedeployment( null, new HashSet<String>() ),
+            StudyDeploymentStatus.Companion,
+            new StudyDeploymentStatus.Invited( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ) ),
+            new StudyDeploymentStatus.DeployingDevices( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ) ),
+            new StudyDeploymentStatus.DeploymentReady( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ) ),
+            new StudyDeploymentStatus.Stopped( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ) )
         ]
 
         const moduleVerifier = new VerifyModule( 'carp.deployment.core', instances )

--- a/typescript-declarations/tests/carp.studies.core.ts
+++ b/typescript-declarations/tests/carp.studies.core.ts
@@ -13,13 +13,17 @@ import DateTime = cdk.cachet.carp.common.DateTime
 import UUID = cdk.cachet.carp.common.UUID
 import UsernameIdentity = cdk.cachet.carp.common.users.UsernameAccountIdentity
 import { dk as ddk } from 'carp.deployment.core'
+import Participation = ddk.cachet.carp.deployment.domain.users.Participation
 import StudyInvitation = ddk.cachet.carp.deployment.domain.users.StudyInvitation
+import StudyDeploymentStatus = ddk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import { dk } from 'carp.studies.core'
 import AssignParticipantDevices = dk.cachet.carp.studies.domain.users.AssignParticipantDevices
 import getAssignedParticipantIds = dk.cachet.carp.studies.domain.users.participantIds_nvx6bb$
 import getAssignedDeviceRoles = dk.cachet.carp.studies.domain.users.deviceRoles_nvx6bb$
+import DeanonymizedParticipant = dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
 import Participant = dk.cachet.carp.studies.domain.users.Participant
 import StudyOwner = dk.cachet.carp.studies.domain.users.StudyOwner
+import ParticipantGroupStatus = dk.cachet.carp.studies.domain.ParticipantGroupStatus
 import StudyDetails = dk.cachet.carp.studies.domain.StudyDetails
 import StudyStatus = dk.cachet.carp.studies.domain.StudyStatus
 import StudyServiceRequest = dk.cachet.carp.studies.infrastructure.StudyServiceRequest
@@ -31,10 +35,14 @@ describe( "carp.studies.core", () => {
         const instances = [
             new AssignParticipantDevices( UUID.Companion.randomUUID(), toSet( [ "Test" ] ) ),
             AssignParticipantDevices.Companion,
+            new DeanonymizedParticipant( UUID.Companion.randomUUID(), new Participation( UUID.Companion.randomUUID() ) ),
+            DeanonymizedParticipant.Companion,
             new Participant( new UsernameIdentity( "Test" ) ),
             Participant.Companion,
             new StudyOwner(),
             StudyOwner.Companion,
+            new ParticipantGroupStatus( new StudyDeploymentStatus(), new HashSet<DeanonymizedParticipant>() ),
+            ParticipantGroupStatus.Companion,
             new StudyDetails( UUID.Companion.randomUUID(), new StudyOwner(), "Name", DateTime.Companion.now(), "Description", StudyInvitation.Companion.empty(), null ),
             StudyDetails.Companion,
             new StudyStatus.Configuring( UUID.Companion.randomUUID(), "Test", DateTime.Companion.now(), true, true, false, true ),

--- a/typescript-declarations/tests/carp.studies.core.ts
+++ b/typescript-declarations/tests/carp.studies.core.ts
@@ -35,7 +35,7 @@ describe( "carp.studies.core", () => {
         const instances = [
             new AssignParticipantDevices( UUID.Companion.randomUUID(), toSet( [ "Test" ] ) ),
             AssignParticipantDevices.Companion,
-            new DeanonymizedParticipant( UUID.Companion.randomUUID(), new Participation( UUID.Companion.randomUUID() ) ),
+            new DeanonymizedParticipant( UUID.Companion.randomUUID(), UUID.Companion.randomUUID() ),
             DeanonymizedParticipant.Companion,
             new Participant( new UsernameIdentity( "Test" ) ),
             Participant.Companion,


### PR DESCRIPTION
**Done:**
- All devices require registration on the back-end before a deployment can be considered 'ready' (https://github.com/cph-cachet/carp.core-kotlin/commit/eb4aa8862be1cb24c8272a6dce7c8004b96ee782). The previous `requiresRegistration` is now specific to individual devices, represented as `remainingDevicesToRegisterBeforeDeployment` in `DeviceDeploymentStatus` (https://github.com/cph-cachet/carp.core-kotlin/commit/b067518d733e0886ea86865541b6d197aaf8aa9a).
- Call `deploymentSuccesful` from `StudyRuntime` (https://github.com/cph-cachet/carp.core-kotlin/commit/6054d89c78a3d2730242030f251b186c358a23d6).
- A `StudyDeployment` can be stopped and has the following `StudyDeploymentStatus` states: `Invited`, `DeployingDevices`, `DeploymentReady`, and `Stopped` (https://github.com/cph-cachet/carp.core-kotlin/pull/119/commits/4bb823711f028a9b785f3c7eb6216b937428a84c).
- The study subsystem now has access to deployment statuses. This can be used to show an overview of all running study deployments (or participant groups, as they are now called in the study subsystem). Participant groups can later carry extra study-subsystem-specific information, but there is a one-to-one mapping to deployments. Added `StudyService.getParticipantGroupStatuses()` and `DeploymentService.getStudyDeploymentStatuses` which it redirects the call to (https://github.com/cph-cachet/carp.core-kotlin/pull/119/commits/4bb6e01408bc522e39ffe89ffd32ea4cf16384d4).
- Added endpoint to stop deployments to `DeploymentService` (https://github.com/cph-cachet/carp.core-kotlin/pull/119/commits/245d29d594407b03280c3fbfbfdda0ffdbbdbf2c) and to stop 'participant groups' as `StudyService.stopParticipantGroup` (https://github.com/cph-cachet/carp.core-kotlin/pull/119/commits/a1e10fe89254eb9368dd9a7430c15c23d89e8126).

**To discuss:**
- I added `DeploymentService.getStudyDeploymentStatuses( studyDeploymentIds )` to enable rendering the full overview of all deployments in the study manager. @ltj, I seem to remember that raised a concern for you in regards to authorization. Will implementing authorization for each individual `studyDeploymentId` be a problem here? Recall that the deployment subsystem is unaware of study ID.
- The study manager will later want to filter, e.g., show all running participant groups. Will it be the task of the study subsystem to cache stopped groups, or should such a filter be passed on to the deployment subsystem?

**Skipped for now**
- We talked about whether or not we should be able to see who stopped a study deployment. But, while trying to implement this I noticed this might depend on a better model of how different accounts participate in a deployment (participant or researcher?), and potentially even incorporating authorization in the deployment domain. This needs more analysis.
- I considered storing the time when a deployment was stopped, but then why not store when it started, when the first device was registered, when the deployment was ready, etc. I think we need to do some use case analysis to have a better understanding which timestamps should be stored and how they are accessed. If all this were needed, this would also advocate switching to event sourcing.
- I did not yet add the TypeScript declarations for devices in the protocol subsystem. This will hopefully be generated during compile time instead in Kotlin 1.4.