### PR TITLE
Add `StudyInvitation.applicationData` to pass infrastructure-specific data to clients.

### DIFF
--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/StudyInvitation.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/StudyInvitation.kt
@@ -15,7 +15,14 @@ data class StudyInvitation(
     /**
      * A description of the study clarifying to participants what it is about.
      */
-    val description: String
+    val description: String,
+    /**
+     * Application-specific data to be shared with clients when they are invited to a study.
+     *
+     * This can be used by infrastructures or concrete applications which require exchanging additional data
+     * between the study and client subsystems, outside of scope or not yet supported by CARP core.
+     */
+    val applicationData: String = ""
 )
 {
     companion object

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
@@ -234,7 +234,7 @@ abstract class DeploymentServiceTest
         val deviceRoleName = "Test device"
         val studyDeploymentId = addTestDeployment( deploymentService, deviceRoleName )
         val identity = AccountIdentity.fromEmailAddress( "test@test.com" )
-        val invitation = StudyInvitation.empty()
+        val invitation = StudyInvitation( "Test study", "description", "Custom data" )
 
         val participation = deploymentService.addParticipation( studyDeploymentId, setOf( deviceRoleName ), identity, invitation )
         val account = accountService.findAccount( identity )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyInvitationTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/StudyInvitationTest.kt
@@ -10,13 +10,22 @@ import kotlin.test.*
 class StudyInvitationTest
 {
     @Test
-    fun can_serialize_and_deserialize_study_description_using_JSON()
+    fun can_serialize_and_deserialize_study_invitation_using_JSON()
     {
-        val invitation = StudyInvitation( "Test", "Description" )
+        val applicationData = """{"extraData":"42"}"""
+        val invitation = StudyInvitation( "Test", "Description", applicationData )
 
         val serialized = invitation.toJson()
         val parsed = StudyInvitation.fromJson( serialized )
 
         assertEquals( invitation, parsed )
+    }
+
+    @Test
+    fun can_deserialize_study_invitation_without_applicationData()
+    {
+        val serialized = """{"name":"Test","description":"Description"}"""
+
+        StudyInvitation.fromJson( serialized )
     }
 }


### PR DESCRIPTION
Fixes https://github.com/cph-cachet/carp.core-kotlin/issues/144