### PR TITLE
Ease querying for participation invitation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,10 @@ val deploymentService = createDeploymentEndpoint()
 
 // Retrieve invitation to participate in the study using a specific device.
 val account: Account = getLoggedInUser()
-val invitation: ParticipationInvitation = deploymentService.getParticipationInvitations( account.id ).first()
+val invitation: ActiveParticipationInvitation =
+	deploymentService.getActiveParticipationInvitations( account.id ).first()
 val studyDeploymentId: UUID = invitation.participation.studyDeploymentId
-val deviceToUse: String = invitation.deviceRoleNames.first() // This matches "Patient's phone".
+val deviceToUse: String = invitation.devices.first().deviceRoleName // This matches "Patient's phone".
 
 // Create a study runtime for the study.
 val clientRepository = createRepository()

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/ClientCodeSamples.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/ClientCodeSamples.kt
@@ -8,7 +8,7 @@ import dk.cachet.carp.common.users.Account
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.deployment.application.DeploymentServiceHost
-import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
+import dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.deployment.infrastructure.InMemoryAccountService
 import dk.cachet.carp.deployment.infrastructure.InMemoryDeploymentRepository
@@ -28,9 +28,10 @@ class ClientCodeSamples
 
         // Retrieve invitation to participate in the study using a specific device.
         val account: Account = getLoggedInUser()
-        val invitation: ParticipationInvitation = deploymentService.getParticipationInvitations( account.id ).first()
+        val invitation: ActiveParticipationInvitation =
+            deploymentService.getActiveParticipationInvitations( account.id ).first()
         val studyDeploymentId: UUID = invitation.participation.studyDeploymentId
-        val deviceToUse: String = invitation.deviceRoleNames.first() // This matches "Patient's phone".
+        val deviceToUse: String = invitation.devices.first().deviceRoleName // This matches "Patient's phone".
 
         // Create a study runtime for the study.
         val clientRepository = createRepository()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -5,8 +5,8 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
+import dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.Participation
-import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.InvalidConfigurationError
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
@@ -116,7 +116,7 @@ interface DeploymentService
     suspend fun addParticipation( studyDeploymentId: UUID, deviceRoleNames: Set<String>, identity: AccountIdentity, invitation: StudyInvitation ): Participation
 
     /**
-     * Get all participations in study deployments the account with the given [accountId] has been invited to.
+     * Get all participations of active study deployments the account with the given [accountId] has been invited to.
      */
-    suspend fun getParticipationInvitations( accountId: UUID ): Set<ParticipationInvitation>
+    suspend fun getActiveParticipationInvitations( accountId: UUID ): Set<ActiveParticipationInvitation>
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt
@@ -88,4 +88,11 @@ sealed class StudyDeploymentStatus
     fun getDeviceStatus( device: AnyDeviceDescriptor ): DeviceDeploymentStatus =
         devicesStatus.firstOrNull { it.device == device }
             ?: throw IllegalArgumentException( "The given device was not found in this study deployment." )
+
+    /**
+     * Get the status of a device with the given [deviceRoleName] in this study deployment.
+     */
+    fun getDeviceStatus( deviceRoleName: String ): DeviceDeploymentStatus =
+        devicesStatus.firstOrNull { it.device.roleName == deviceRoleName }
+            ?: throw IllegalArgumentException( "The a device with the given role name was not found in this study deployment." )
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ActiveParticipationInvitation.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ActiveParticipationInvitation.kt
@@ -1,0 +1,27 @@
+package dk.cachet.carp.deployment.domain.users
+
+import kotlinx.serialization.Serializable
+
+
+/**
+ * An [invitation] to participate in an active study deployment using the specified master [devices].
+ * Some of the devices which the participant is invited to might already be registered.
+ * If the participant wants to use a different device, they will need to unregister the existing device first.
+ */
+@Serializable
+data class ActiveParticipationInvitation(
+    val participation: Participation,
+    val invitation: StudyInvitation,
+    val devices: Set<DeviceInvitation>
+)
+{
+    @Serializable
+    data class DeviceInvitation(
+        val deviceRoleName: String,
+        /**
+         * True when the device is already registered in the study deployment; false otherwise.
+         * In case a device is registered, it needs to be unregistered first before a new device can be registered.
+         */
+        val isRegistered: Boolean
+    )
+}

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationService.kt
@@ -11,6 +11,8 @@ object ParticipationService
      * Filter the given [invitations] to only return those that have active study deployments.
      * This subset is returned as [ActiveParticipationInvitation]s,
      * appending the current device registration status to the devices the participant was invited to use.
