### PR TITLE
Add test to ensure correct `DataType` additions.

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/CarpDataTypes.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/CarpDataTypes.kt
@@ -3,39 +3,48 @@
  */
 package dk.cachet.carp.common.data
 
+import dk.cachet.carp.common.EnumObjectList
+
 
 /**
- * The [DataType] namespace of all CARP data type definitions.
+ * All CARP [DataType]s.
  */
-const val CARP_NAMESPACE: String = "dk.cachet.carp"
+object CarpDataTypes : EnumObjectList<DataType>()
+{
+    /**
+     * The [DataType] namespace of all CARP data type definitions.
+     */
+    const val CARP_NAMESPACE: String = "dk.cachet.carp"
 
 
-internal const val FREEFORMTEXT_TYPE_NAME = "$CARP_NAMESPACE.freeformtext"
-/**
- * Text of which the interpretation is left up to the specific application.
- */
-val FREEFORMTEXT_TYPE = DataType.fromFullyQualifiedName( FREEFORMTEXT_TYPE_NAME )
+    internal const val FREEFORMTEXT_TYPE_NAME = "$CARP_NAMESPACE.freeformtext"
+    /**
+     * Text of which the interpretation is left up to the specific application.
+     */
+    val FREEFORMTEXT = add( DataType.fromFullyQualifiedName( FREEFORMTEXT_TYPE_NAME ) )
 
-internal const val GEOLOCATION_TYPE_NAME = "$CARP_NAMESPACE.geolocation"
-/**
- * Geographic location data, representing latitude and longitude in decimal degrees within the World Geodetic System 1984.
- */
-val GEOLOCATION_TYPE = DataType.fromFullyQualifiedName( GEOLOCATION_TYPE_NAME )
+    internal const val GEOLOCATION_TYPE_NAME = "$CARP_NAMESPACE.geolocation"
+    /**
+     * Geographic location data, representing latitude and longitude in decimal degrees within the World Geodetic System 1984.
+     */
+    val GEOLOCATION = add( DataType.fromFullyQualifiedName( GEOLOCATION_TYPE_NAME ) )
 
-internal const val STEPCOUNT_TYPE_NAME = "$CARP_NAMESPACE.stepcount"
-/**
- * Stepcount data, representing the number of steps a participant has taken in a specified time interval.
- */
-val STEPCOUNT_TYPE = DataType.fromFullyQualifiedName( STEPCOUNT_TYPE_NAME )
+    internal const val STEPCOUNT_TYPE_NAME = "$CARP_NAMESPACE.stepcount"
+    /**
+     * Step count data, representing the number of steps a participant has taken in a specified time interval.
+     */
+    val STEPCOUNT = add( DataType.fromFullyQualifiedName( STEPCOUNT_TYPE_NAME ) )
 
-internal const val ECG_TYPE_NAME = "$CARP_NAMESPACE.ecg"
-/**
- * ECG data, representing electrical activity of the heart over time for a single lead.
- */
-val ECG_TYPE = DataType.fromFullyQualifiedName( ECG_TYPE_NAME )
+    internal const val ECG_TYPE_NAME = "$CARP_NAMESPACE.ecg"
+    /**
+     * ECG data, representing electrical activity of the heart over time for a single lead.
+     */
+    val ECG = add( DataType.fromFullyQualifiedName( ECG_TYPE_NAME ) )
 
-internal const val HEARTRATE_TYPE_NAME = "$CARP_NAMESPACE.heartrate"
-/**
- * Heart rate. Measures the number of heart contractions (beats) per minute.
- */
-val HEARTRATE_TYPE = DataType.fromFullyQualifiedName( HEARTRATE_TYPE_NAME )
+    internal const val HEARTRATE_TYPE_NAME = "$CARP_NAMESPACE.heartrate"
+    /**
+     * Heart rate. Measures the number of heart contractions (beats) per minute.
+     */
+    val HEARTRATE = add( DataType.fromFullyQualifiedName( HEARTRATE_TYPE_NAME ) )
+}
+

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/DataType.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/DataType.kt
@@ -54,6 +54,9 @@ data class DataType(
             return DataType( namespace, name )
         }
     }
