### PR TITLE
Bugfix: tryDeployment should return true when already deployed.

### DIFF
--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/ClientManager.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/ClientManager.kt
@@ -95,9 +95,10 @@ abstract class ClientManager<
 
     /**
      * Verifies whether the device is ready for deployment of the study runtime identified by [studyRuntimeId],
-     * and in case it is, deploys.
+     * and in case it is, deploys. In case already deployed, nothing happens and this call returns true.
      *
-     * @return True in case deployment succeeded; false in case device could not yet be deployed (e.g., awaiting registration of other devices).
+     * @return True in case deployment succeeded or is already deployed;
+     *   false in case device could not yet be deployed (e.g., awaiting registration of other devices).
      * @throws IllegalArgumentException in case no [StudyRuntime] with the given [studyRuntimeId] exists.
      * @throws UnsupportedOperationException in case deployment failed since not all necessary plugins to execute the study are available.
      */
@@ -105,6 +106,9 @@ abstract class ClientManager<
     {
         val runtime = repository.getStudyRuntimeList().firstOrNull { it.id == studyRuntimeId }
         requireNotNull( runtime ) { "The specified study runtime does not exist." }
+
+        // Early out in case this runtime has already received and validated deployment information.
+        if ( runtime.isDeployed ) return true
 
         val isDeployed = runtime.tryDeployment( deploymentService, dataCollector )
         if ( isDeployed )

--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
@@ -114,6 +114,7 @@ class StudyRuntime private constructor(
 
     /**
      * Verifies whether the device is ready for deployment and in case it is, deploys.
+     * In case already deployed, nothing happens and this call returns true.
      *
      * @return True in case deployment succeeded; false in case device could not yet be deployed (e.g., awaiting registration of other devices).
      * @throws UnsupportedOperationException in case deployment failed since not all necessary plugins to execute the study are available.
@@ -132,9 +133,10 @@ class StudyRuntime private constructor(
         deploymentStatus: StudyDeploymentStatus
     ): Boolean
     {
-        // Early out in case state indicates the device is not yet ready to deploy.
+        // Early out in case state indicates the device is already deployed or not yet ready to deploy.
         val deviceStatus = deploymentStatus.getDeviceStatus( device )
-        if ( deviceStatus !is DeviceDeploymentStatus.NotDeployed || !deviceStatus.isReadyForDeployment ) return false
+        if ( deviceStatus is DeviceDeploymentStatus.Deployed ) return true
+        if ( deviceStatus is DeviceDeploymentStatus.NotDeployed && !deviceStatus.isReadyForDeployment ) return false
 
         // Get deployment information.
         val deployment = deploymentService.getDeviceDeploymentFor( studyDeploymentId, device.roleName )

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/StudyRuntimeTest.kt
@@ -20,7 +20,7 @@ class StudyRuntimeTest
     @Test
     fun initialize_matches_requested_runtime() = runBlockingTest {
         // Create a deployment service which contains a 'smartphone study'.
-        val ( deploymentService, deploymentStatus ) = createStudyDeployment( createSmartphoneStudy() )
+        val (deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
 
         val deviceRegistration = smartphone.createRegistration()
         val dataCollector = MockDataCollector()
@@ -35,7 +35,7 @@ class StudyRuntimeTest
     @Test
     fun initialize_deploys_when_possible() = runBlockingTest {
         // Create a deployment service which contains a 'smartphone study'.
-        val ( deploymentService, deploymentStatus ) = createStudyDeployment( createSmartphoneStudy() )
+        val (deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
 
         val deviceRegistration = smartphone.createRegistration()
         val dataCollector = MockDataCollector()
@@ -52,7 +52,7 @@ class StudyRuntimeTest
     @Test
     fun initialize_does_not_deploy_when_depending_on_other_devices() = runBlockingTest {
         // Create a deployment service which contains a study where 'smartphone' depends on another master device.
-        val ( deploymentService, deploymentStatus ) = createStudyDeployment( createDependentSmartphoneStudy() )
+        val (deploymentService, deploymentStatus) = createStudyDeployment( createDependentSmartphoneStudy() )
 
         val deviceRegistration = smartphone.createRegistration()
         val dataCollector = MockDataCollector()
@@ -69,7 +69,7 @@ class StudyRuntimeTest
     @Test
     fun initialize_fails_for_unknown_studyDeploymentId() = runBlockingTest {
         // Create a deployment service which contains a 'smartphone study'.
-        val ( deploymentService, _ ) = createStudyDeployment( createSmartphoneStudy() )
+        val (deploymentService, _) = createStudyDeployment( createSmartphoneStudy() )
 
         val unknownId = UUID.randomUUID()
         val deviceRegistration = smartphone.createRegistration()
@@ -83,7 +83,7 @@ class StudyRuntimeTest
 
     @Test
     fun initialize_fails_for_unknown_deviceRoleName() = runBlockingTest {
-        val ( deploymentService, deploymentStatus ) = createStudyDeployment( createSmartphoneStudy() )
+        val (deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
 
         val deviceRegistration = smartphone.createRegistration()
         val dataCollector = MockDataCollector()
@@ -96,7 +96,7 @@ class StudyRuntimeTest
 
     @Test
     fun initialize_fails_for_incorrect_deviceRegistration() = runBlockingTest {
-        val ( deploymentService, deploymentStatus ) = createStudyDeployment( createSmartphoneStudy() )
+        val (deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
 
         val incorrectRegistration = AltBeaconDeviceRegistration( 0, UUID.randomUUID(), 0, 0 )
         val dataCollector = MockDataCollector()
@@ -110,7 +110,7 @@ class StudyRuntimeTest
     @Test
     fun tryDeployment_only_succeeds_after_dependent_devices_are_registered() = runBlockingTest {
         // Create a study runtime for a study where 'smartphone' depends on another master device ('deviceSmartphoneDependsOn').
-        val ( deploymentService, deploymentStatus ) = createStudyDeployment( createDependentSmartphoneStudy() )
+        val (deploymentService, deploymentStatus) = createStudyDeployment( createDependentSmartphoneStudy() )
         val deviceRegistration = smartphone.createRegistration()
         val dataCollector = MockDataCollector()
         val runtime = StudyRuntime.initialize(
@@ -130,6 +130,21 @@ class StudyRuntimeTest
     }
 
     @Test
+    fun tryDeployment_returns_true_when_already_deployed() = runBlockingTest {
+        // Create a study runtime which instantly deploys because the protocol only contains one master device.
+        val (deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
+        val deviceRegistration = smartphone.createRegistration()
+        val dataCollector = MockDataCollector()
+        val runtime = StudyRuntime.initialize(
+            deploymentService, dataCollector,
+            deploymentStatus.studyDeploymentId, smartphone.roleName, deviceRegistration )
+        assertTrue( runtime.isDeployed )
+
+        val isDeployed = runtime.tryDeployment( deploymentService, dataCollector )
+        assertTrue( isDeployed )
+    }
+
+    @Test
     fun tryDeployment_fails_when_requested_data_cannot_be_collected() = runBlockingTest {
         // Create a protocol that has one measure.
         val protocol = createSmartphoneStudy()
@@ -137,7 +152,7 @@ class StudyRuntimeTest
         protocol.addTriggeredTask( smartphone.atStartOfStudy(), task, smartphone )
 
         // Initializing study runtime for the smartphone deployment should fail since StubMeasure can't be collected.
-        val ( deploymentService, deploymentStatus ) = createStudyDeployment( protocol )
+        val (deploymentService, deploymentStatus) = createStudyDeployment( protocol )
         val deviceRegistration = smartphone.createRegistration()
         val dataCollector = MockDataCollector( supportsDataCollection = false )
         assertFailsWith<IllegalStateException>
@@ -151,7 +166,7 @@ class StudyRuntimeTest
     @Test
     fun creating_runtime_fromSnapshot_obtained_by_getSnapshot_is_the_same() = runBlockingTest {
         // Create a study runtime snapshot for the 'smartphone' in 'smartphone study'.
-        val ( deploymentService, deploymentStatus ) = createStudyDeployment( createSmartphoneStudy() )
+        val (deploymentService, deploymentStatus) = createStudyDeployment( createSmartphoneStudy() )
         val deviceRegistration = smartphone.createRegistration()
         val dataCollector = MockDataCollector()
         val runtime = StudyRuntime.initialize(


### PR DESCRIPTION
Thanks for the bug report, @patrickusiewicz!

I changed the behavior so that it returns `true` when already deployed. As discussed, I agree this is a more intuitive API.