### PR TITLE
Replace `MasterDeviceDeployment` checksum with `lastUpdateDate`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ if ( patientPhoneStatus.canObtainDeviceDeployment ) // True since there are no d
 {
     val deploymentInformation: MasterDeviceDeployment =
         deploymentService.getDeviceDeploymentFor( studyDeploymentId, patientPhone.roleName )
-    val deploymentChecksum: Int = deploymentInformation.getChecksum() // To verify correct deployment.
-    deploymentService.deploymentSuccessful( studyDeploymentId, patientPhone.roleName, deploymentChecksum )
+    val deploymentDate: DateTime = deploymentInformation.lastUpdateDate // To verify correct deployment.
+    deploymentService.deploymentSuccessful( studyDeploymentId, patientPhone.roleName, deploymentDate )
 }
 
 // Now that all devices have been registered and deployed, the deployment is ready.

--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
@@ -128,7 +128,7 @@ class StudyRuntime private constructor(
         // Notify deployment service of successful deployment.
         try
         {
-            deploymentService.deploymentSuccessful( studyDeploymentId, device.roleName, deployment.getChecksum() )
+            deploymentService.deploymentSuccessful( studyDeploymentId, device.roleName, deployment.lastUpdateDate )
             isDeployed = true
             event( Event.Deployed( deployment ) )
         }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployment.application
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
@@ -75,16 +76,20 @@ interface DeploymentService
 
     /**
      * Indicate to stakeholders in the study deployment with [studyDeploymentId] that the device with [masterDeviceRoleName] was deployed successfully,
-     * using the deployment with the specified [deploymentChecksum],
+     * using the deployment with the specified [deviceDeploymentLastUpdateDate],
      * i.e., that the study deployment was loaded on the device and that the necessary runtime is available to run it.
      *
      * @throws IllegalArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [masterDeviceRoleName] is not present in the deployment
-     * - the [deploymentChecksum] does not match the checksum of the expected deployment. The deployment might be outdated.
+     * - the [deviceDeploymentLastUpdateDate] does not match the expected date. The deployment might be outdated.
      * @throws IllegalStateException when the deployment cannot be deployed yet, or the deployment has stopped.
      */
-    suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ): StudyDeploymentStatus
+    suspend fun deploymentSuccessful(
+        studyDeploymentId: UUID,
+        masterDeviceRoleName: String,
+        deviceDeploymentLastUpdateDate: DateTime
+    ): StudyDeploymentStatus
 
     /**
      * Stop the study deployment with the specified [studyDeploymentId].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployment.application
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.DeploymentRepository
@@ -140,21 +141,25 @@ class DeploymentServiceHost( private val repository: DeploymentRepository, priva
 
     /**
      * Indicate to stakeholders in the study deployment with [studyDeploymentId] that the device with [masterDeviceRoleName] was deployed successfully,
-     * using the deployment with the specified [deploymentChecksum],
+     * using the deployment with the specified [deviceDeploymentLastUpdateDate],
      * i.e., that the study deployment was loaded on the device and that the necessary runtime is available to run it.
      *
      * @throws IllegalArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [masterDeviceRoleName] is not present in the deployment
-     * - the [deploymentChecksum] does not match the checksum of the expected deployment. The deployment might be outdated.
+     * - the [deviceDeploymentLastUpdateDate] does not match the expected date. The deployment might be outdated.
      * @throws IllegalStateException when the deployment cannot be deployed yet, or the deployment has stopped.
      */
