### PR TITLE
Fix protocol description from snapshot

### DIFF
--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -56,7 +56,7 @@ class StudyProtocol(
         fun fromSnapshot( snapshot: StudyProtocolSnapshot ): StudyProtocol
         {
             val owner = ProtocolOwner( snapshot.ownerId )
-            val protocol = StudyProtocol( owner, snapshot.name )
+            val protocol = StudyProtocol( owner, snapshot.name, snapshot.description )
             protocol.creationDate = snapshot.creationDate
 
             // Add master devices.

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
@@ -61,7 +61,7 @@ fun createEmptyProtocol(): StudyProtocol
     JSON = createProtocolsSerializer( STUBS_SERIAL_MODULE )
 
     val alwaysSameOwner = ProtocolOwner( UUID( "27879e75-ccc1-4866-9ab3-4ece1b735052" ) )
-    return StudyProtocol( alwaysSameOwner, "Test protocol" )
+    return StudyProtocol( alwaysSameOwner, "Test protocol", "Test description" )
 }
 
 /**


### PR DESCRIPTION
The dangers of default values :) The protocol description was not set correctly when using  the `StudyProtocol.fromSnapshot()` factory.