+     *
+     * @throws IllegalArgumentException when a deployment for one of the [invitations] is missing in [deployments].
      */
     fun filterActiveParticipationInvitations(
         invitations: Set<ParticipationInvitation>,
@@ -21,7 +23,7 @@ object ParticipationService
             .map { it to (
                 deployments.firstOrNull { d -> d.id == it.participation.studyDeploymentId }
                     ?.getStatus()
-                    ?: error( "No deployment is passed to pair with one of the given invitations." )
+                    ?: throw IllegalArgumentException( "No deployment is passed to pair with one of the given invitations." )
             ) }
             .filter { it.second !is StudyDeploymentStatus.Stopped }
             .map {

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationService.kt
@@ -12,7 +12,8 @@ object ParticipationService
      * This subset is returned as [ActiveParticipationInvitation]s,
      * appending the current device registration status to the devices the participant was invited to use.
      *
-     * @throws IllegalArgumentException when a deployment for one of the [invitations] is missing in [deployments].
+     * @throws IllegalArgumentException when a deployment for one of the [invitations] is missing in [deployments],
+     * or when the device roles specified in [invitations] do not match the deployment.
      */
     fun filterActiveParticipationInvitations(
         invitations: Set<ParticipationInvitation>,

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationService.kt
@@ -1,0 +1,40 @@
+package dk.cachet.carp.deployment.domain.users
+
+import dk.cachet.carp.deployment.domain.DeviceDeploymentStatus
+import dk.cachet.carp.deployment.domain.StudyDeployment
+import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
+
+
+object ParticipationService
+{
+    /**
+     * Filter the given [invitations] to only return those that have active study deployments.
+     * This subset is returned as [ActiveParticipationInvitation]s,
+     * appending the current device registration status to the devices the participant was invited to use.
+     */
+    fun filterActiveParticipationInvitations(
+        invitations: Set<ParticipationInvitation>,
+        deployments: List<StudyDeployment>
+    ): Set<ActiveParticipationInvitation>
+    {
+        return invitations
+            .map { it to (
+                deployments.firstOrNull { d -> d.id == it.participation.studyDeploymentId }
+                    ?.getStatus()
+                    ?: error( "No deployment is passed to pair with one of the given invitations." )
+            ) }
+            .filter { it.second !is StudyDeploymentStatus.Stopped }
+            .map {
+                ActiveParticipationInvitation(
+                    it.first.participation,
+                    it.first.invitation,
+                    it.first.deviceRoleNames.map { deviceRoleName ->
+                        ActiveParticipationInvitation.DeviceInvitation(
+                            deviceRoleName,
+                            it.second.getDeviceStatus( deviceRoleName ) is DeviceDeploymentStatus.Registered
+                        )
+                    }.toSet()
+                )
+            }.toSet()
+    }
+}

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -8,8 +8,8 @@ import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
+import dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.Participation
-import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
@@ -76,7 +76,7 @@ sealed class DeploymentServiceRequest
         Invoker<Participation> by createServiceInvoker( Service::addParticipation, studyDeploymentId, deviceRoleNames, identity, invitation )
 
     @Serializable
-    data class GetParticipationInvitations( val accountId: UUID ) :
+    data class GetActiveParticipationInvitations( val accountId: UUID ) :
         DeploymentServiceRequest(),
-        Invoker<Set<ParticipationInvitation>> by createServiceInvoker( Service::getParticipationInvitations, accountId )
+        Invoker<Set<ActiveParticipationInvitation>> by createServiceInvoker( Service::getActiveParticipationInvitations, accountId )
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -5,8 +5,8 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
+import dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.Participation
-import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
@@ -25,7 +25,7 @@ class DeploymentServiceMock(
     private val getDeviceDeploymentForResult: MasterDeviceDeployment = emptyMasterDeviceDeployment,
     private val deploymentSuccessfulResult: StudyDeploymentStatus = emptyStatus,
     private val stopResult: StudyDeploymentStatus = emptyStatus,
-    private val getParticipationInvitationResult: Set<ParticipationInvitation> = emptySet()
+    private val getActiveParticipationInvitationResult: Set<ActiveParticipationInvitation> = emptySet()
 ) : Mock<Service>(), Service
 {
     companion object
@@ -75,7 +75,7 @@ class DeploymentServiceMock(
         Participation( studyDeploymentId )
         .also { trackSuspendCall( Service::addParticipation, studyDeploymentId, deviceRoleNames, identity, invitation ) }
 
-    override suspend fun getParticipationInvitations( accountId: UUID ) =
-        getParticipationInvitationResult
-        .also { trackSuspendCall( Service::getParticipationInvitations, accountId ) }
+    override suspend fun getActiveParticipationInvitations( accountId: UUID ) =
+        getActiveParticipationInvitationResult
+        .also { trackSuspendCall( Service::getActiveParticipationInvitations, accountId ) }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
@@ -4,8 +4,8 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.deployment.domain.users.AccountService
+import dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.Participation
-import dk.cachet.carp.deployment.domain.users.ParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.infrastructure.test.createSingleMasterWithConnectedDeviceProtocol
 import dk.cachet.carp.test.runBlockingTest
@@ -239,8 +239,9 @@ abstract class DeploymentServiceTest
         val participation = deploymentService.addParticipation( studyDeploymentId, setOf( deviceRoleName ), identity, invitation )
         val account = accountService.findAccount( identity )
         assertNotNull( account )
-        val retrievedInvitations = deploymentService.getParticipationInvitations( account.id )
-        assertEquals( ParticipationInvitation( participation, invitation, setOf( deviceRoleName ) ), retrievedInvitations.single() )
+        val retrievedInvitations = deploymentService.getActiveParticipationInvitations( account.id )
+        val expectedDeviceInvitation = ActiveParticipationInvitation.DeviceInvitation( deviceRoleName, false )
+        assertEquals( ActiveParticipationInvitation( participation, invitation, setOf( expectedDeviceInvitation ) ), retrievedInvitations.single() )
     }
 
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.users.Account
 import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
+import dk.cachet.carp.protocols.infrastructure.test.createSingleMasterDeviceProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSingleMasterWithConnectedDeviceProtocol
 
 
@@ -43,3 +44,19 @@ fun createComplexDeployment(): StudyDeployment
 
     return deployment
 }
+
+/**
+ * Creates a study deployment that is active (not stopped) for a study protocol with a single master device.
+ */
+fun createActiveDeployment( masterDeviceRoleName: String ): StudyDeployment
+{
+    val protocol = createSingleMasterDeviceProtocol( masterDeviceRoleName )
+
+    return studyDeploymentFor( protocol )
+}
+
+/**
+ * Creates a stopped study deployment for a study protocol with a single master device.
+ */
+fun createStoppedDeployment( masterDeviceRoleName: String ): StudyDeployment =
+    createActiveDeployment( masterDeviceRoleName ).apply { stop() }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationServiceTest.kt
@@ -1,0 +1,84 @@
+package dk.cachet.carp.deployment.domain.users
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.deployment.domain.createActiveDeployment
+import dk.cachet.carp.deployment.domain.createStoppedDeployment
+import kotlin.test.*
+
+
+/**
+ * Tests for [ParticipationService].
+ */
+class ParticipationServiceTest
+{
+    @Test
+    fun filterActiveParticipationInvitations_only_returns_active_deployments()
+    {
+        val deviceRole = "Participant's phone"
+        val activeDeployment = createActiveDeployment( deviceRole )
+        val stoppedDeployment = createStoppedDeployment( deviceRole )
+
+        val participation = Participation( activeDeployment.id )
+        val invitation = ParticipationInvitation( participation, StudyInvitation.empty(), setOf( deviceRole ) )
+
+        val activeInvitations = ParticipationService.filterActiveParticipationInvitations(
+            setOf( invitation ),
+            listOf( activeDeployment, stoppedDeployment )
+        )
+
+        assertEquals( participation, activeInvitations.single().participation )
+    }
+
+    @Test
+    fun filterActiveParticipationInvitations_includes_device_registration_state()
+    {
+        val deviceRole = "Participant's phone"
+        val deployment = createActiveDeployment( deviceRole )
+
+        val participation = Participation( deployment.id )
+        val invitation = ParticipationInvitation( participation, StudyInvitation.empty(), setOf( deviceRole ) )
+
+        // When the device is not registered in the deployment, this is communicated in the active invitation.
+        var activeInvitation = ParticipationService.filterActiveParticipationInvitations(
+            setOf( invitation ),
+            listOf( deployment )
+        ).first()
+        assertFalse( activeInvitation.devices.first { it.deviceRoleName == deviceRole }.isRegistered )
+
+        // Once the device is registered, this is communicated in the active invitation.
+        val toRegister = deployment.registrableDevices.first { it.device.roleName == deviceRole }.device
+        deployment.registerDevice( toRegister, toRegister.createRegistration() )
+        activeInvitation = ParticipationService.filterActiveParticipationInvitations(
+            setOf( invitation ),
+            listOf( deployment )
+        ).first()
+        assertTrue( activeInvitation.devices.first { it.deviceRoleName == deviceRole }.isRegistered )
+    }
+
+    @Test
+    fun filterActiveParticipationInvitations_fails_when_required_deployment_is_not_passed()
+    {
+        val unknownDeployment = UUID.randomUUID()
+        val participation = Participation( unknownDeployment )
+        val invitation = ParticipationInvitation( participation, StudyInvitation.empty(), setOf( "Smartphone" ) )
+
+        assertFailsWith<IllegalArgumentException>
+        {
+            ParticipationService.filterActiveParticipationInvitations( setOf( invitation ), emptyList() )
+        }
+    }
+
+    @Test
+    fun filterActiveParticipationInvitations_fails_when_participation_device_role_does_not_match()
+    {
+        val deployment = createActiveDeployment( "Master" )
+
+        val participation = Participation( deployment.id )
+        val invitation = ParticipationInvitation( participation, StudyInvitation.empty(), setOf( "Incorrect device role" ) )
+
+        assertFailsWith<IllegalArgumentException>
+        {
+            ParticipationService.filterActiveParticipationInvitations( setOf( invitation ), listOf( deployment ) )
+        }
+    }
+}

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -30,7 +30,7 @@ class DeploymentServiceRequestsTest
             DeploymentServiceRequest.DeploymentSuccessful( UUID.randomUUID(), "Test role", DateTime.now() ),
             DeploymentServiceRequest.Stop( UUID.randomUUID() ),
             DeploymentServiceRequest.AddParticipation( UUID.randomUUID(), setOf( "Phone" ), UsernameAccountIdentity( "Test" ), StudyInvitation.empty() ),
-            DeploymentServiceRequest.GetParticipationInvitations( UUID.randomUUID() )
+            DeploymentServiceRequest.GetActiveParticipationInvitations( UUID.randomUUID() )
         )
     }
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
@@ -65,6 +65,17 @@ fun createEmptyProtocol(): StudyProtocol
 }
 
 /**
+ * Creates a study protocol with a single master device.
+ */
+fun createSingleMasterDeviceProtocol( masterDeviceName: String = "Master" ): StudyProtocol
+{
+    val protocol = createEmptyProtocol()
+    val master = StubMasterDeviceDescriptor( masterDeviceName )
+    protocol.addMasterDevice( master )
+    return protocol
+}
+
+/**
  * Creates a study protocol with a single master device which has a single connected device.
  */
 fun createSingleMasterWithConnectedDeviceProtocol(


### PR DESCRIPTION
Fixes #140 

I decided to load the `ParticipationInvitation` and `StudyDeployments` in the application service (`DeploymentService`) and pass those to the newly introduced domain service (`ParticipationService`) which merely processes these domain objects. The alternative would be letting `ParticipationService` depend on `DeploymentRepository`.

But, maybe it is a good guideline to only inject infrastructure dependencies into application services? It felt right, but have not thought this 100% through. Feedback welcome. But a simple approve is fine as well. :)