-    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ): StudyDeploymentStatus
+    override suspend fun deploymentSuccessful(
+        studyDeploymentId: UUID,
+        masterDeviceRoleName: String,
+        deviceDeploymentLastUpdateDate: DateTime
+    ): StudyDeploymentStatus
     {
         val deployment: StudyDeployment = getStudyDeployment( studyDeploymentId )
         val device = getRegisteredMasterDevice( deployment, masterDeviceRoleName )
 
-        deployment.deviceDeployed( device, deploymentChecksum )
+        deployment.deviceDeployed( device, deviceDeploymentLastUpdateDate )
         repository.update( deployment )
 
         return deployment.getStatus()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
@@ -68,8 +68,11 @@ data class MasterDeviceDeployment(
      * The time when this device deployment was last updated.
      * This corresponds to the most recent device registration as part of this device deployment.
      */
-    val lastUpdateDate: DateTime = connectedDeviceConfigurations.values.plus( configuration )
-        .map { it.registrationCreationDate.msSinceUTC }
-        .max()
-        .let { DateTime( it!! ) }
+    val lastUpdateDate: DateTime =
+        // HACK: This is a workaround for a bug in kotlinx.serialization: https://github.com/Kotlin/kotlinx.serialization/issues/716
+        if ( connectedDeviceConfigurations == null ) DateTime.now()
+        else connectedDeviceConfigurations.values.plus( configuration )
+            .map { it.registrationCreationDate.msSinceUTC }
+            .max()
+            .let { DateTime( it!! ) }
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
@@ -69,8 +69,8 @@ data class MasterDeviceDeployment(
      * This corresponds to the most recent device registration as part of this device deployment.
      */
     val lastUpdateDate: DateTime =
-        // HACK: This is a workaround for a bug in kotlinx.serialization: https://github.com/Kotlin/kotlinx.serialization/issues/716
-        if ( connectedDeviceConfigurations == null ) DateTime.now()
+        // TODO: Remove this workaround once JS serialization bug is fixed: https://github.com/Kotlin/kotlinx.serialization/issues/716
+        if ( connectedDeviceConfigurations == null || configuration == null ) DateTime.now()
         else connectedDeviceConfigurations.values.plus( configuration )
             .map { it.registrationCreationDate.msSinceUTC }
             .max()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.deployment.domain
 
-import dk.cachet.carp.deployment.application.DeploymentService
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.DeviceDescriptorSerializer
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
@@ -63,8 +63,13 @@ data class MasterDeviceDeployment(
         val destinationDeviceRoleName: String
     )
 
+
     /**
-     * Get the checksum which needs to be passed to [DeploymentService] to identify this device deployment.
+     * The time when this device deployment was last updated.
+     * This corresponds to the most recent device registration as part of this device deployment.
      */
-    fun getChecksum(): Int = hashCode()
+    val lastUpdateDate: DateTime = connectedDeviceConfigurations.values.plus( configuration )
+        .map { it.registrationCreationDate.msSinceUTC }
+        .max()
+        .let { DateTime( it!! ) }
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
@@ -68,11 +68,14 @@ data class MasterDeviceDeployment(
      * The time when this device deployment was last updated.
      * This corresponds to the most recent device registration as part of this device deployment.
      */
-    val lastUpdateDate: DateTime =
-        // TODO: Remove this workaround once JS serialization bug is fixed: https://github.com/Kotlin/kotlinx.serialization/issues/716
-        if ( connectedDeviceConfigurations == null || configuration == null ) DateTime.now()
-        else connectedDeviceConfigurations.values.plus( configuration )
+    val lastUpdateDate: DateTime
+
+    // TODO: Remove this workaround assignment once JS serialization bug is fixed: https://github.com/Kotlin/kotlinx.serialization/issues/716
+    init
+    {
+        lastUpdateDate = connectedDeviceConfigurations.values.plus( configuration )
             .map { it.registrationCreationDate.msSinceUTC }
             .max()
             .let { DateTime( it!! ) }
+    }
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
@@ -68,14 +68,11 @@ data class MasterDeviceDeployment(
      * The time when this device deployment was last updated.
      * This corresponds to the most recent device registration as part of this device deployment.
      */
-    val lastUpdateDate: DateTime
-
-    // TODO: Remove this workaround assignment once JS serialization bug is fixed: https://github.com/Kotlin/kotlinx.serialization/issues/716
-    init
-    {
-        lastUpdateDate = connectedDeviceConfigurations.values.plus( configuration )
+    val lastUpdateDate: DateTime =
+        // TODO: Remove this workaround once JS serialization bug is fixed: https://github.com/Kotlin/kotlinx.serialization/issues/716
+        if ( connectedDeviceConfigurations == null || configuration == null ) DateTime.now()
+        else connectedDeviceConfigurations.values.plus( configuration )
             .map { it.registrationCreationDate.msSinceUTC }
             .max()
             .let { DateTime( it!! ) }
-    }
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -68,7 +68,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
                 val deployedDevice = deployment.protocolSnapshot.masterDevices.firstOrNull { it.roleName == roleName }
                     ?: throw IllegalArgumentException( "Can't find deployed device with role name '$roleName' in snapshot." )
                 val deviceDeployment = deployment.getDeviceDeploymentFor( deployedDevice )
-                deployment.deviceDeployed( deployedDevice, deviceDeployment.getChecksum() )
+                deployment.deviceDeployed( deployedDevice, deviceDeployment.lastUpdateDate )
             }
 
             // Add invalidated deployed devices.
@@ -372,21 +372,21 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
     }
 
     /**
-     * Indicate that the specified [device] was deployed successfully using the deployment with the specified [deploymentChecksum].
+     * Indicate that the specified [device] was deployed successfully using the deployment with the specified [deviceDeploymentLastUpdateDate].
      *
      * @throws IllegalArgumentException when:
      * - the passed [device] is not part of the protocol of this study deployment
-     * - the [deploymentChecksum] does not match the checksum of the expected deployment. The deployment might be outdated.
+     * - the [deviceDeploymentLastUpdateDate] does not match the expected date. The deployment might be outdated.
      * @throws IllegalStateException when the passed [device] cannot be deployed yet, or the deployment has stopped.
      */
-    fun deviceDeployed( device: AnyMasterDeviceDescriptor, deploymentChecksum: Int )
+    fun deviceDeployed( device: AnyMasterDeviceDescriptor, deviceDeploymentLastUpdateDate: DateTime )
     {
         // Verify whether the specified device is part of the protocol of this deployment.
         require( device in protocolSnapshot.masterDevices ) { "The specified master device is not part of the protocol of this deployment." }
 
         // Verify whether deployment matches the expected deployment.
         val latestDeployment = getDeviceDeploymentFor( device )
-        require( latestDeployment.getChecksum() == deploymentChecksum )
+        require( latestDeployment.lastUpdateDate == deviceDeploymentLastUpdateDate )
 
         check( !isStopped ) { "Cannot deploy devices after a study deployment has stopped." }
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployment.infrastructure
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.createServiceInvoker
 import dk.cachet.carp.common.ddd.ServiceInvoker
@@ -60,9 +61,9 @@ sealed class DeploymentServiceRequest
         Invoker<MasterDeviceDeployment> by createServiceInvoker( Service::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName )
 
     @Serializable
-    data class DeploymentSuccessful( val studyDeploymentId: UUID, val masterDeviceRoleName: String, val deploymentChecksum: Int ) :
+    data class DeploymentSuccessful( val studyDeploymentId: UUID, val masterDeviceRoleName: String, val deviceDeploymentLastUpdateDate: DateTime ) :
         DeploymentServiceRequest(),
-        Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deploymentChecksum )
+        Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deviceDeploymentLastUpdateDate )
 
     @Serializable
     data class Stop( val studyDeploymentId: UUID ) :

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/DeploymentCodeSamples.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/DeploymentCodeSamples.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployment
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.deployment.application.DeploymentServiceHost
 import dk.cachet.carp.deployment.domain.DeviceDeploymentStatus
@@ -38,8 +39,8 @@ class DeploymentCodeSamples
         {
             val deploymentInformation: MasterDeviceDeployment =
                 deploymentService.getDeviceDeploymentFor( studyDeploymentId, patientPhone.roleName )
-            val deploymentChecksum: Int = deploymentInformation.getChecksum() // To verify correct deployment.
-            deploymentService.deploymentSuccessful( studyDeploymentId, patientPhone.roleName, deploymentChecksum )
+            val deploymentDate: DateTime = deploymentInformation.lastUpdateDate // To verify correct deployment.
+            deploymentService.deploymentSuccessful( studyDeploymentId, patientPhone.roleName, deploymentDate )
         }
 
         // Now that all devices have been registered and deployed, the deployment is ready.

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployment.application
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
@@ -62,9 +63,9 @@ class DeploymentServiceMock(
         getDeviceDeploymentForResult
         .also { trackSuspendCall( Service::getDeviceDeploymentFor, studyDeploymentId, masterDeviceRoleName ) }
 
-    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deploymentChecksum: Int ) =
+    override suspend fun deploymentSuccessful( studyDeploymentId: UUID, masterDeviceRoleName: String, deviceDeploymentLastUpdateDate: DateTime ) =
         deploymentSuccessfulResult
-        .also { trackSuspendCall( Service::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deploymentChecksum ) }
+        .also { trackSuspendCall( Service::deploymentSuccessful, studyDeploymentId, masterDeviceRoleName, deviceDeploymentLastUpdateDate ) }
 
     override suspend fun stop( studyDeploymentId: UUID ) =
         stopResult

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
@@ -137,7 +137,7 @@ abstract class DeploymentServiceTest
             { deploymentService.unregisterDevice( studyDeploymentId, master.roleName ) }
         val deviceDeployment = deploymentService.getDeviceDeploymentFor( studyDeploymentId, master.roleName )
         assertFailsWith<IllegalStateException>
-            { deploymentService.deploymentSuccessful( studyDeploymentId, master.roleName, deviceDeployment.getChecksum() ) }
+            { deploymentService.deploymentSuccessful( studyDeploymentId, master.roleName, deviceDeployment.lastUpdateDate ) }
         val accountId = AccountIdentity.fromUsername( "Test" )
         val invitation = StudyInvitation.empty()
         assertFailsWith<IllegalStateException>

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -34,7 +34,7 @@ fun createComplexDeployment(): StudyDeployment
 
     // Deploy a device.
     val deviceDeployment = deployment.getDeviceDeploymentFor( master )
-    deployment.deviceDeployed( master, deviceDeployment.getChecksum() )
+    deployment.deviceDeployed( master, deviceDeployment.lastUpdateDate )
 
     deployment.stop()
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
@@ -114,7 +114,7 @@ interface DeploymentRepositoryTest
             registerDevice( connectedDevice, connectedDevice.createRegistration() )
 
             val deviceDeployment = deployment.getDeviceDeploymentFor( masterDevice )
-            deviceDeployed( masterDevice, deviceDeployment.getChecksum() )
+            deviceDeployed( masterDevice, deviceDeployment.lastUpdateDate )
 
             addParticipation( Account.withUsernameIdentity( "Test" ), Participation( deployment.id ) )
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
@@ -570,7 +570,13 @@ class StudyDeploymentTest
 
         val deviceDeployment = deployment.getDeviceDeploymentFor( device )
         deployment.unregisterDevice( device )
+
+        // Ensure new registration is more recent than previous one.
+        // The timer precision on the JS runtime is sometimes not enough to notice a difference.
+        // In practice, in a distributed system, the timestamps of a re-registration will never overlap due to latency.
+        while ( DateTime.now() == deviceDeployment.lastUpdateDate ) { /* Wait. */ }
         deployment.registerDevice( device, device.createRegistration { } )
+
         assertFailsWith<IllegalArgumentException> { deployment.deviceDeployed( device, deviceDeployment.lastUpdateDate ) }
     }
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployment.domain
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.serialization.createDefaultJSON
 import dk.cachet.carp.common.users.Account
@@ -224,7 +225,7 @@ class StudyDeploymentTest
         deployment.registerDevice( master1, master1.createRegistration { } )
         deployment.registerDevice( master2, master2.createRegistration { } )
         val deviceDeployment = deployment.getDeviceDeploymentFor( master1 )
-        deployment.deviceDeployed( master1, deviceDeployment.getChecksum() )
+        deployment.deviceDeployed( master1, deviceDeployment.lastUpdateDate )
 
         deployment.unregisterDevice( master2 )
         assertEquals( 0, deployment.deployedDevices.count() )
@@ -324,7 +325,7 @@ class StudyDeploymentTest
 
         // Notify of successful master device deployment.
         val deviceDeployment = deployment.getDeviceDeploymentFor( master )
-        deployment.deviceDeployed( master, deviceDeployment.getChecksum() )
+        deployment.deviceDeployed( master, deviceDeployment.lastUpdateDate )
         val afterDeployStatus = deployment.getStatus()
         assertTrue( afterDeployStatus is StudyDeploymentStatus.DeploymentReady )
         val deviceStatus = afterDeployStatus.getDeviceStatus( master )
@@ -348,12 +349,12 @@ class StudyDeploymentTest
 
         // Deploy first master device.
         val master1Deployment = deployment.getDeviceDeploymentFor( master1 )
-        deployment.deviceDeployed( master1, master1Deployment.getChecksum() )
+        deployment.deviceDeployed( master1, master1Deployment.lastUpdateDate )
         assertTrue( deployment.getStatus() is StudyDeploymentStatus.DeployingDevices )
 
         // After deployment of the second master device, deployment is ready.
         val master2Deployment = deployment.getDeviceDeploymentFor( master2 )
-        deployment.deviceDeployed( master2, master2Deployment.getChecksum() )
+        deployment.deviceDeployed( master2, master2Deployment.lastUpdateDate )
         assertTrue( deployment.getStatus() is StudyDeploymentStatus.DeploymentReady )
 
         // Unregistering one device returns deployment to 'deploying'.
@@ -473,7 +474,7 @@ class StudyDeploymentTest
         deployment.registerDevice( device, device.createRegistration { } )
 
         val deviceDeployment = deployment.getDeviceDeploymentFor( device )
-        deployment.deviceDeployed( device, deviceDeployment.getChecksum() )
+        deployment.deviceDeployed( device, deviceDeployment.lastUpdateDate )
         assertTrue( deployment.deployedDevices.contains( device ) )
         assertEquals(
             StudyDeployment.Event.DeviceDeployed( device ),
@@ -494,13 +495,13 @@ class StudyDeploymentTest
 
         // Deploying a device while others still need to be deployed does not set start time.
         val master1Deployment = deployment.getDeviceDeploymentFor( master1 )
-        deployment.deviceDeployed( master1, master1Deployment.getChecksum() )
+        deployment.deviceDeployed( master1, master1Deployment.lastUpdateDate )
         assertNull( deployment.startTime )
         assertEquals( 0, deployment.consumeEvents().filterIsInstance<StudyDeployment.Event.Started>().count() )
 
         // Deploying the last device sets start time.
         val master2Deployment = deployment.getDeviceDeploymentFor( master2 )
-        deployment.deviceDeployed( master2, master2Deployment.getChecksum() )
+        deployment.deviceDeployed( master2, master2Deployment.lastUpdateDate )
         assertNotNull( deployment.startTime )
         assertEquals(
             deployment.startTime,
@@ -517,9 +518,9 @@ class StudyDeploymentTest
         deployment.registerDevice( device, device.createRegistration { } )
 
         val deviceDeployment = deployment.getDeviceDeploymentFor( device )
-        val deploymentChecksum = deviceDeployment.getChecksum()
-        deployment.deviceDeployed( device, deploymentChecksum )
-        deployment.deviceDeployed( device, deploymentChecksum )
+        val deploymentDate = deviceDeployment.lastUpdateDate
+        deployment.deviceDeployed( device, deploymentDate )
+        deployment.deviceDeployed( device, deploymentDate )
         assertEquals( 1, deployment.deployedDevices.count() )
         assertEquals( 1, deployment.consumeEvents().filterIsInstance<StudyDeployment.Event.DeviceDeployed>().count() )
     }
@@ -530,7 +531,7 @@ class StudyDeploymentTest
         val deployment = createComplexDeployment()
 
         val invalidDevice = StubMasterDeviceDescriptor( "Not in deployment" )
-        assertFailsWith<IllegalArgumentException> { deployment.deviceDeployed( invalidDevice, 0 ) }
+        assertFailsWith<IllegalArgumentException> { deployment.deviceDeployed( invalidDevice, DateTime.now() ) }
         assertEquals( 0, deployment.consumeEvents().filterIsInstance<StudyDeployment.Event.DeviceDeployed>().count() )
     }
 
@@ -542,7 +543,7 @@ class StudyDeploymentTest
         protocol.addMasterDevice( device )
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
-        assertFailsWith<IllegalStateException> { deployment.deviceDeployed( device, 0 ) }
+        assertFailsWith<IllegalStateException> { deployment.deviceDeployed( device, DateTime.now() ) }
         assertEquals( 0, deployment.consumeEvents().filterIsInstance<StudyDeployment.Event.DeviceDeployed>().count() )
     }
 
