### PR TITLE
Kotlin 1.4.0 and serialization 1.0.0-RC upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ buildscript {
 
         versions = [
             // Kotlin multiplatform versions.
-            kotlin:'1.3.72',
-            serialization:'0.20.0',
-            coroutines:'1.3.7',
+            kotlin:'1.4.0',
+            serialization:'1.0.0-RC',
+            coroutines:'1.3.9',
 
             // JVM versions.
             jvmTarget:'1.6',
@@ -52,10 +52,7 @@ buildscript {
 
     repositories {
         jcenter()
-
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        gradlePluginPortal()
     }
 }
 
@@ -84,28 +81,19 @@ configure( subprojects - detektModule ) {
             compilations.main.kotlinOptions.jvmTarget = versions.jvmTarget
             compilations.test.kotlinOptions.jvmTarget = versions.jvmTarget
         }
-        js {
-            compilations.main.kotlinOptions {
-                metaInfo = true
-                sourceMap = true
-                moduleKind = 'umd'
-                main = "noCall"
-                sourceMapEmbedSources = 'always'
-            }
-            compilations.test.kotlinOptions {
-                metaInfo = true
-                sourceMap = true
-                moduleKind = 'umd'
-                main = "call"
-                sourceMapEmbedSources = 'always'
-            }
+        js(IR) {
+            binaries.executable()
+            browser()
         }
 
         sourceSets {
+            all {
+                // TODO: Find out which kotlinx.serialization features cause this and whether we can work around it.
+                languageSettings.useExperimentalAnnotation("kotlinx.serialization.InternalSerializationApi")
+            }
             commonMain {
                 dependencies {
-                    implementation kotlin('stdlib-common')
-                    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:${versions.serialization}"
+                    implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:${versions.serialization}"
                 }
             }
             commonTest {
@@ -114,24 +102,12 @@ configure( subprojects - detektModule ) {
                     implementation kotlin('test-annotations-common')
                 }
             }
-            jvmMain {
-                dependencies {
-                    implementation kotlin('stdlib-jdk8')
-                    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:${versions.serialization}"
-                }
-            }
             jvmTest {
                 dependencies {
                     implementation kotlin('test')
                     implementation kotlin('test-junit5')
                     implementation "org.junit.jupiter:junit-jupiter-api:${versions.jUnit5}"
                     runtimeOnly "org.junit.jupiter:junit-jupiter-engine:${versions.jUnit5}"
-                }
-            }
-            jsMain {
-                dependencies {
-                    implementation kotlin('stdlib-js')
-                    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-js:${versions.serialization}"
                 }
             }
             jsTest {
@@ -146,38 +122,6 @@ configure( subprojects - detektModule ) {
     jvmTest {
         useJUnitPlatform()
     }
-
-    // JS test configuration.
-    // This is adapted from kotlinx-io's build file; I do not fully understand this configuration:
-    // https://stackoverflow.com/a/55244288/590790
-    apply plugin: 'com.github.node-gradle.node'
-    task copyJsDependencies(type: Copy, dependsOn: compileTestKotlinJs) {
-        from compileKotlinJs.destinationDir
-        into "${buildDir}/node_modules"
-
-        def configuration = configurations.jsTestRuntimeClasspath
-        from(files {
-            configuration.collect { File file ->
-                file.name.endsWith(".jar")
-                        ? zipTree(file.absolutePath).matching {
-                    include '*.js'
-                    include '*.js.map' }
-                        : files()
-            }
-        }.builtBy(configuration))
-    }
-    node {
-        version = versions.node
-        download = true
-    }
-    task installMocha(type: NpmTask) {
-        args = ['install', "mocha@${versions.mocha}"]
-    }
-    task runMocha(type: NodeTask, dependsOn: [installMocha, compileTestKotlinJs, copyJsDependencies]) {
-        script = file('node_modules/mocha/bin/mocha')
-        args = [compileTestKotlinJs.outputFile]
-    }
-    jsTest.dependsOn runMocha
 
     // Publish configuration.
     // For signing and publishing to work, a 'publish.properties' file needs to be added to the root containing:
@@ -296,10 +240,11 @@ task setupTsProject(type: NpmTask) {
 task copyTestJsSources(type: Copy, dependsOn: setupTsProject) {
     // First compile all subprojects for which TypeScript declarations are defined.
     def projects = coreModules + commonModule
-    projects.each { dependsOn("${it.name}:compileKotlinJs") }
+    projects.each { dependsOn("${it.name}:jsBrowserDistribution") }
 
     projects.each {
         // Copy JS sources into ...
+        from "${it.projectDir}/build/distributions"
         from it.compileKotlinJs.destinationDir
         def configuration = it.configurations.jsTestRuntimeClasspath
         from(files {

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ configure( subprojects - detektModule ) {
             compilations.main.kotlinOptions.jvmTarget = versions.jvmTarget
             compilations.test.kotlinOptions.jvmTarget = versions.jvmTarget
         }
-        js(IR) {
+        js(LEGACY) {
             binaries.executable()
             browser()
         }

--- a/build.gradle
+++ b/build.gradle
@@ -243,19 +243,8 @@ task copyTestJsSources(type: Copy, dependsOn: setupTsProject) {
     projects.each { dependsOn("${it.name}:jsBrowserDistribution") }
 
     projects.each {
-        // Copy JS sources into ...
-        from "${it.projectDir}/build/distributions"
-        from it.compileKotlinJs.destinationDir
-        def configuration = it.configurations.jsTestRuntimeClasspath
-        from(files {
-            configuration.collect { File file ->
-                file.name.endsWith(".jar")
-                        ? zipTree(file.absolutePath).matching {
-                    include '*.js'
-                    include '*.js.map' }
-                        : files()
-            }
-        }.builtBy(configuration))
+        // Copy JS packages into ...
+        from "${it.rootDir}/build/js/node_modules"
 
         // ... 'node_modules' so that test can retrieve dependencies.
         into "./${typescriptFolder}/node_modules"
@@ -266,7 +255,11 @@ task verifyTsDeclarations(type: NodeTask, dependsOn: copyTestJsSources) {
     execOverrides {
         it.workingDir = typescriptFolder
     }
-    args = ['--require', 'ts-node/register', './tests/**/*.ts']
+    args = [
+        '--require', 'ts-node/register',
+        '--require', 'jsdom-global/register',
+        './tests/**/*.ts'
+    ]
 }
 
 // Add common dependencies:

--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/infrastructure/Serialization.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/infrastructure/Serialization.kt
@@ -9,7 +9,7 @@ import dk.cachet.carp.protocols.infrastructure.JSON
  */
 fun StudyRuntimeSnapshot.Companion.fromJson( json: String ): StudyRuntimeSnapshot
 {
-    return JSON.parse( serializer(), json )
+    return JSON.decodeFromString( serializer(), json )
 }
 
 /**
@@ -17,5 +17,5 @@ fun StudyRuntimeSnapshot.Companion.fromJson( json: String ): StudyRuntimeSnapsho
  */
 fun StudyRuntimeSnapshot.toJson(): String
 {
-    return JSON.stringify( StudyRuntimeSnapshot.serializer(), this )
+    return JSON.encodeToString( StudyRuntimeSnapshot.serializer(), this )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/DateTime.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/DateTime.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.common
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/RecurrenceRule.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/RecurrenceRule.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.common
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/TimeOfDay.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/TimeOfDay.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.common
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/UUID.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/UUID.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.common
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/CustomSerializerWrapper.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/CustomSerializerWrapper.kt
@@ -1,8 +1,7 @@
 package dk.cachet.carp.common.serialization
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.encode
-import kotlinx.serialization.Encoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer
@@ -19,7 +18,7 @@ class CustomSerializerWrapper internal constructor( val inner: Any, val serializ
     companion object : KSerializer<CustomSerializerWrapper>
     {
         override fun serialize( encoder: Encoder, value: CustomSerializerWrapper ) =
-            encoder.encode( value.serializer, value.inner )
+            encoder.encodeSerializableValue( value.serializer, value.inner )
 
         override fun deserialize( decoder: Decoder ): CustomSerializerWrapper =
             throw UnsupportedOperationException( "${CustomSerializerWrapper::class.simpleName} only supports serialization." )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/NotSerializable.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/NotSerializable.kt
@@ -1,10 +1,11 @@
 package dk.cachet.carp.common.serialization
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 
 
 /**
@@ -19,7 +20,7 @@ object NotSerializable : KSerializer<Any>
         "Types annotated as `@Serializable( with = NotSerializable::class )` are never expected to be serialized. " +
         "The serializer is only defined since the compiler does not know this, causing a compilation error." )
 
-    override val descriptor: SerialDescriptor = SerialDescriptor( "This should never be serialized." )
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor( "This should never be serialized." )
     override fun deserialize( decoder: Decoder ): Any = throw exception
     override fun serialize( encoder: Encoder, value: Any ) = throw exception
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/UnknownPolymorphicSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/UnknownPolymorphicSerializer.kt
@@ -1,18 +1,19 @@
 package dk.cachet.carp.common.serialization
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.PolymorphicKind
 import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.json.Json
 import kotlin.reflect.KClass
 
 
 internal val UnknownPolymorphicClassDesc =
-    SerialDescriptor( "kotlin.Any", PolymorphicKind.OPEN )
+    buildSerialDescriptor( "kotlin.Any", PolymorphicKind.OPEN )
     {
         element( "klass", String.serializer().descriptor )
         element( "object", PolymorphicSerializer( Any::class ).descriptor )

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/DateTimeTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/DateTimeTest.kt
@@ -35,8 +35,8 @@ class DateTimeTest
         val dateTime = DateTime.now()
 
         val json = createDefaultJSON()
-        val serialized = json.stringify( DateTime.serializer(), dateTime )
-        val parsed = json.parse( DateTime.serializer(), serialized )
+        val serialized = json.encodeToString( DateTime.serializer(), dateTime )
+        val parsed = json.decodeFromString( DateTime.serializer(), serialized )
 
         assertEquals( dateTime, parsed )
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/EmailAddressTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/EmailAddressTest.kt
@@ -15,8 +15,8 @@ class EmailAddressTest
         val email = EmailAddress( "test@test.com" )
 
         val json = createDefaultJSON()
-        val serialized: String = json.stringify( EmailAddress.serializer(), email )
-        val parsed: EmailAddress = json.parse( EmailAddress.serializer(), serialized )
+        val serialized: String = json.encodeToString( EmailAddress.serializer(), email )
+        val parsed: EmailAddress = json.decodeFromString( EmailAddress.serializer(), serialized )
 
         assertEquals( email, parsed )
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/RecurrenceRuleTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/RecurrenceRuleTest.kt
@@ -40,8 +40,8 @@ class RecurrenceRuleTest
         val rule = RecurrenceRule.daily( 2, RecurrenceRule.End.Count( 5 ) )
 
         val json = createDefaultJSON()
-        val serialized = json.stringify( RecurrenceRule.serializer(), rule )
-        val parsed = json.parse( RecurrenceRule.serializer(), serialized )
+        val serialized = json.encodeToString( RecurrenceRule.serializer(), rule )
+        val parsed = json.decodeFromString( RecurrenceRule.serializer(), serialized )
 
         assertEquals( rule, parsed )
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/TimeOfDayTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/TimeOfDayTest.kt
@@ -34,8 +34,8 @@ class TimeOfDayTest
         val time = TimeOfDay( 12 )
 
         val json = createDefaultJSON()
-        val serialized = json.stringify( TimeOfDay.serializer(), time )
-        val parsed = json.parse( TimeOfDay.serializer(), serialized )
+        val serialized = json.encodeToString( TimeOfDay.serializer(), time )
+        val parsed = json.decodeFromString( TimeOfDay.serializer(), serialized )
 
         assertEquals( time, parsed )
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/UUIDTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/UUIDTest.kt
@@ -16,8 +16,8 @@ class UUIDTest
         val id = UUID( "00000000-0000-0000-0000-000000000000" )
 
         val json = createDefaultJSON()
-        val serialized = json.stringify( UUID.serializer(), id )
-        val parsed = json.parse( UUID.serializer(), serialized )
+        val serialized = json.encodeToString( UUID.serializer(), id )
+        val parsed = json.decodeFromString( UUID.serializer(), serialized )
 
         assertEquals( id, parsed )
     }
@@ -31,13 +31,13 @@ class UUIDTest
         val json = createDefaultJSON()
 
         val id = Id( UUID( "00000000-0000-0000-0000-000000000000" ) )
-        val idSerialized = json.stringify( Id.serializer(), id )
-        val idParsed = json.parse( Id.serializer(), idSerialized )
+        val idSerialized = json.encodeToString( Id.serializer(), id )
+        val idParsed = json.decodeFromString( Id.serializer(), idSerialized )
         assertEquals( id, idParsed )
 
         val nullableId = Id( null )
-        val nullableSerialized = json.stringify( Id.serializer(), nullableId )
-        val nullableParsed = json.parse( Id.serializer(), nullableSerialized )
+        val nullableSerialized = json.encodeToString( Id.serializer(), nullableId )
+        val nullableParsed = json.decodeFromString( Id.serializer(), nullableSerialized )
         assertEquals( nullableId, nullableParsed )
     }
 
@@ -48,7 +48,7 @@ class UUIDTest
         val id = UUID( "00000000-0000-0000-0000-000000000000" )
 
         val json = createDefaultJSON()
-        val serialized = json.stringify( UUID.serializer(), id )
+        val serialized = json.encodeToString( UUID.serializer(), id )
 
         assertEquals( "\"${id.stringRepresentation}\"", serialized )
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/serialization/CustomSerializerWrapperTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/serialization/CustomSerializerWrapperTest.kt
@@ -2,7 +2,6 @@ package dk.cachet.carp.common.serialization
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.*
 
@@ -20,11 +19,11 @@ class CustomSerializerWrapperTest
     fun can_enforce_serializing_as_polymorph_base_class()
     {
         val wrapper = customSerializerWrapper( SealedBase.ExtendsSealed(), SealedBase.serializer() )
-        val json = Json( JsonConfiguration.Stable )
+        val json = Json {}
 
-        val serialized = json.stringify( CustomSerializerWrapper.serializer(), wrapper )
+        val serialized = json.encodeToString( CustomSerializerWrapper.serializer(), wrapper )
 
-        val jsonObject = json.parseJson( serialized ) as JsonObject
+        val jsonObject = json.parseToJsonElement( serialized ) as JsonObject
         assertTrue( jsonObject.contains( "type" ) )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/users/AccountTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/users/AccountTest.kt
@@ -16,8 +16,8 @@ class AccountTest
         var account = Account.withUsernameIdentity( "Test" )
 
         val json = createDefaultJSON()
-        val serialized = json.stringify( Account.serializer(), account )
-        val parsed = json.parse( Account.serializer(), serialized )
+        val serialized = json.encodeToString( Account.serializer(), account )
+        val parsed = json.decodeFromString( Account.serializer(), serialized )
 
         assertEquals( account, parsed )
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/users/UsernameTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/users/UsernameTest.kt
@@ -15,8 +15,8 @@ class UsernameTest
         val username = Username( "Test" )
 
         val json = createDefaultJSON()
-        val serialized: String = json.stringify( Username.serializer(), username )
-        val parsed: Username = json.parse( Username.serializer(), serialized )
+        val serialized: String = json.encodeToString( Username.serializer(), username )
+        val parsed: Username = json.decodeFromString( Username.serializer(), serialized )
 
         assertEquals( username, parsed )
     }

--- a/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/serialization/UnknownPolymorphicSerializer.kt
+++ b/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/serialization/UnknownPolymorphicSerializer.kt
@@ -53,9 +53,9 @@ actual abstract class UnknownPolymorphicSerializer<P : Any, W : P> actual constr
 
             // Output raw JSON as originally wrapped.
             // TODO: This relies on accessing private properties dynamically since no raw JSON can be output using KOutput.
-            val composer = encoder.asDynamic()._composer
+            val composer = encoder.asDynamic().composer_0
             val toPrint = "," + value.jsonSource // The ',' is needed since it is normally added by the Encoder which is not called here.
-            composer.print_4( toPrint ) // This is the generated 'print' function overload for strings.
+            composer.`print_61zpoe$`( toPrint ) // This is the generated 'print' function overload for strings.
         }
         else
         {
@@ -102,18 +102,18 @@ actual abstract class UnknownPolymorphicSerializer<P : Any, W : P> actual constr
         {
             // TODO: Currently, the following relies on accessing properties dynamically.
 
-            val reader = decoder.asDynamic()._reader_0
+            val reader = decoder.asDynamic().`reader_8be2vx$`
 
             // Get source string.
-            val jsonSource: String = reader._source as String
+            val jsonSource: String = reader.source_0 as String
 
             // Find starting position of the unknown object.
-            val start = reader._tokenPosition as Int
+            val start = reader.tokenPosition_0 as Int
 
             // Find end position of the unknown object by skipping to the next element.
             // Skipping the element is also needed since otherwise deserialization of subsequent elements fails.
             reader.skipElement()
-            val end = reader._tokenPosition as Int
+            val end = reader.tokenPosition_0 as Int
 
             // Initialize wrapper for unknown object based on source string.
             val elementSource = jsonSource.subSequence( start, end ).toString()

--- a/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/serialization/UnknownPolymorphicSerializer.kt
+++ b/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/serialization/UnknownPolymorphicSerializer.kt
@@ -1,13 +1,13 @@
 package dk.cachet.carp.common.serialization
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonInput
-import kotlinx.serialization.json.JsonOutput
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonDecoder
 import kotlin.reflect.KClass
 
 
@@ -39,7 +39,7 @@ actual abstract class UnknownPolymorphicSerializer<P : Any, W : P> actual constr
 
     actual override fun serialize( encoder: Encoder, value: P )
     {
-        if ( encoder !is JsonOutput )
+        if ( encoder !is JsonEncoder )
         {
             throw unsupportedException
         }
@@ -53,13 +53,13 @@ actual abstract class UnknownPolymorphicSerializer<P : Any, W : P> actual constr
 
             // Output raw JSON as originally wrapped.
             // TODO: This relies on accessing private properties dynamically since no raw JSON can be output using KOutput.
-            val composer = encoder.asDynamic().composer_0
+            val composer = encoder.asDynamic()._composer
             val toPrint = "," + value.jsonSource // The ',' is needed since it is normally added by the Encoder which is not called here.
-            composer.`print_61zpoe$`( toPrint ) // This is the generated 'print' function overload for strings.
+            composer.print_4( toPrint ) // This is the generated 'print' function overload for strings.
         }
         else
         {
-            val registeredSerializer = encoder.context.getPolymorphic( baseClass, value )
+            val registeredSerializer = encoder.serializersModule.getPolymorphic( baseClass, value )
                 ?: throw SerializationException( "${value.asDynamic().constructor.name} is not registered for polymorph serialization." )
 
             @Suppress( "UNCHECKED_CAST" )
@@ -74,7 +74,7 @@ actual abstract class UnknownPolymorphicSerializer<P : Any, W : P> actual constr
     actual override fun deserialize( decoder: Decoder ): P
     {
         // Get JSON serializer. This serializer assumes JSON serialization.
-        if ( decoder !is JsonInput )
+        if ( decoder !is JsonDecoder )
         {
             throw unsupportedException
         }
@@ -86,7 +86,7 @@ actual abstract class UnknownPolymorphicSerializer<P : Any, W : P> actual constr
         // Determine class to be loaded and whether it is available at runtime.
         decoder.decodeElementIndex( descriptor )
         val className = decoder.decodeStringElement( descriptor, 0 )
-        val registeredSerializer = decoder.context.getPolymorphic( baseClass, className )
+        val registeredSerializer = decoder.serializersModule.getPolymorphic( baseClass, className )
         val canLoadClass = registeredSerializer != null
 
         // Deserialize object when serializer is available, or wrap in case type is unknown.
@@ -102,18 +102,18 @@ actual abstract class UnknownPolymorphicSerializer<P : Any, W : P> actual constr
         {
             // TODO: Currently, the following relies on accessing properties dynamically.
 
-            val reader = decoder.asDynamic().`reader_8be2vx$`
+            val reader = decoder.asDynamic()._reader_0
 
             // Get source string.
-            val jsonSource: String = reader.source_0 as String
+            val jsonSource: String = reader._source as String
 
             // Find starting position of the unknown object.
-            val start = reader.tokenPosition_0 as Int
+            val start = reader._tokenPosition as Int
 
             // Find end position of the unknown object by skipping to the next element.
             // Skipping the element is also needed since otherwise deserialization of subsequent elements fails.
             reader.skipElement()
-            val end = reader.tokenPosition_0 as Int
+            val end = reader._tokenPosition as Int
 
             // Initialize wrapper for unknown object based on source string.
             val elementSource = jsonSource.subSequence( start, end ).toString()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/Serialization.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/Serialization.kt
@@ -12,9 +12,9 @@ import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.protocols.infrastructure.PROTOCOLS_SERIAL_MODULE
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.EmptyModule
+import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.plus
-import kotlinx.serialization.modules.SerialModule
+import kotlinx.serialization.modules.SerializersModule
 
 
 /**
@@ -22,7 +22,7 @@ import kotlinx.serialization.modules.SerialModule
  * This ensures a global configuration on how serialization should occur.
  * Additional types the serializer needs to be aware about (such as polymorph extending classes) should be registered through [module].
  */
-fun createDeploymentSerializer( module: SerialModule = EmptyModule ): Json
+fun createDeploymentSerializer( module: SerializersModule = EmptySerializersModule ): Json
 {
     return createDefaultJSON( PROTOCOLS_SERIAL_MODULE + module )
 }
@@ -38,82 +38,82 @@ var JSON: Json = createDeploymentSerializer()
  * Create a [Account] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun Account.Companion.fromJson( json: String ): Account =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun Account.toJson(): String =
-    JSON.stringify( Account.serializer(), this )
+    JSON.encodeToString( Account.serializer(), this )
 
 /**
  * Create a [Username] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun Username.Companion.fromJson( json: String ): Username =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun Username.toJson(): String =
-    JSON.stringify( Username.serializer(), this )
+    JSON.encodeToString( Username.serializer(), this )
 
 /**
  * Create a [Participation] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun Participation.Companion.fromJson( json: String ): Participation =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun Participation.toJson(): String =
-    JSON.stringify( Participation.serializer(), this )
+    JSON.encodeToString( Participation.serializer(), this )
 
 /**
  * Create a [StudyInvitation] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyInvitation.Companion.fromJson( json: String ): StudyInvitation =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyInvitation.toJson(): String =
-    JSON.stringify( StudyInvitation.serializer(), this )
+    JSON.encodeToString( StudyInvitation.serializer(), this )
 
 /**
  * Create a [StudyDeploymentSnapshot] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyDeploymentSnapshot.Companion.fromJson( json: String ): StudyDeploymentSnapshot =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyDeploymentSnapshot.toJson(): String =
-    JSON.stringify( StudyDeploymentSnapshot.serializer(), this )
+    JSON.encodeToString( StudyDeploymentSnapshot.serializer(), this )
 
 /**
  * Create a [StudyDeploymentStatus] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyDeploymentStatus.Companion.fromJson( json: String ): StudyDeploymentStatus =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyDeploymentStatus.toJson(): String =
-    JSON.stringify( StudyDeploymentStatus.serializer(), this )
+    JSON.encodeToString( StudyDeploymentStatus.serializer(), this )
 
 /**
  * Create a [MasterDeviceDeployment] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun MasterDeviceDeployment.Companion.fromJson( json: String ): MasterDeviceDeployment =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun MasterDeviceDeployment.toJson(): String =
-    JSON.stringify( MasterDeviceDeployment.serializer(), this )
+    JSON.encodeToString( MasterDeviceDeployment.serializer(), this )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentTest.kt
@@ -125,8 +125,8 @@ class StudyDeploymentTest
         val connected = StubDeviceDescriptor( "Unknown connected" )
 
         // Mimic that the types are unknown at runtime. When this occurs, they are wrapped in 'Custom...'.
-        val masterCustom = CustomMasterDeviceDescriptor( "Irrelevant", JSON.stringify( StubMasterDeviceDescriptor.serializer(), master ), JSON )
-        val connectedCustom = CustomDeviceDescriptor( "Irrelevant", JSON.stringify( StubDeviceDescriptor.serializer(), connected ), JSON )
+        val masterCustom = CustomMasterDeviceDescriptor( "Irrelevant", JSON.encodeToString( StubMasterDeviceDescriptor.serializer(), master ), JSON )
+        val connectedCustom = CustomDeviceDescriptor( "Irrelevant", JSON.encodeToString( StubDeviceDescriptor.serializer(), connected ), JSON )
 
         protocol.addMasterDevice( masterCustom )
         protocol.addConnectedDevice( connectedCustom, masterCustom )
@@ -164,8 +164,8 @@ class StudyDeploymentTest
         val device2 = StubDeviceDescriptor( "Unknown device 2" )
 
         // Mimic that the types are unknown at runtime. When this occurs, they are wrapped in 'Custom...'.
-        val device1Custom = CustomDeviceDescriptor( "One class", JSON.stringify( StubMasterDeviceDescriptor.serializer(), device1 ), JSON )
-        val device2Custom = CustomDeviceDescriptor( "Not the same class", JSON.stringify( StubDeviceDescriptor.serializer(), device2 ), JSON )
+        val device1Custom = CustomDeviceDescriptor( "One class", JSON.encodeToString( StubMasterDeviceDescriptor.serializer(), device1 ), JSON )
+        val device2Custom = CustomDeviceDescriptor( "Not the same class", JSON.encodeToString( StubDeviceDescriptor.serializer(), device2 ), JSON )
 
         protocol.addMasterDevice( master )
         protocol.addConnectedDevice( device1Custom, master )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -42,8 +42,8 @@ class DeploymentServiceRequestsTest
     {
         requests.forEach { request ->
             val serializer = DeploymentServiceRequest.serializer()
-            val serialized = JSON.stringify( serializer, request )
-            val parsed = JSON.parse( serializer, serialized )
+            val serialized = JSON.encodeToString( serializer, request )
+            val parsed = JSON.decodeFromString( serializer, serialized )
             assertEquals( request, parsed )
         }
     }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/Smartphone.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/Smartphone.kt
@@ -30,7 +30,7 @@ data class Smartphone(
         /**
          * A factory to create measures for sensors commonly available on smartphones.
          */
-        val Sensors: PhoneSensorMeasure.Factory = PhoneSensorMeasure.Factory
+        val Sensors: PhoneSensorMeasure.Companion = PhoneSensorMeasure.Companion
 
         /**
          * All the data types and sampling schemes of sensor commonly available on smartphones.

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/UnknownDeviceSerializers.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/UnknownDeviceSerializers.kt
@@ -9,9 +9,10 @@ import dk.cachet.carp.protocols.domain.data.SamplingConfiguration
 import dk.cachet.carp.protocols.domain.data.SamplingConfigurationSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.json.content
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.reflect.KClass
 
 
@@ -26,11 +27,11 @@ data class CustomDeviceDescriptor( override val className: String, override val 
 
     init
     {
-        val json = serializer.parseJson( jsonSource ) as JsonObject
+        val json = serializer.parseToJsonElement( jsonSource ) as JsonObject
 
         val roleNameField = AnyDeviceDescriptor::roleName.name
         require( roleNameField in json.keys ) { "No '$roleNameField' defined." }
-        roleName = json[ roleNameField ]!!.content
+        roleName = json[ roleNameField ]!!.jsonPrimitive.content
 
         val samplingConfigurationField = AnyDeviceDescriptor::samplingConfiguration.name
         samplingConfiguration =
@@ -38,7 +39,7 @@ data class CustomDeviceDescriptor( override val className: String, override val 
             {
                 val configurationJson: String = json[ samplingConfigurationField ]!!.jsonArray.toString()
                 val configurationSerializer = MapSerializer( DataType.serializer(), SamplingConfigurationSerializer )
-                serializer.parse( configurationSerializer, configurationJson )
+                serializer.decodeFromString( configurationSerializer, configurationJson )
             }
             else emptyMap()
     }
@@ -65,11 +66,11 @@ data class CustomMasterDeviceDescriptor( override val className: String, overrid
 
     init
     {
-        val json = serializer.parseJson( jsonSource ) as JsonObject
+        val json = serializer.parseToJsonElement( jsonSource ) as JsonObject
 
         val roleNameField = AnyMasterDeviceDescriptor::roleName.name
         require( roleNameField in json.keys ) { "No '$roleNameField' defined." }
-        roleName = json[ roleNameField ]!!.content
+        roleName = json[ roleNameField ]!!.jsonPrimitive.content
 
         val samplingConfigurationField = AnyDeviceDescriptor::samplingConfiguration.name
         samplingConfiguration =
@@ -77,7 +78,7 @@ data class CustomMasterDeviceDescriptor( override val className: String, overrid
             {
                 val configurationJson: String = json[ samplingConfigurationField ]!!.jsonArray.toString()
                 val configurationSerializer = MapSerializer( DataType.serializer(), SamplingConfigurationSerializer )
-                serializer.parse( configurationSerializer, configurationJson )
+                serializer.decodeFromString( configurationSerializer, configurationJson )
             }
             else emptyMap()
     }
@@ -100,7 +101,7 @@ object DeviceDescriptorSerializer : UnknownPolymorphicSerializer<AnyDeviceDescri
 {
     override fun createWrapper( className: String, json: String, serializer: Json ): AnyDeviceDescriptor
     {
-        val jsonObject = serializer.parseJson( json ) as JsonObject
+        val jsonObject = serializer.parseToJsonElement( json ) as JsonObject
         val isMasterDevice = jsonObject.containsKey( AnyMasterDeviceDescriptor::isMasterDevice.name )
 
         return if ( isMasterDevice )
@@ -131,11 +132,11 @@ data class CustomDeviceRegistration( override val className: String, override va
 
     init
     {
-        val json = serializer.parseJson( jsonSource ) as JsonObject
+        val json = serializer.parseToJsonElement( jsonSource ) as JsonObject
 
         val deviceIdField = DeviceRegistration::deviceId.name
         require( json.containsKey( deviceIdField ) ) { "No '$deviceIdField' defined." }
-        deviceId = json[ deviceIdField ]!!.content
+        deviceId = json[ deviceIdField ]!!.jsonPrimitive.content
     }
 }
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/UnknownTaskSerializers.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/UnknownTaskSerializers.kt
@@ -6,9 +6,11 @@ import dk.cachet.carp.protocols.domain.data.DataType
 import dk.cachet.carp.protocols.domain.tasks.measures.Measure
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.content
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 
 /**
@@ -22,17 +24,17 @@ data class CustomTaskDescriptor( override val className: String, override val js
 
     init
     {
-        val json = serializer.parseJson( jsonSource ) as JsonObject
+        val json = serializer.parseToJsonElement( jsonSource ) as JsonObject
 
         val nameField = TaskDescriptor::name.name
         require( json.containsKey( nameField ) ) { "No '$nameField' defined." }
-        name = json[ nameField ]!!.content
+        name = json[ nameField ]!!.jsonPrimitive.content
 
         // Get raw JSON string of measures and use kotlinx serialization to deserialize.
         val measuresField = TaskDescriptor::measures.name
         require( json.containsKey( measuresField ) ) { "No '$measuresField' defined." }
         val measuresJson = json[ measuresField ]!!.jsonArray.toString()
-        measures = serializer.parse( MeasuresSerializer, measuresJson )
+        measures = serializer.decodeFromString( MeasuresSerializer, measuresJson )
     }
 }
 
@@ -53,13 +55,13 @@ data class CustomMeasure( override val className: String, override val jsonSourc
 
     init
     {
-        val json = serializer.parseJson( jsonSource ) as JsonObject
+        val json = serializer.parseToJsonElement( jsonSource ) as JsonObject
 
         // Get raw JSON string of type (using klaxon) and use kotlinx serialization to deserialize.
         val typeField = Measure::type.name
         require( json.containsKey( typeField ) ) { "No '$typeField' defined." }
         val typeJson = json[ typeField ]!!.jsonObject.toString()
-        type = serializer.parse( DataType.serializer(), typeJson )
+        type = serializer.decodeFromString( DataType.serializer(), typeJson )
     }
 }
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/measures/PhoneSensorMeasure.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/measures/PhoneSensorMeasure.kt
@@ -50,7 +50,7 @@ data class PhoneSensorMeasure private constructor(
         val STEPCOUNT = add( Stepcount ) // No configuration options available.
     }
 
-    companion object Factory
+    companion object
     {
         private fun <T : DataTypeSamplingScheme<*>> measureOf( samplingScheme: T, duration: TimeSpan ) =
             PhoneSensorMeasure( samplingScheme.type, duration )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/triggers/ManualTrigger.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/triggers/ManualTrigger.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.protocols.domain.triggers
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 
 /**
@@ -8,6 +9,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ManualTrigger(
+    override val sourceDeviceRoleName: String,
     /**
      * A short label to describe the action performed once the user chooses to initiate this trigger.
      */
@@ -16,4 +18,8 @@ data class ManualTrigger(
      * An optional description elaborating on what happens when initiating this trigger.
      */
     val description: String = ""
-)
+) : Trigger()
+{
+    @Transient
+    override val requiresMasterDevice: Boolean = true // Software is needed to display this to the user.
+}

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/triggers/UnknownTriggerSerializers.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/triggers/UnknownTriggerSerializers.kt
@@ -3,9 +3,9 @@ package dk.cachet.carp.protocols.domain.triggers
 import dk.cachet.carp.common.serialization.createUnknownPolymorphicSerializer
 import dk.cachet.carp.common.serialization.UnknownPolymorphicWrapper
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.json.content
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 
 /**
@@ -18,11 +18,11 @@ data class CustomTrigger( override val className: String, override val jsonSourc
 
     init
     {
-        val json = serializer.parseJson( jsonSource ) as JsonObject
+        val json = serializer.parseToJsonElement( jsonSource ) as JsonObject
 
         val sourceDeviceRoleNameField = Trigger::sourceDeviceRoleName.name
         require( json.containsKey( sourceDeviceRoleNameField ) ) { "No '$sourceDeviceRoleNameField' defined." }
-        sourceDeviceRoleName = json[ sourceDeviceRoleNameField ]!!.content
+        sourceDeviceRoleName = json[ sourceDeviceRoleNameField ]!!.jsonPrimitive.content
     }
 }
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
@@ -16,8 +16,11 @@ import dk.cachet.carp.protocols.infrastructure.JSON
 import dk.cachet.carp.protocols.infrastructure.PROTOCOLS_SERIAL_MODULE
 import dk.cachet.carp.protocols.infrastructure.createProtocolsSerializer
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.plus
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.subclass
 import kotlin.reflect.KClass
 
 
@@ -25,29 +28,35 @@ import kotlin.reflect.KClass
  * Stubs for testing extending from types in [dk.cachet.carp.protocols] module which need to be registered when using [Json] serializer.
  */
 val STUBS_SERIAL_MODULE = SerializersModule {
+    fun PolymorphicModuleBuilder<AnyMasterDeviceDescriptor>.registerMasterDeviceDescriptorSubclasses()
+    {
+        subclass( StubMasterDeviceDescriptor::class )
+    }
+
     polymorphic( DeviceDescriptor::class )
     {
-        StubDeviceDescriptor::class with StubDeviceDescriptor.serializer()
+        subclass( StubDeviceDescriptor::class )
+        registerMasterDeviceDescriptorSubclasses()
     }
-    polymorphic( MasterDeviceDescriptor::class, DeviceDescriptor::class )
+    polymorphic( MasterDeviceDescriptor::class )
     {
-        StubMasterDeviceDescriptor::class with StubMasterDeviceDescriptor.serializer()
+        registerMasterDeviceDescriptorSubclasses()
     }
     polymorphic( SamplingConfiguration::class )
     {
-        StubSamplingConfiguration::class with StubSamplingConfiguration.serializer()
+        subclass( StubSamplingConfiguration::class )
     }
     polymorphic( TaskDescriptor::class )
     {
-        StubTaskDescriptor::class with StubTaskDescriptor.serializer()
+        subclass( StubTaskDescriptor::class )
     }
     polymorphic( Measure::class )
     {
-        StubMeasure::class with StubMeasure.serializer()
+        subclass( StubMeasure::class )
     }
     polymorphic( Trigger::class )
     {
-        StubTrigger::class with StubTrigger.serializer()
+        subclass( StubTrigger::class )
     }
 }
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/data/UnknownSamplingConfigurationSerializersTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/data/UnknownSamplingConfigurationSerializersTest.kt
@@ -26,7 +26,7 @@ class CustomSamplingConfigurationTest
     fun initialization_from_any_object_succeeds()
     {
         val anyObject = SomeRandomSerializableObject( "Whatever" )
-        val serialized: String = JSON.stringify( SomeRandomSerializableObject.serializer(), anyObject )
+        val serialized: String = JSON.encodeToString( SomeRandomSerializableObject.serializer(), anyObject )
 
         // Currently, there are no base members in `SamplingConfiguration`.
         // Any class, even those that don't implement `SamplingConfiguration` can be used.

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/devices/AltBeaconTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/devices/AltBeaconTest.kt
@@ -2,7 +2,8 @@ package dk.cachet.carp.protocols.domain.devices
 
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.serialization.createDefaultJSON
-import kotlinx.serialization.json.content
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.*
 
 
@@ -46,9 +47,9 @@ class AltBeaconTest
         val registration = AltBeaconDeviceRegistration( 0, UUID.randomUUID(), 0, 0 )
 
         val json = createDefaultJSON()
-        val serialized = json.stringify( AltBeaconDeviceRegistration.serializer(), registration )
-        val jsonElement = json.parseJson( serialized ).jsonObject
-        val serializedDeviceId = jsonElement[ DeviceRegistration::deviceId.name ]?.content
+        val serialized = json.encodeToString( AltBeaconDeviceRegistration.serializer(), registration )
+        val jsonElement = json.parseToJsonElement( serialized ).jsonObject
+        val serializedDeviceId = jsonElement[ DeviceRegistration::deviceId.name ]?.jsonPrimitive?.content
         assertEquals( registration.deviceId, serializedDeviceId )
     }
 }

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/devices/UnknownDeviceSerializersTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/devices/UnknownDeviceSerializersTest.kt
@@ -23,7 +23,7 @@ class CustomDeviceDescriptorTest
     fun initialization_from_json_extracts_base_DeviceDescriptor_properties()
     {
         val device = StubDeviceDescriptor( "Unknown" )
-        val serialized: String = JSON.stringify( StubDeviceDescriptor.serializer(), device )
+        val serialized: String = JSON.encodeToString( StubDeviceDescriptor.serializer(), device )
 
         val custom = CustomDeviceDescriptor( "Irrelevant", serialized, JSON )
         assertEquals( device.roleName, custom.roleName )
@@ -36,7 +36,7 @@ class CustomDeviceDescriptorTest
     fun initialization_from_invalid_json_fails()
     {
         val incorrect = IncorrectDevice()
-        val serialized: String = JSON.stringify( IncorrectDevice.serializer(), incorrect )
+        val serialized: String = JSON.encodeToString( IncorrectDevice.serializer(), incorrect )
 
         assertFailsWith<IllegalArgumentException>
         {
@@ -48,7 +48,7 @@ class CustomDeviceDescriptorTest
     fun createRegistration_is_not_supported()
     {
         val device = StubDeviceDescriptor( "Unknown" )
-        val serialized: String = JSON.stringify( StubDeviceDescriptor.serializer(), device )
+        val serialized: String = JSON.encodeToString( StubDeviceDescriptor.serializer(), device )
 
         val custom = CustomDeviceDescriptor( "Irrelevant", serialized, JSON )
 
@@ -75,7 +75,7 @@ class CustomMasterDeviceDescriptorTest
     fun initialization_from_json_extracts_base_MasterDeviceDescriptor_properties()
     {
         val device = StubMasterDeviceDescriptor( "Unknown" )
-        val serialized: String = JSON.stringify( StubMasterDeviceDescriptor.serializer(), device )
+        val serialized: String = JSON.encodeToString( StubMasterDeviceDescriptor.serializer(), device )
 
         val custom = CustomMasterDeviceDescriptor( "Irrelevant", serialized, JSON )
         assertEquals( device.roleName, custom.roleName )
@@ -88,7 +88,7 @@ class CustomMasterDeviceDescriptorTest
     fun initialization_from_invalid_json_fails()
     {
         val incorrect = IncorrectMasterDevice()
-        val serialized: String = JSON.stringify( IncorrectMasterDevice.serializer(), incorrect )
+        val serialized: String = JSON.encodeToString( IncorrectMasterDevice.serializer(), incorrect )
 
         assertFailsWith<IllegalArgumentException>
         {
@@ -100,7 +100,7 @@ class CustomMasterDeviceDescriptorTest
     fun createRegistration_is_not_supported()
     {
         val device = StubMasterDeviceDescriptor( "Unknown" )
-        val serialized: String = JSON.stringify( StubMasterDeviceDescriptor.serializer(), device )
+        val serialized: String = JSON.encodeToString( StubMasterDeviceDescriptor.serializer(), device )
 
         val custom = CustomMasterDeviceDescriptor( "Irrelevant", serialized, JSON )
 
@@ -127,7 +127,7 @@ class CustomDeviceRegistrationTest
     fun initialization_from_json_extracts_base_DeviceRegistration_properties()
     {
         val registration = DefaultDeviceRegistration( "Unknown" )
-        val serialized: String = JSON.stringify( DefaultDeviceRegistration.serializer(), registration )
+        val serialized: String = JSON.encodeToString( DefaultDeviceRegistration.serializer(), registration )
 
         val custom = CustomDeviceRegistration( "Irrelevant", serialized, JSON )
         assertEquals( registration.deviceId, custom.deviceId )
@@ -140,7 +140,7 @@ class CustomDeviceRegistrationTest
     fun initialization_from_invalid_json_fails()
     {
         val incorrect = IncorrectRegistration()
-        val serialized: String = JSON.stringify( IncorrectRegistration.serializer(), incorrect )
+        val serialized: String = JSON.encodeToString( IncorrectRegistration.serializer(), incorrect )
 
         assertFailsWith<IllegalArgumentException>
         {

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/tasks/UnknownTaskSerializersTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/tasks/UnknownTaskSerializersTest.kt
@@ -27,7 +27,7 @@ class CustomTaskDescriptorTest
     {
         val measures: List<Measure> = listOf( StubMeasure() )
         val task = StubTaskDescriptor( "Unknown", measures )
-        val serialized: String = JSON.stringify( StubTaskDescriptor.serializer(), task )
+        val serialized: String = JSON.encodeToString( StubTaskDescriptor.serializer(), task )
 
         val custom = CustomTaskDescriptor( "Irrelevant", serialized, JSON )
         assertEquals( task.name, custom.name )
@@ -41,7 +41,7 @@ class CustomTaskDescriptorTest
     fun initialization_from_invalid_json_fails()
     {
         val incorrect = IncorrectTask()
-        val serialized: String = JSON.stringify( IncorrectTask.serializer(), incorrect )
+        val serialized: String = JSON.encodeToString( IncorrectTask.serializer(), incorrect )
 
         assertFailsWith<IllegalArgumentException>
         {
@@ -66,7 +66,7 @@ class CustomMeasureTest
     fun initialization_from_json_extracts_base_Measure_properties()
     {
         val measure = StubMeasure( STUB_DATA_TYPE )
-        val serialized: String = JSON.stringify( StubMeasure.serializer(), measure )
+        val serialized: String = JSON.encodeToString( StubMeasure.serializer(), measure )
 
         val custom = CustomMeasure( "Irrelevant", serialized, JSON )
         assertEquals( measure.type, custom.type )
@@ -79,7 +79,7 @@ class CustomMeasureTest
     fun initialization_from_invalid_json_fails()
     {
         val incorrect = IncorrectMeasure()
-        val serialized: String = JSON.stringify( IncorrectMeasure.serializer(), incorrect )
+        val serialized: String = JSON.encodeToString( IncorrectMeasure.serializer(), incorrect )
 
         assertFailsWith<IllegalArgumentException>
         {

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/triggers/UnknownTriggerSerializersTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/triggers/UnknownTriggerSerializersTest.kt
@@ -24,7 +24,7 @@ class CustomTriggerTest
     fun initialization_from_json_extracts_base_Trigger_properties()
     {
         val trigger = StubTrigger( "Some device" )
-        val serialized: String = JSON.stringify( StubTrigger.serializer(), trigger )
+        val serialized: String = JSON.encodeToString( StubTrigger.serializer(), trigger )
 
         val custom = CustomTrigger( "Irrelevant", serialized, JSON )
         assertEquals( trigger.sourceDeviceRoleName, custom.sourceDeviceRoleName )
@@ -37,7 +37,7 @@ class CustomTriggerTest
     fun initialization_from_invalid_json_fails()
     {
         val incorrect = IncorrectTrigger()
-        val serialized: String = JSON.stringify( IncorrectTrigger.serializer(), incorrect )
+        val serialized: String = JSON.encodeToString( IncorrectTrigger.serializer(), incorrect )
 
         assertFailsWith<IllegalArgumentException>
         {

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
@@ -33,8 +33,8 @@ class ProtocolServiceRequestsTest
     {
         requests.forEach { request ->
             val serializer = ProtocolServiceRequest.serializer()
-            val serialized = JSON.stringify( serializer, request )
-            val parsed = JSON.parse( serializer, serialized )
+            val serialized = JSON.encodeToString( serializer, request )
+            val parsed = JSON.decodeFromString( serializer, serialized )
             assertEquals( request, parsed )
         }
     }
@@ -55,8 +55,8 @@ class ProtocolServiceRequestsTest
     fun invokeOn_deserialized_request_requires_copy() = runBlockingTest {
         val request = ProtocolServiceRequest.Add( createComplexProtocol().getSnapshot(), "Initial" )
         val serializer = ProtocolServiceRequest.serializer()
-        val serialized = JSON.stringify( serializer, request )
-        val parsed = JSON.parse( serializer, serialized ) as ProtocolServiceRequest.Add
+        val serialized = JSON.encodeToString( serializer, request )
+        val parsed = JSON.decodeFromString( serializer, serialized ) as ProtocolServiceRequest.Add
 
         // `ServiceInvoker` class delegation is not initialized as part of deserialization:
         // https://github.com/Kotlin/kotlinx.serialization/issues/241#issuecomment-555020729

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/SerializationTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/SerializationTest.kt
@@ -47,7 +47,11 @@ private val protocolInstances = listOf(
         Smartphone( "User's phone"),
         TimeOfDay( 12 ), RecurrenceRule( RecurrenceRule.Frequency.DAILY )
     ),
-    ManualTrigger( "Mood", "Describe how you are feeling at the moment." )
+    ManualTrigger(
+        "User's phone",
+        "Mood",
+        "Describe how you are feeling at the moment."
+    )
 )
 
 /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/Serialization.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/Serialization.kt
@@ -10,9 +10,9 @@ import dk.cachet.carp.studies.domain.StudyStatus
 import dk.cachet.carp.studies.domain.users.AssignParticipantDevices
 import dk.cachet.carp.studies.domain.users.Participant
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.EmptyModule
+import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.plus
-import kotlinx.serialization.modules.SerialModule
+import kotlinx.serialization.modules.SerializersModule
 
 
 /**
@@ -20,7 +20,7 @@ import kotlinx.serialization.modules.SerialModule
  * This ensures a global configuration on how serialization should occur.
  * Additional types the serializer needs to be aware about (such as polymorph extending classes) should be registered through [module].
  */
-fun createStudiesSerializer( module: SerialModule = EmptyModule ): Json
+fun createStudiesSerializer( module: SerializersModule = EmptySerializersModule ): Json
 {
     return createDefaultJSON( PROTOCOLS_SERIAL_MODULE + module )
 }
@@ -36,58 +36,58 @@ var JSON: Json = createStudiesSerializer()
  * Create a [StudySnapshot] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun StudySnapshot.Companion.fromJson( json: String ): StudySnapshot =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun StudySnapshot.toJson(): String =
-    JSON.stringify( StudySnapshot.serializer(), this )
+    JSON.encodeToString( StudySnapshot.serializer(), this )
 
 /**
  * Create a [Participant] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun Participant.Companion.fromJson( json: String ): Participant =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun Participant.toJson(): String =
-    JSON.stringify( Participant.serializer(), this )
+    JSON.encodeToString( Participant.serializer(), this )
 
 /**
  * Create a [StudyOwner] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyOwner.Companion.fromJson( json: String ): StudyOwner =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyOwner.toJson(): String =
-    JSON.stringify( StudyOwner.serializer(), this )
+    JSON.encodeToString( StudyOwner.serializer(), this )
 
 /**
  * Create a [StudyStatus] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyStatus.Companion.fromJson( json: String ): StudyStatus =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun StudyStatus.toJson(): String =
-    JSON.stringify( StudyStatus.serializer(), this )
+    JSON.encodeToString( StudyStatus.serializer(), this )
 
 /**
  * Create a [AssignParticipantDevices] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun AssignParticipantDevices.Companion.fromJson( json: String ): AssignParticipantDevices =
-    JSON.parse( serializer(), json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun AssignParticipantDevices.toJson(): String =
-    JSON.stringify( AssignParticipantDevices.serializer(), this )
+    JSON.encodeToString( AssignParticipantDevices.serializer(), this )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/DeanonymizedParticipationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/DeanonymizedParticipationTest.kt
@@ -16,8 +16,8 @@ class DeanonymizedParticipationTest
     {
         val participation = DeanonymizedParticipation( UUID.randomUUID(), UUID.randomUUID() )
 
-        val serialized: String = JSON.stringify( DeanonymizedParticipation.serializer(), participation )
-        val parsed: DeanonymizedParticipation = JSON.parse( DeanonymizedParticipation.serializer(), serialized )
+        val serialized: String = JSON.encodeToString( DeanonymizedParticipation.serializer(), participation )
+        val parsed: DeanonymizedParticipation = JSON.decodeFromString( DeanonymizedParticipation.serializer(), serialized )
 
         assertEquals( participation, parsed )
     }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
@@ -20,8 +20,8 @@ class ParticipantGroupStatusTest
         val participants = setOf( DeanonymizedParticipation( UUID.randomUUID(), UUID.randomUUID() ) )
         val groupStatus = ParticipantGroupStatus( deploymentStatus, participants )
 
-        val serialized: String = JSON.stringify( ParticipantGroupStatus.serializer(), groupStatus )
-        val parsed: ParticipantGroupStatus = JSON.parse( ParticipantGroupStatus.serializer(), serialized )
+        val serialized: String = JSON.encodeToString( ParticipantGroupStatus.serializer(), groupStatus )
+        val parsed: ParticipantGroupStatus = JSON.decodeFromString( ParticipantGroupStatus.serializer(), serialized )
 
         assertEquals( groupStatus, parsed )
     }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
@@ -47,8 +47,8 @@ class StudyServiceRequestsTest
     {
         requests.forEach { request ->
             val serializer = StudyServiceRequest.serializer()
-            val serialized = JSON.stringify( serializer, request )
-            val parsed = JSON.parse( serializer, serialized )
+            val serialized = JSON.encodeToString( serializer, request )
+            val parsed = JSON.decodeFromString( serializer, serialized )
             assertEquals( request, parsed )
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Sep 03 11:02:31 CEST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,3 @@ include 'carp.protocols.core'
 include 'carp.studies.core'
 include 'carp.deployment.core'
 include 'carp.client.core'
-
-// Allow specifying a single dependency in the common source sets to projects configured in this build.
-// https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#experimental-metadata-publishing-mode
-enableFeaturePreview('GRADLE_METADATA')

--- a/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
@@ -1,7 +1,7 @@
-declare module 'carp.common'
+declare module 'carp.core-kotlin-carp.common'
 {
     import { Long } from 'kotlin'
-    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-runtime'
+    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
     import Json = kotlinx.serialization.json.Json
     
     
@@ -113,6 +113,6 @@ declare module 'carp.common'
 
     namespace dk.cachet.carp.common.serialization
     {
-        function createDefaultJSON_stpyu4$(): Json
+        function createDefaultJSON_4jix7z$(): Json
     }
 }

--- a/typescript-declarations/@types/carp.core-kotlin-carp.deployment.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.deployment.core/index.d.ts
@@ -1,9 +1,9 @@
-declare module 'carp.deployment.core'
+declare module 'carp.core-kotlin-carp.deployment.core'
 {
     import { kotlin } from 'kotlin'
     import ArrayList = kotlin.collections.ArrayList
     import HashSet = kotlin.collections.HashSet
-    import { dk as cdk } from 'carp.common'
+    import { dk as cdk } from 'carp.core-kotlin-carp.common'
     import UUID = cdk.cachet.carp.common.UUID
     import DateTime = cdk.cachet.carp.common.DateTime
 

--- a/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
@@ -1,8 +1,8 @@
-declare module 'carp.protocols.core'
+declare module 'carp.core-kotlin-carp.protocols.core'
 {
-    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-runtime'
+    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
     import Json = kotlinx.serialization.json.Json
-    import { dk as cdk } from 'carp.common'
+    import { dk as cdk } from 'carp.core-kotlin-carp.common'
     import DateTime = cdk.cachet.carp.common.DateTime
     import UUID = cdk.cachet.carp.common.UUID
 
@@ -72,6 +72,6 @@ declare module 'carp.protocols.core'
             }
         }
 
-        function createProtocolsSerializer_stpyu4$(): Json
+        function createProtocolsSerializer_4jix7z$(): Json
     }
 }

--- a/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
@@ -1,18 +1,18 @@
-declare module 'carp.studies.core'
+declare module 'carp.core-kotlin-carp.studies.core'
 {
     import { kotlin } from 'kotlin'
     import ArrayList = kotlin.collections.ArrayList
     import HashSet = kotlin.collections.HashSet
-    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-runtime'
+    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
     import Json = kotlinx.serialization.json.Json
-    import { dk as cdk } from 'carp.common'
+    import { dk as cdk } from 'carp.core-kotlin-carp.common'
     import DateTime = cdk.cachet.carp.common.DateTime
     import EmailAddress = cdk.cachet.carp.common.EmailAddress
     import UUID = cdk.cachet.carp.common.UUID
     import AccountIdentity = cdk.cachet.carp.common.users.AccountIdentity
-    import { dk as pdk } from 'carp.protocols.core'
+    import { dk as pdk } from 'carp.core-kotlin-carp.protocols.core'
     import StudyProtocolSnapshot = pdk.cachet.carp.protocols.domain.StudyProtocolSnapshot
-    import { dk as ddk } from 'carp.deployment.core'
+    import { dk as ddk } from 'carp.core-kotlin-carp.deployment.core'
     import Participation = ddk.cachet.carp.deployment.domain.users.Participation
     import StudyDeploymentStatus = ddk.cachet.carp.deployment.domain.StudyDeploymentStatus
     import StudyInvitation = ddk.cachet.carp.deployment.domain.users.StudyInvitation
@@ -221,6 +221,6 @@ declare module 'carp.studies.core'
             }
         }
 
-        function createStudiesSerializer_stpyu4$(): Json
+        function createStudiesSerializer_4jix7z$(): Json
     }
 }

--- a/typescript-declarations/@types/kotlinx-serialization-kotlinx-serialization-core-jsLegacy/index.d.ts
+++ b/typescript-declarations/@types/kotlinx-serialization-kotlinx-serialization-core-jsLegacy/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'kotlinx-serialization-kotlinx-serialization-runtime'
+declare module 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
 {
     namespace kotlinx.serialization
     {
@@ -11,8 +11,8 @@ declare module 'kotlinx-serialization-kotlinx-serialization-runtime'
     {
         class Json
         {
-            stringify_tf03ej$( serializer: any, obj: any ): string
-            parse_awif5v$( deserializer: any, string: string ): any
+            encodeToString_tf03ej$( serializer: any, obj: any ): string
+            decodeFromString_awif5v$( deserializer: any, string: string ): any
         }
     }
 }

--- a/typescript-declarations/package-lock.json
+++ b/typescript-declarations/package-lock.json
@@ -148,16 +148,38 @@
         "eslint-visitor-keys": "^1.1.0"
       }
     },
+    "abab": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
+      "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
       "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true
     },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
+    },
     "acorn-jsx": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
     "ajv": {
@@ -230,6 +252,21 @@
         "is-string": "^1.0.4"
       }
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -242,11 +279,38 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -273,6 +337,12 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -295,6 +365,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chai": {
@@ -428,10 +504,25 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cross-spawn": {
@@ -443,6 +534,49 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+          "dev": true
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
       }
     },
     "debug": {
@@ -458,6 +592,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
       "dev": true
     },
     "deep-eql": {
@@ -484,6 +624,12 @@
         "object-keys": "^1.0.12"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -497,6 +643,33 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "dev": true
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "emoji-regex": {
@@ -570,6 +743,60 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
+      }
     },
     "eslint": {
       "version": "7.7.0",
@@ -695,6 +922,18 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -767,6 +1006,23 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -803,6 +1059,15 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -842,6 +1107,22 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -868,6 +1149,35 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "ignore": {
       "version": "4.0.6",
@@ -905,6 +1215,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
     "is-arguments": {
@@ -979,6 +1295,12 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -1009,6 +1331,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -1019,6 +1347,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "iterate-iterator": {
@@ -1053,6 +1387,58 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdom": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+      "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.3",
+        "acorn": "^7.1.1",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.2.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.0",
+        "domexception": "^2.0.1",
+        "escodegen": "^1.14.1",
+        "html-encoding-sniffer": "^2.0.1",
+        "is-potential-custom-element-name": "^1.0.0",
+        "nwsapi": "^2.2.0",
+        "parse5": "5.1.1",
+        "request": "^2.88.2",
+        "request-promise-native": "^1.0.8",
+        "saxes": "^5.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^3.0.1",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0",
+        "ws": "^7.2.3",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "jsdom-global": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1064,6 +1450,24 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "levn": {
       "version": "0.4.1",
@@ -1088,6 +1492,12 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "log-symbols": {
@@ -1117,6 +1527,21 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.44.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1235,6 +1660,18 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -1315,6 +1752,12 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1337,6 +1780,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "picomatch": {
@@ -1370,10 +1819,22 @@
         "iterate-value": "^1.0.0"
       }
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "randombytes": {
@@ -1399,6 +1860,78 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -1432,6 +1965,21 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "semver": {
       "version": "7.3.2",
@@ -1500,6 +2048,29 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "string-width": {
@@ -1574,6 +2145,12 @@
         "has-flag": "^3.0.0"
       }
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -1599,6 +2176,26 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "dev": true,
+      "requires": {
+        "ip-regex": "^2.1.0",
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.1"
       }
     },
     "ts-node": {
@@ -1628,6 +2225,21 @@
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -1665,11 +2277,78 @@
         "punycode": "^2.1.0"
       }
     },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
     "v8-compile-cache": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-ZmVCr6nfBeaMxEHALLEGy0LszYjpJqf6PVNQUQ1qd9Et+q7Jpygd4rGGDXgHjD8e99yLFseD69msHDM4YwPZ4A==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^2.0.2",
+        "webidl-conversions": "^6.1.0"
+      }
     },
     "which": {
       "version": "2.0.2",
@@ -1776,6 +2455,24 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "ws": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/typescript-declarations/package.json
+++ b/typescript-declarations/package.json
@@ -10,6 +10,8 @@
     "chai": "^4.2.0",
     "eslint": "^7.7.0",
     "mocha": "^8.1.1",
+    "jsdom": "16.4.0",
+    "jsdom-global": "3.0.2",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.7"
   }

--- a/typescript-declarations/tests/carp.common.ts
+++ b/typescript-declarations/tests/carp.common.ts
@@ -2,9 +2,9 @@ import { expect } from 'chai'
 import VerifyModule from './VerifyModule'
 
 import { Long } from 'kotlin'
-import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-runtime'
+import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
 import Json = kotlinx.serialization.json.Json
-import { dk } from "carp.common"
+import { dk } from "carp.core-kotlin-carp.common"
 import DateTime = dk.cachet.carp.common.DateTime
 import EmailAddress = dk.cachet.carp.common.EmailAddress
 import TimeSpan = dk.cachet.carp.common.TimeSpan
@@ -15,7 +15,7 @@ import AccountIdentity = dk.cachet.carp.common.users.AccountIdentity
 import EmailAccountIdentity = dk.cachet.carp.common.users.EmailAccountIdentity
 import emailAccountIdentityFromString = dk.cachet.carp.common.users.EmailAccountIdentity_init_61zpoe$
 import UsernameAccountIdentity = dk.cachet.carp.common.users.UsernameAccountIdentity
-import createDefaultJSON = dk.cachet.carp.common.serialization.createDefaultJSON_stpyu4$
+import createDefaultJSON = dk.cachet.carp.common.serialization.createDefaultJSON_4jix7z$
 
 
 describe( "carp.common", () => {
@@ -36,7 +36,7 @@ describe( "carp.common", () => {
             UsernameAccountIdentity.Companion
         ]
 
-        const moduleVerifier = new VerifyModule( 'carp.common', instances )
+        const moduleVerifier = new VerifyModule( 'carp.core-kotlin-carp.common', instances )
         await moduleVerifier.verify()
     } )
 
@@ -47,7 +47,7 @@ describe( "carp.common", () => {
             
             const json: Json = createDefaultJSON()
             const serializer = DateTime.Companion.serializer()
-            const serialized = json.stringify_tf03ej$( serializer, dateTime )
+            const serialized = json.encodeToString_tf03ej$( serializer, dateTime )
     
             expect( serialized ).equals( "42" )
         } )

--- a/typescript-declarations/tests/carp.deployment.core.ts
+++ b/typescript-declarations/tests/carp.deployment.core.ts
@@ -4,9 +4,9 @@ import { kotlin } from 'kotlin'
 import ArrayList = kotlin.collections.ArrayList
 import HashSet = kotlin.collections.HashSet
 import toSet = kotlin.collections.toSet_us0mfu$
-import { dk as dkc } from 'carp.common'
+import { dk as dkc } from 'carp.core-kotlin-carp.common'
 import UUID = dkc.cachet.carp.common.UUID
-import { dk } from 'carp.deployment.core'
+import { dk } from 'carp.core-kotlin-carp.deployment.core'
 import Participation = dk.cachet.carp.deployment.domain.users.Participation
 import StudyInvitation = dk.cachet.carp.deployment.domain.users.StudyInvitation
 import DeviceDeploymentStatus = dk.cachet.carp.deployment.domain.DeviceDeploymentStatus
@@ -33,7 +33,7 @@ describe( "carp.deployment.core", () => {
             new StudyDeploymentStatus.Stopped( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ), null )
         ]
 
-        const moduleVerifier = new VerifyModule( 'carp.deployment.core', instances )
+        const moduleVerifier = new VerifyModule( 'carp.core-kotlin-carp.deployment.core', instances )
         await moduleVerifier.verify()
     } )
 } )

--- a/typescript-declarations/tests/carp.protocols.core.ts
+++ b/typescript-declarations/tests/carp.protocols.core.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai'
 import VerifyModule from './VerifyModule'
 
-import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-runtime'
+import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
 import Json = kotlinx.serialization.json.Json
-import { dk } from 'carp.protocols.core'
+import { dk } from 'carp.core-kotlin-carp.protocols.core'
 import ProtocolOwner = dk.cachet.carp.protocols.domain.ProtocolOwner
 import ProtocolVersion = dk.cachet.carp.protocols.domain.ProtocolVersion
 import StudyProtocolSnapshot = dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
-import createProtocolsSerializer = dk.cachet.carp.protocols.infrastructure.createProtocolsSerializer_stpyu4$
+import createProtocolsSerializer = dk.cachet.carp.protocols.infrastructure.createProtocolsSerializer_4jix7z$
 import ProtocolServiceRequest = dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest
 
 const serializedSnapshot = `{"ownerId":"27879e75-ccc1-4866-9ab3-4ece1b735052","name":"Test protocol","description":"","creationDate":1587991653533,"masterDevices":[["dk.cachet.carp.protocols.domain.devices.StubMasterDeviceDescriptor",{"isMasterDevice":true,"roleName":"Stub master device"}]],"connectedDevices":[["dk.cachet.carp.protocols.domain.devices.StubDeviceDescriptor",{"roleName":"Stub device"}],["dk.cachet.carp.protocols.domain.devices.StubMasterDeviceDescriptor",{"isMasterDevice":true,"roleName":"Chained master"}],["dk.cachet.carp.protocols.domain.devices.StubDeviceDescriptor",{"roleName":"Chained connected"}]],"connections":[{"roleName":"Stub device","connectedToRoleName":"Stub master device"},{"roleName":"Chained master","connectedToRoleName":"Stub master device"},{"roleName":"Chained connected","connectedToRoleName":"Chained master"}],"tasks":[["dk.cachet.carp.protocols.domain.tasks.StubTaskDescriptor",{"name":"Task","measures":[["dk.cachet.carp.protocols.domain.tasks.measures.StubMeasure",{"type":{"namespace":"dk.cachet.carp","name":"stub"}}]]}]],"triggers":{"0":["dk.cachet.carp.protocols.domain.triggers.StubTrigger",{"sourceDeviceRoleName":"Stub device","uniqueProperty":"Unique"}]},"triggeredTasks":[{"triggerId":0,"taskName":"Task","targetDeviceRoleName":"Stub master device"}]}`
@@ -22,7 +22,7 @@ describe( "carp.protocols.core", () => {
             ProtocolOwner.Companion
         ]
 
-        const moduleVerifier = new VerifyModule( 'carp.protocols.core', instances )
+        const moduleVerifier = new VerifyModule( 'carp.core-kotlin-carp.protocols.core', instances )
         await moduleVerifier.verify()
     } )
 
@@ -30,7 +30,7 @@ describe( "carp.protocols.core", () => {
         it( "can deserialize", () => {
             const json: Json = createProtocolsSerializer()
             const serializer = StudyProtocolSnapshot.Companion.serializer()
-            const parsed = json.parse_awif5v$( serializer, serializedSnapshot )
+            const parsed = json.decodeFromString_awif5v$( serializer, serializedSnapshot )
             expect( parsed ).is.instanceOf( StudyProtocolSnapshot )
         } )
     } )

--- a/typescript-declarations/tests/carp.studies.core.ts
+++ b/typescript-declarations/tests/carp.studies.core.ts
@@ -5,18 +5,18 @@ import { kotlin } from 'kotlin'
 import ArrayList = kotlin.collections.ArrayList
 import HashSet = kotlin.collections.HashSet
 import toSet = kotlin.collections.toSet_us0mfu$
-import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-runtime'
+import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
 import Json = kotlinx.serialization.json.Json
 import getListSerializer = kotlinx.serialization.get_list_gekvwj$
-import { dk as cdk } from 'carp.common'
+import { dk as cdk } from 'carp.core-kotlin-carp.common'
 import DateTime = cdk.cachet.carp.common.DateTime
 import UUID = cdk.cachet.carp.common.UUID
 import UsernameIdentity = cdk.cachet.carp.common.users.UsernameAccountIdentity
-import { dk as ddk } from 'carp.deployment.core'
+import { dk as ddk } from 'carp.core-kotlin-carp.deployment.core'
 import Participation = ddk.cachet.carp.deployment.domain.users.Participation
 import StudyInvitation = ddk.cachet.carp.deployment.domain.users.StudyInvitation
 import StudyDeploymentStatus = ddk.cachet.carp.deployment.domain.StudyDeploymentStatus
-import { dk } from 'carp.studies.core'
+import { dk } from 'carp.core-kotlin-carp.studies.core'
 import AssignParticipantDevices = dk.cachet.carp.studies.domain.users.AssignParticipantDevices
 import getAssignedParticipantIds = dk.cachet.carp.studies.domain.users.participantIds_nvx6bb$
 import getAssignedDeviceRoles = dk.cachet.carp.studies.domain.users.deviceRoles_nvx6bb$
@@ -27,7 +27,7 @@ import ParticipantGroupStatus = dk.cachet.carp.studies.domain.ParticipantGroupSt
 import StudyDetails = dk.cachet.carp.studies.domain.StudyDetails
 import StudyStatus = dk.cachet.carp.studies.domain.StudyStatus
 import StudyServiceRequest = dk.cachet.carp.studies.infrastructure.StudyServiceRequest
-import createStudiesSerializer = dk.cachet.carp.studies.infrastructure.createStudiesSerializer_stpyu4$
+import createStudiesSerializer = dk.cachet.carp.studies.infrastructure.createStudiesSerializer_4jix7z$
 
 
 describe( "carp.studies.core", () => {
@@ -51,7 +51,7 @@ describe( "carp.studies.core", () => {
             StudyServiceRequest.Companion
         ]
 
-        const moduleVerifier = new VerifyModule( 'carp.studies.core', instances )
+        const moduleVerifier = new VerifyModule( 'carp.core-kotlin-carp.studies.core', instances )
         await moduleVerifier.verify()
     } )
 
@@ -110,7 +110,7 @@ describe( "carp.studies.core", () => {
 
             const json: Json = createStudiesSerializer()
             const serializer = StudyServiceRequest.Companion.serializer()
-            const serialized = json.stringify_tf03ej$( serializer, createStudy )
+            const serialized = json.encodeToString_tf03ej$( serializer, createStudy )
             expect( serialized ).has.string( "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.CreateStudy" )
         } )
 
@@ -124,7 +124,7 @@ describe( "carp.studies.core", () => {
 
             const json: Json = createStudiesSerializer()
             const serializer = StudyServiceRequest.Companion.serializer()
-            const serialized = json.stringify_tf03ej$( serializer, deployGroup )
+            const serialized = json.encodeToString_tf03ej$( serializer, deployGroup )
             expect( serialized ).is.not.undefined
         } )
 
@@ -135,7 +135,7 @@ describe( "carp.studies.core", () => {
             const json: Json = createStudiesSerializer()
             const serializer = getListSerializer( StudyStatus.Companion.serializer() )
             expect( serializer ).is.not.undefined
-            const serialized = json.stringify_tf03ej$( serializer, statusList )
+            const serialized = json.encodeToString_tf03ej$( serializer, statusList )
             expect( serialized ).is.not.not.undefined
         } )
     } )

--- a/typescript-declarations/tests/kotlinx-serialization.ts
+++ b/typescript-declarations/tests/kotlinx-serialization.ts
@@ -6,7 +6,7 @@ describe( "kotlinx-serialization", () => {
         const instances = new Array<any>()
 
         const moduleVerifier = new VerifyModule(
-            'kotlinx-serialization-kotlinx-serialization-runtime',
+            'kotlinx-serialization-kotlinx-serialization-core-jsLegacy',
             instances
         )
         await moduleVerifier.verify()


### PR DESCRIPTION
Currently, we are still using the JavaScript LEGACY backend. When configuring the new IR backend and updating the `UnknownPolymorphicSerializer` in JS to point to newly transpiled dynamic methods (https://github.com/cph-cachet/carp.core-kotlin/commit/f8cd6c780a437d8dcea804c7cc379ead94e76afd#diff-16ff27123678e43bff8305b98a555d66) all JVM and JS tests pass.

But, the `verifyTsDeclarations` fails. I believe that the new IR backend _requires_ exporting types using `@JsExport` in order for the names to be maintained in the sources. The JS sources show `_no_name_provided` methods. 

Unfortunately, `@JsExport` still seems fairly limited, and buggy. Classes which have companion objects and a serializer can't seem to be exported: https://github.com/Kotlin/kotlinx.serialization/issues/980

For now, this PR allows us to update to 1.4.0 and maintain our custom-written TS descriptors.