+
+
+    override fun toString(): String = "$namespace.$name"
 }
 
 
@@ -65,7 +68,7 @@ object DataTypeSerializer : KSerializer<DataType>
 
     override fun serialize( encoder: Encoder, value: DataType )
     {
-        encoder.encodeString( "${value.namespace}.${value.name}" )
+        encoder.encodeString( value.toString() )
     }
 
     override fun deserialize( decoder: Decoder ): DataType

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/ECG.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/ECG.kt
@@ -8,5 +8,5 @@ import kotlinx.serialization.Serializable
  * Holds electrocardiogram data of a single lead.
  */
 @Serializable
-@SerialName( ECG_TYPE_NAME )
+@SerialName( CarpDataTypes.ECG_TYPE_NAME )
 data class ECG( val milliVolt: Double ) : Data

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/FreeFormText.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/FreeFormText.kt
@@ -8,5 +8,5 @@ import kotlinx.serialization.Serializable
  * Holds text of which the interpretation is left up to the specific application.
  */
 @Serializable
-@SerialName( FREEFORMTEXT_TYPE_NAME )
+@SerialName( CarpDataTypes.FREEFORMTEXT_TYPE_NAME )
 data class FreeFormText( val text: String ) : Data

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/GeoLocation.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/GeoLocation.kt
@@ -8,5 +8,5 @@ import kotlinx.serialization.Serializable
  * Holds geolocation data as latitude and longitude in decimal degrees within the World Geodetic System 1984.
  */
 @Serializable
-@SerialName( GEOLOCATION_TYPE_NAME )
-data class GeoLocation( val latitude: Double, val longitude: Double )
+@SerialName( CarpDataTypes.GEOLOCATION_TYPE_NAME )
+data class GeoLocation( val latitude: Double, val longitude: Double ) : Data

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/HeartRate.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/HeartRate.kt
@@ -8,5 +8,5 @@ import kotlinx.serialization.Serializable
  * Holds heart rate data in beats per minute.
  */
 @Serializable
-@SerialName( HEARTRATE_TYPE_NAME )
+@SerialName( CarpDataTypes.HEARTRATE_TYPE_NAME )
 data class HeartRate( val beatsPerMinute: Float ) : Data

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/StepCount.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/data/StepCount.kt
@@ -1,0 +1,18 @@
+package dk.cachet.carp.common.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+/**
+ * Holds step count data as number of steps taken in a corresponding time interval.
+ */
+@Serializable
+@SerialName( CarpDataTypes.STEPCOUNT_TYPE_NAME )
+data class StepCount( val steps: Int ) : Data
+{
+    init
+    {
+        require( steps >= 0 ) { "Number of steps needs to be a positive number." }
+    }
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/Serialization.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/Serialization.kt
@@ -1,7 +1,11 @@
 package dk.cachet.carp.common.serialization
 
 import dk.cachet.carp.common.data.Data
+import dk.cachet.carp.common.data.ECG
 import dk.cachet.carp.common.data.FreeFormText
+import dk.cachet.carp.common.data.GeoLocation
+import dk.cachet.carp.common.data.HeartRate
+import dk.cachet.carp.common.data.StepCount
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.common.users.EmailAccountIdentity
 import dk.cachet.carp.common.users.UsernameAccountIdentity
@@ -25,7 +29,11 @@ val COMMON_SERIAL_MODULE = SerializersModule {
 
     polymorphic( Data::class )
     {
+        subclass( ECG::class )
         subclass( FreeFormText::class )
+        subclass( GeoLocation::class )
+        subclass( HeartRate::class )
+        subclass( StepCount::class )
     }
 }
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/data/CarpDataTypesTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/data/CarpDataTypesTest.kt
@@ -1,0 +1,20 @@
+package dk.cachet.carp.common.data
+
+import dk.cachet.carp.common.serialization.COMMON_SERIAL_MODULE
+import kotlin.test.*
+
+
+/**
+ * Tests for [CarpDataTypes].
+ */
+class CarpDataTypesTest
+{
+    @Test
+    fun serializable_data_class_registered_for_each_data_type()
+    {
+        CarpDataTypes.forEach {
+            val serializer = COMMON_SERIAL_MODULE.getPolymorphic( Data::class, "${it.namespace}.${it.name}" )
+            assertNotNull( serializer )
+        }
+    }
+}

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/data/DataSerializationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/data/DataSerializationTest.kt
@@ -30,6 +30,6 @@ class DataSerializationTest
         val serializer = PolymorphicSerializer( Data::class )
 
         val serialized = json.encodeToString( serializer, data )
-        assertEquals( "{\"$CLASS_DISCRIMINATOR\":\"$FREEFORMTEXT_TYPE_NAME\",\"text\":\"some text\"}", serialized )
+        assertEquals( "{\"$CLASS_DISCRIMINATOR\":\"${CarpDataTypes.FREEFORMTEXT_TYPE_NAME}\",\"text\":\"some text\"}", serialized )
     }
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/carp/ECGSamplingScheme.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/carp/ECGSamplingScheme.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.protocols.domain.sampling.carp
 