@@ -555,11 +556,11 @@ class StudyDeploymentTest
         deployment.registerDevice( master, DefaultDeviceRegistration( "0" ) )
         val deviceDeployment = deployment.getDeviceDeploymentFor( master )
 
-        assertFailsWith<IllegalStateException> { deployment.deviceDeployed( master, deviceDeployment.getChecksum() ) }
+        assertFailsWith<IllegalStateException> { deployment.deviceDeployed( master, deviceDeployment.lastUpdateDate ) }
     }
 
     @Test
-    fun deviceDeployed_fails_with_outdated_deployment_checksum()
+    fun deviceDeployed_fails_with_outdated_deployment()
     {
         val protocol = createEmptyProtocol()
         val device = StubMasterDeviceDescriptor()
@@ -570,7 +571,7 @@ class StudyDeploymentTest
         val deviceDeployment = deployment.getDeviceDeploymentFor( device )
         deployment.unregisterDevice( device )
         deployment.registerDevice( device, device.createRegistration { } )
-        assertFailsWith<IllegalArgumentException> { deployment.deviceDeployed( device, deviceDeployment.getChecksum() ) }
+        assertFailsWith<IllegalArgumentException> { deployment.deviceDeployed( device, deviceDeployment.lastUpdateDate ) }
     }
 
     @Test
