### PR TITLE
Add `creationDate` to `AggregateRoot`.

### DIFF
--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
@@ -77,6 +77,7 @@ class StudyRuntime private constructor(
 
         internal fun fromSnapshot( snapshot: StudyRuntimeSnapshot ): StudyRuntime =
             StudyRuntime( snapshot.studyDeploymentId, snapshot.device ).apply {
+                creationDate = snapshot.creationDate
                 isDeployed = snapshot.isDeployed
                 deploymentInformation = snapshot.deploymentInformation
             }

--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntimeSnapshot.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntimeSnapshot.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.client.domain
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.Snapshot
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
@@ -11,6 +12,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class StudyRuntimeSnapshot(
     val studyDeploymentId: UUID,
+    override val creationDate: DateTime,
     @Serializable( DeviceDescriptorSerializer::class )
     val device: AnyMasterDeviceDescriptor,
     val isDeployed: Boolean,
@@ -21,7 +23,12 @@ data class StudyRuntimeSnapshot(
     {
         fun fromStudyRuntime( studyRuntime: StudyRuntime ): StudyRuntimeSnapshot
         {
-            return StudyRuntimeSnapshot( studyRuntime.studyDeploymentId, studyRuntime.device, studyRuntime.isDeployed, studyRuntime.deploymentInformation )
+            return StudyRuntimeSnapshot(
+                studyRuntime.studyDeploymentId,
+                studyRuntime.creationDate,
+                studyRuntime.device,
+                studyRuntime.isDeployed,
+                studyRuntime.deploymentInformation )
         }
     }
 

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
@@ -114,6 +114,7 @@ class StudyRuntimeTest
         val parsed = StudyRuntimeSnapshot.fromJson( serialized )
 
         assertEquals( runtime.studyDeploymentId, parsed.studyDeploymentId )
+        assertEquals( runtime.creationDate, parsed.creationDate )
         assertEquals( runtime.device, parsed.device )
         assertEquals( runtime.isDeployed, parsed.isDeployed )
         assertEquals( runtime.deploymentInformation, parsed.deploymentInformation )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/AggregateRoot.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/AggregateRoot.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.ddd
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.Immutable
 
 
@@ -9,6 +10,12 @@ import dk.cachet.carp.common.Immutable
  */
 abstract class AggregateRoot<TRoot, TSnapshot : Snapshot<TRoot>, TEvent : Immutable>
 {
+    /**
+     * The date when this object was created.
+     */
+    var creationDate: DateTime = DateTime.now()
+        protected set
+
     private val events: MutableList<TEvent> = mutableListOf()
 
     /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/Snapshot.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/Snapshot.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.ddd
 
+import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.Immutable
 
 
@@ -8,6 +9,9 @@ import dk.cachet.carp.common.Immutable
  */
 abstract class Snapshot<TAggregateRoot> : Immutable()
 {
+    abstract val creationDate: DateTime
+
+
     /**
      * Load the aggregate root object from this snapshot.
      */

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -48,6 +48,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
         fun fromSnapshot( snapshot: StudyDeploymentSnapshot ): StudyDeployment
         {
             val deployment = StudyDeployment( snapshot.studyProtocolSnapshot, snapshot.studyDeploymentId )
+            deployment.creationDate = snapshot.creationDate
             deployment.startTime = snapshot.startTime
 
             // Replay device registration history.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class StudyDeploymentSnapshot(
     val studyDeploymentId: UUID,
+    override val creationDate: DateTime,
     val studyProtocolSnapshot: StudyProtocolSnapshot,
     val registeredDevices: Set<String>,
     val deviceRegistrationHistory: Map<String, List<@Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>>,
@@ -37,6 +38,7 @@ data class StudyDeploymentSnapshot(
         {
             return StudyDeploymentSnapshot(
                 studyDeployment.id,
+                studyDeployment.creationDate,
                 studyDeployment.protocolSnapshot,
                 studyDeployment.registeredDevices.map { it.key.roleName }.toSet(),
                 studyDeployment.deviceRegistrationHistory.mapKeys { it.key.roleName },

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
@@ -266,6 +266,7 @@ class StudyDeploymentTest
         val fromSnapshot = StudyDeployment.fromSnapshot( snapshot )
 
         assertEquals( deployment.id, fromSnapshot.id )
+        assertEquals( deployment.creationDate, fromSnapshot.creationDate )
         assertEquals( deployment.protocolSnapshot, fromSnapshot.protocolSnapshot )
         assertEquals(
             deployment.registrableDevices.count(),

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -1,6 +1,5 @@
 package dk.cachet.carp.protocols.domain
 
-import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.Immutable
 import dk.cachet.carp.protocols.domain.deployment.DeploymentError
 import dk.cachet.carp.protocols.domain.deployment.DeploymentIssue
@@ -91,12 +90,6 @@ class StudyProtocol(
         }
     }
 
-
-    /**
-     * The date when this protocol was created.
-     */
-    var creationDate: DateTime = DateTime.now()
-        private set
 
     /**
      * Add a master device which is responsible for aggregating and synchronizing incoming data.

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolSnapshot.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolSnapshot.kt
@@ -22,7 +22,7 @@ data class StudyProtocolSnapshot(
     val ownerId: UUID,
     val name: String,
     val description: String,
-    val creationDate: DateTime,
+    override val creationDate: DateTime,
     val masterDevices: List<@Serializable( MasterDeviceDescriptorSerializer::class ) AnyMasterDeviceDescriptor>,
     val connectedDevices: List<@Serializable( DeviceDescriptorSerializer::class ) AnyDeviceDescriptor>,
     val connections: List<DeviceConnection>,

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/Study.kt
@@ -1,6 +1,5 @@
 package dk.cachet.carp.studies.domain
 
-import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.Immutable
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.AggregateRoot
@@ -103,12 +102,6 @@ class Study(
             field = value
             event( Event.InvitationChanged( invitation ) )
         }
-
-    /**
-     * The date when this study was created.
-     */
-    var creationDate: DateTime = DateTime.now()
-        private set
 
     /**
      * Get the status (serializable) of this [Study].

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudySnapshot.kt
@@ -16,7 +16,7 @@ data class StudySnapshot(
     val name: String,
     val description: String,
     val invitation: StudyInvitation,
-    val creationDate: DateTime,
+    override val creationDate: DateTime,
     val protocolSnapshot: StudyProtocolSnapshot?,
     val isLive: Boolean,
     val participations: Map<UUID, Set<DeanonymizedParticipation>>

--- a/carp.test/package-lock.json
+++ b/carp.test/package-lock.json
@@ -2,11 +2,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
-    },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -105,21 +100,6 @@
         }
       }
     },
-    "chokidar": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
-      "requires": {
-        "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
-        "glob-parent": "~5.1.0",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.2.0"
-      }
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -193,11 +173,6 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
-    },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -299,9 +274,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "optional": true
     },
     "function-bind": {
@@ -313,27 +288,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-      "requires": {
-        "is-glob": "^4.0.1"
-      }
     },
     "global-modules": {
       "version": "1.0.0",
@@ -546,40 +500,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "requires": {
-        "chalk": "^2.0.1"
-      }
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
-      "requires": {
-        "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
       }
     },
     "mocha": {
@@ -664,6 +590,14 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "requires": {
+            "is-glob": "^4.0.1"
           }
         },
         "has-flag": {
@@ -817,15 +751,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
-    "node-environment-flags": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
-      "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -850,15 +775,6 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
       }
     },
     "once": {
@@ -922,14 +838,6 @@
         "iterate-value": "^1.0.0"
       }
     },
-    "readdirp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
-      "requires": {
-        "picomatch": "^2.0.4"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -948,11 +856,6 @@
         "expand-tilde": "^2.0.0",
         "global-modules": "^1.0.0"
       }
-    },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "serialize-javascript": {
       "version": "3.0.0",
@@ -1002,19 +905,6 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
         "ansi-regex": "^3.0.0"
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "supports-color": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
-      "requires": {
-        "has-flag": "^3.0.0"
       }
     },
     "to-regex-range": {


### PR DESCRIPTION
I was about to add `creationDate` to `StudyDeployment`. It seems like `creationDate` can be expected to be a desirable property of any aggregate root domain object.

We currently had it in `Study` and `StudyProtocol`. Adding it to `StudyDeployment` would mean the only aggregate root that does not have it is `StudyRuntime`.

This PR also adds it to `StudyRuntime`; does this make sense or is it a premature generalization?