### PR TITLE
Add studyDeploymentId field to ParticipationAdded event

### DIFF
--- a/carp.studies.core/package-lock.json
+++ b/carp.studies.core/package-lock.json
@@ -271,8 +271,7 @@
     "fsevents": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-      "optional": true
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
     },
     "function-bind": {
       "version": "1.1.1",

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -43,7 +43,7 @@ class Study(
         data class InvitationChanged( val invitation: StudyInvitation ) : Event()
         data class ProtocolSnapshotChanged( val protocolSnapshot: StudyProtocolSnapshot? ) : Event()
         data class StateChanged( val isLive: Boolean ) : Event()
-        data class ParticipationAdded( val participation: DeanonymizedParticipation ) : Event()
+        data class ParticipationAdded( val studyDeploymentId: UUID, val participation: DeanonymizedParticipation ) : Event()
     }
 
 
@@ -195,7 +195,7 @@ class Study(
         val participations = _participations.getOrPut( studyDeploymentId ) { mutableSetOf() }
         if ( participations.add( participation ) )
         {
-            event( Event.ParticipationAdded( participation ) )
+            event( Event.ParticipationAdded( studyDeploymentId, participation ) )
         }
     }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyTest.kt
@@ -168,7 +168,7 @@ class StudyTest
         val studyDeploymentId = UUID.randomUUID()
         val participation = DeanonymizedParticipation( UUID.randomUUID(), UUID.randomUUID() )
         study.addParticipation( studyDeploymentId, participation )
-        assertEquals( Study.Event.ParticipationAdded( participation ), study.consumeEvents().last() )
+        assertEquals( Study.Event.ParticipationAdded( studyDeploymentId, participation ), study.consumeEvents().last() )
         assertEquals( participation, study.getParticipations( studyDeploymentId ).single() )
     }
 


### PR DESCRIPTION
We need to store the studyDeploymentId alongside study participations. This field was missing in `ParticipationAdded` event forcing a more complex repo implementation to search through the participations map in the study, rather than just getting it directly.