@@ -582,7 +583,7 @@ class StudyDeploymentTest
         val deployment = studyDeploymentFor( protocol )
         deployment.registerDevice( device, device.createRegistration() )
         val deviceDeployment = deployment.getDeviceDeploymentFor( device )
-        deployment.deviceDeployed( device, deviceDeployment.getChecksum() )
+        deployment.deviceDeployed( device, deviceDeployment.lastUpdateDate )
 
         assertTrue( deployment.getStatus() is StudyDeploymentStatus.DeploymentReady )
 
@@ -623,7 +624,7 @@ class StudyDeploymentTest
         assertFailsWith<IllegalStateException> { deployment.registerDevice( connected, connected.createRegistration() ) }
         assertFailsWith<IllegalStateException> { deployment.unregisterDevice( master ) }
         val deviceDeployment = deployment.getDeviceDeploymentFor( master )
-        assertFailsWith<IllegalStateException> { deployment.deviceDeployed( master, deviceDeployment.getChecksum() ) }
+        assertFailsWith<IllegalStateException> { deployment.deviceDeployed( master, deviceDeployment.lastUpdateDate ) }
         val account = Account.withUsernameIdentity( "Test" )
         val participation = Participation( deployment.id )
         assertFailsWith<IllegalStateException> { deployment.addParticipation( account, participation ) }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployment.infrastructure
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.ServiceInvoker
 import dk.cachet.carp.common.users.UsernameAccountIdentity