-import dk.cachet.carp.common.data.ECG_TYPE
+import dk.cachet.carp.common.data.CarpDataTypes
 import dk.cachet.carp.protocols.domain.sampling.DataTypeSamplingScheme
 import dk.cachet.carp.protocols.domain.sampling.NoOptionsSamplingConfigurationBuilder
 
@@ -8,7 +8,7 @@ import dk.cachet.carp.protocols.domain.sampling.NoOptionsSamplingConfigurationBu
 /**
  * Sampling scheme for ECG, representing electrical activity of the heart over time for a single lead.
  */
-object ECGSamplingScheme : DataTypeSamplingScheme<ECGSamplingConfigurationBuilder>( ECG_TYPE )
+object ECGSamplingScheme : DataTypeSamplingScheme<ECGSamplingConfigurationBuilder>( CarpDataTypes.ECG )
 {
     override fun createSamplingConfigurationBuilder(): ECGSamplingConfigurationBuilder =
         ECGSamplingConfigurationBuilder

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/carp/GeolocationSamplingScheme.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/carp/GeolocationSamplingScheme.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.protocols.domain.sampling.carp
 
 import dk.cachet.carp.common.TimeSpan
-import dk.cachet.carp.common.data.GEOLOCATION_TYPE
+import dk.cachet.carp.common.data.CarpDataTypes
 import dk.cachet.carp.protocols.domain.sampling.DataTypeSamplingScheme
 import dk.cachet.carp.protocols.domain.sampling.IntervalSamplingConfigurationBuilder
 
@@ -11,7 +11,7 @@ import dk.cachet.carp.protocols.domain.sampling.IntervalSamplingConfigurationBui
  */
 class GeolocationSamplingScheme(
     val defaultMeasureInterval: TimeSpan
-) : DataTypeSamplingScheme<GeolocationSamplingConfigurationBuilder>( GEOLOCATION_TYPE )
+) : DataTypeSamplingScheme<GeolocationSamplingConfigurationBuilder>( CarpDataTypes.GEOLOCATION )
 {
     override fun createSamplingConfigurationBuilder(): GeolocationSamplingConfigurationBuilder =
         GeolocationSamplingConfigurationBuilder( defaultMeasureInterval )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/carp/HeartRateSamplingScheme.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/carp/HeartRateSamplingScheme.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.protocols.domain.sampling.carp
 
-import dk.cachet.carp.common.data.HEARTRATE_TYPE
+import dk.cachet.carp.common.data.CarpDataTypes
 import dk.cachet.carp.protocols.domain.sampling.DataTypeSamplingScheme
 import dk.cachet.carp.protocols.domain.sampling.NoOptionsSamplingConfigurationBuilder
 
@@ -8,7 +8,7 @@ import dk.cachet.carp.protocols.domain.sampling.NoOptionsSamplingConfigurationBu
 /**
  * Sampling scheme for heart rate data, representing the number of heart contractions (beats) per minute.
  */
-object HeartRateSamplingScheme : DataTypeSamplingScheme<HearRateSamplingConfigurationBuilder>( HEARTRATE_TYPE )
+object HeartRateSamplingScheme : DataTypeSamplingScheme<HearRateSamplingConfigurationBuilder>( CarpDataTypes.HEARTRATE )
 {
     override fun createSamplingConfigurationBuilder(): HearRateSamplingConfigurationBuilder =
         HearRateSamplingConfigurationBuilder

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/carp/StepcountSamplingScheme.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/carp/StepcountSamplingScheme.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.protocols.domain.sampling.carp
 
-import dk.cachet.carp.common.data.STEPCOUNT_TYPE
+import dk.cachet.carp.common.data.CarpDataTypes
 import dk.cachet.carp.protocols.domain.sampling.DataTypeSamplingScheme
 import dk.cachet.carp.protocols.domain.sampling.NoOptionsSamplingConfigurationBuilder
 
@@ -8,7 +8,7 @@ import dk.cachet.carp.protocols.domain.sampling.NoOptionsSamplingConfigurationBu
 /**
  * Sampling scheme for stepcount data, representing the number of steps a participant has taken in a specified time interval.
  */
-object StepcountSamplingScheme : DataTypeSamplingScheme<StepcountSamplingConfigurationBuilder>( STEPCOUNT_TYPE )
+object StepcountSamplingScheme : DataTypeSamplingScheme<StepcountSamplingConfigurationBuilder>( CarpDataTypes.STEPCOUNT )
 {
     override fun createSamplingConfigurationBuilder(): StepcountSamplingConfigurationBuilder =
         StepcountSamplingConfigurationBuilder

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/StubDataTypes.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/StubDataTypes.kt
@@ -1,12 +1,12 @@
 package dk.cachet.carp.protocols.infrastructure.test
 
-import dk.cachet.carp.common.data.CARP_NAMESPACE
+import dk.cachet.carp.common.data.CarpDataTypes
 import dk.cachet.carp.common.data.DataType
 import dk.cachet.carp.protocols.domain.sampling.DataTypeSamplingScheme
 import dk.cachet.carp.protocols.domain.sampling.NoOptionsSamplingConfigurationBuilder
 
 
-val STUB_DATA_TYPE: DataType = DataType( CARP_NAMESPACE, "stub" )
+val STUB_DATA_TYPE: DataType = DataType( CarpDataTypes.CARP_NAMESPACE, "stub" )
 
 class StubDataTypeSamplingScheme : DataTypeSamplingScheme<NoOptionsSamplingConfigurationBuilder>( STUB_DATA_TYPE )
 {

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.*
 
 
 /**
- * Tests for [ProtocolServiceRequest]'s which rely on reflection, and for now can only be executed on the JVM platform.
+ * Tests for [ProtocolServiceRequest]'s.
  */
 class ProtocolServiceRequestsTest
 {

--- a/carp.protocols.core/src/jvmTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsReflectionTest.kt
+++ b/carp.protocols.core/src/jvmTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsReflectionTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.*
 
 
 /**
- * Tests for [ProtocolServiceRequest]'s.
+ * Tests for [ProtocolServiceRequest]'s which rely on reflection, and for now can only be executed on the JVM platform.
  */
 class ProtocolServiceRequestsReflectionTest
 {


### PR DESCRIPTION
@ltj Just a pull request so you can see where (and why) the CARP `DataType`s have been moved to.

To write a unit test to ensure correct implementations of future `DataType`s I had to be able to iterate them. This is where the `EnumObjectList<DataType>` comes in. I've used this before to list all available sampling configurations in `DeviceDescriptor`s.