@@ -26,7 +27,7 @@ class DeploymentServiceRequestsTest
             DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration( "Device ID" ) ),
             DeploymentServiceRequest.UnregisterDevice( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.GetDeviceDeploymentFor( UUID.randomUUID(), "Test role" ),
-            DeploymentServiceRequest.DeploymentSuccessful( UUID.randomUUID(), "Test role", 0 ),
+            DeploymentServiceRequest.DeploymentSuccessful( UUID.randomUUID(), "Test role", DateTime.now() ),
             DeploymentServiceRequest.Stop( UUID.randomUUID() ),
             DeploymentServiceRequest.AddParticipation( UUID.randomUUID(), setOf( "Phone" ), UsernameAccountIdentity( "Test" ), StudyInvitation.empty() ),
             DeploymentServiceRequest.GetParticipationInvitations( UUID.randomUUID() )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/DeviceRegistration.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/DeviceRegistration.kt
@@ -1,8 +1,10 @@
 package dk.cachet.carp.protocols.domain.devices
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.Immutable
 import dk.cachet.carp.common.serialization.NotSerializable
 import dk.cachet.carp.protocols.domain.notImmutableErrorFor
+import dk.cachet.carp.protocols.domain.StudyProtocol
 import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.Serializable
 
@@ -21,6 +23,8 @@ abstract class DeviceRegistration : Immutable( notImmutableErrorFor( DeviceRegis
      * TODO: This might be useful for potential optimizations later (e.g., prevent pulling in data from the same source more than once), but for now is ignored.
      */
     abstract val deviceId: String
+
+    val registrationCreationDate: DateTime = DateTime.now()
 }
 
 


### PR DESCRIPTION
This is a more robust implementation to verify on `deviceDeployed` whether the most recent `MasterDeviceDeployment` was deployed.

- Added `registrationCreationDate` to `DeviceRegistration`.
- `MasterDeviceDeployment.lastUpdateDate` is set upon creation to max `registrationCreationDate` of device registrations present in the `MasterDeviceDeployment`. Thus, no additional state needs to be stored on the backend (other than the added `registrationCreationDate`.

This fixes https://github.com/cph-cachet/carp.core-kotlin/issues/135