### PR TITLE
Release 1.0.0-alpha.25

### DIFF
--- a/.github/workflows/imotions-notify-releases.yml
+++ b/.github/workflows/imotions-notify-releases.yml
@@ -4,7 +4,7 @@ name: Notify iMotions Slack of release
 
 on:
   release:
-    types: [published, edited]
+    types: [published]
 
 jobs:
   notify-webhook:

--- a/.github/workflows/imotions-notify-releases.yml
+++ b/.github/workflows/imotions-notify-releases.yml
@@ -1,0 +1,27 @@
+# Notify iMotions Slack webhook of releases.
+
+name: Notify iMotions Slack of release
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  notify-webhook:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        env:
+          VERSION_NAME: ${{ github.event.release.name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_NOTES: ${{ github.event.release.body }}
+        run: |
+          curl \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            -d "{ \
+                \"versionName\": \"$VERSION_NAME\", \
+                \"releaseUrl\": \"$RELEASE_URL\", \
+                \"releaseNotes\": \"$RELEASE_NOTES\" \
+              }" \
+            ${{ secrets.IMOTIONS_SLACK_RELEASE_WEBHOOK }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Two key **design goals** differentiate this project from similar projects:
     - [Domain objects](docs/carp-protocols.md#domain-objects)
     - [Built-in types](docs/carp-protocols.md#built-in-types)
     - [Extending domain objects](docs/carp-protocols.md#extending-domain-objects)
-    - [Application service](docs/carp-protocols.md#application-service)
+    - [Application services](docs/carp-protocols.md#application-services)
   - [Studies](docs/carp-studies.md)
     - [Application service](docs/carp-studies.md#application-service)
   - [Deployment](docs/carp-deployment.md)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Two key **design goals** differentiate this project from similar projects:
   - [Deployment](docs/carp-deployment.md)
     - [Study and device deployment state](docs/carp-deployment.md#study-and-device-deployment-state)
     - [Application service](docs/carp-deployment.md#application-service)
+  - [Client](docs/carp-client.md)
+    - [Study runtime state](docs/carp-client.md#study-runtime-state)
 - [Infrastructure helpers](#infrastructure-helpers)
   - [Serialization](#serialization)
   - [Request objects](#request-objects)
@@ -54,7 +56,7 @@ Two key **design goals** differentiate this project from similar projects:
 
   [![Maven Central](https://maven-badges.herokuapp.com/maven-central/dk.cachet.carp.deployment/carp.deployment.core/badge.svg?color=orange)](https://mvnrepository.com/artifact/dk.cachet.carp.deployment) [![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/dk.cachet.carp.deployment/carp.deployment.core?server=https%3A%2F%2Foss.sonatype.org)](https://oss.sonatype.org/content/repositories/snapshots/dk/cachet/carp/deployment/)
 
-- **Client**: The runtime which performs the actual data collection on a device (e.g., desktop computer or smartphone). This subsystem contains reusable components which understand the runtime configuration derived from a study protocol by the ‘deployment’ subsystem. Integrations with sensors are loaded through a 'data collection' plug-in system to decouple sensing—not part of core⁠—from sensing logic.
+- [**Client**](docs/carp-client.md): The runtime which performs the actual data collection on a device (e.g., desktop computer or smartphone). This subsystem contains reusable components which understand the runtime configuration derived from a study protocol by the ‘deployment’ subsystem. Integrations with sensors are loaded through a 'device data collector' plug-in system to decouple sensing—not part of core⁠—from sensing logic.
 
    [![Maven Central](https://maven-badges.herokuapp.com/maven-central/dk.cachet.carp.client/carp.client.core/badge.svg?color=orange)](https://mvnrepository.com/artifact/dk.cachet.carp.client) [![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/dk.cachet.carp.client/carp.client.core?server=https%3A%2F%2Foss.sonatype.org)](https://oss.sonatype.org/content/repositories/snapshots/dk/cachet/carp/client/)
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         // Version used for all submodule artifacts.
         // Snapshot publishing changes (or adds) the suffix after '-' with 'SNAPSHOT' prior to publishing.
         // The 'publishSigned' task publishes to SonaType's staging repo and 'publishSnapshot' instantly uploads to the snapshots repo.
-        globalVersion = '1.0.0-alpha.24'
+        globalVersion = '1.0.0-alpha.25'
 
         versions = [
             // Kotlin multiplatform versions.

--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntime.kt
@@ -37,6 +37,8 @@ class StudyRuntime private constructor(
         ) : Event()
 
         object DeploymentCompleted : Event()
+
+        object DeploymentStopped : Event()
     }
 
 
@@ -96,6 +98,7 @@ class StudyRuntime private constructor(
                 isDeployed = snapshot.isDeployed
                 deploymentInformation = snapshot.deploymentInformation
                 remainingDevicesToRegister = snapshot.remainingDevicesToRegister
+                isStopped = snapshot.isStopped
             }
     }
 
@@ -114,6 +117,12 @@ class StudyRuntime private constructor(
     private var remainingDevicesToRegister: List<AnyDeviceDescriptor> = emptyList()
     private var deploymentInformation: MasterDeviceDeployment? = null
 
+    /**
+     * Determines whether the study has stopped and no more further data is being collected.
+     */
+    var isStopped: Boolean = false
+        private set
+
 
     /**
      * Get the status of this [StudyRuntime].
@@ -123,6 +132,7 @@ class StudyRuntime private constructor(
             deploymentInformation == null -> StudyRuntimeStatus.NotReadyForDeployment( id )
             remainingDevicesToRegister.isNotEmpty() ->
                 StudyRuntimeStatus.RegisteringDevices( id, deploymentInformation!!, remainingDevicesToRegister )
+            isStopped -> StudyRuntimeStatus.Stopped( id, deploymentInformation!! )
             isDeployed -> StudyRuntimeStatus.Deployed( id, deploymentInformation!! )
             else -> error( "Unexpected study runtime state." )
         }
@@ -211,6 +221,26 @@ class StudyRuntime private constructor(
         // Handle race conditions with competing clients modifying device registrations, invalidating this deployment.
         catch ( ignore: IllegalArgumentException ) { } // TODO: When deployment is out of date, maybe also use `IllegalStateException` for easier handling here.
         catch ( ignore: IllegalStateException ) { }
+    }
+
+    /**
+     * Permanently stop collecting data for this [StudyRuntime].
+     */
+    suspend fun stop( deploymentService: DeploymentService ): StudyRuntimeStatus
+    {
+        // Early out in case study has already been stopped.
+        val status = getStatus()
+        if ( status is StudyRuntimeStatus.Stopped ) return status
+
+        // Stop study deployment.
+        // TODO: Right now this requires the client to be online in case `deploymentService` is an online service.
+        //       Once we have domain events in place this should be modeled as a request to stop deployment which is cached when offline.
+        val deploymentStatus = deploymentService.stop( studyDeploymentId )
+        check( deploymentStatus is StudyDeploymentStatus.Stopped )
+        isStopped = true
+        event( Event.DeploymentStopped )
+
+        return getStatus()
     }
 
     /**

--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntimeSnapshot.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntimeSnapshot.kt
@@ -18,7 +18,8 @@ data class StudyRuntimeSnapshot(
     val device: AnyMasterDeviceDescriptor,
     val isDeployed: Boolean,
     val deploymentInformation: MasterDeviceDeployment?,
-    val remainingDevicesToRegister: List<AnyDeviceDescriptor>
+    val remainingDevicesToRegister: List<AnyDeviceDescriptor>,
+    val isStopped: Boolean
 ) : Snapshot<StudyRuntime>
 {
     companion object
@@ -34,7 +35,8 @@ data class StudyRuntimeSnapshot(
                 studyRuntime.isDeployed,
                 (status as? StudyRuntimeStatus.DeploymentReceived)?.deploymentInformation,
                 (status as? StudyRuntimeStatus.RegisteringDevices)?.remainingDevicesToRegister
-                    ?: emptyList()
+                    ?: emptyList(),
+                studyRuntime.isStopped
             )
         }
     }

--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntimeStatus.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntimeStatus.kt
@@ -66,6 +66,17 @@ sealed class StudyRuntimeStatus
     {
         override val devicesRegistrationStatus = getDevicesRegistrationStatus( deploymentInformation )
     }
+
+    /**
+     * Study runtime status when deployment has been stopped, either by this client or researcher.
+     */
+    data class Stopped internal constructor(
+        override val id: StudyRuntimeId,
+        override val deploymentInformation: MasterDeviceDeployment
+    ) : StudyRuntimeStatus(), DeploymentReceived
+    {
+        override val devicesRegistrationStatus = getDevicesRegistrationStatus( deploymentInformation )
+    }
 }
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/DateTime.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/DateTime.kt
@@ -5,6 +5,9 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
 
 
 /**
@@ -34,13 +37,9 @@ expect class DateTime( msSinceUTC: Long )
 @Serializer( forClass = DateTime::class )
 object DateTimeSerializer : KSerializer<DateTime>
 {
-    override fun serialize( encoder: Encoder, value: DateTime )
-    {
-        encoder.encodeLong( value.msSinceUTC )
-    }
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor( "dk.cachet.carp.common.DateTime", PrimitiveKind.STRING )
 
-    override fun deserialize( decoder: Decoder ): DateTime
-    {
-        return DateTime( decoder.decodeLong() )
-    }
+    override fun serialize( encoder: Encoder, value: DateTime ) = encoder.encodeLong( value.msSinceUTC )
+    override fun deserialize( decoder: Decoder ): DateTime = DateTime( decoder.decodeLong() )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/MACAddress.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/MACAddress.kt
@@ -67,8 +67,8 @@ val MACAddressRegex = Regex( "([0-9A-F]{2}-){5}([0-9A-F]{2})" )
  */
 object MACAddressSerializer : KSerializer<MACAddress>
 {
-    override val descriptor: SerialDescriptor
-        get() = PrimitiveSerialDescriptor( "dk.cachet.carp.common.MACAddress", PrimitiveKind.STRING )
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor( "dk.cachet.carp.common.MACAddress", PrimitiveKind.STRING )
 
     override fun serialize( encoder: Encoder, value: MACAddress ) = encoder.encodeString( value.address )
     override fun deserialize( decoder: Decoder ): MACAddress = MACAddress( decoder.decodeString() )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/UUID.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/UUID.kt
@@ -45,8 +45,8 @@ val UUIDRegex = Regex( "([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9
  */
 object UUIDSerializer : KSerializer<UUID>
 {
-    override val descriptor: SerialDescriptor
-        get() = PrimitiveSerialDescriptor( "dk.cachet.carp.common.UUID", PrimitiveKind.STRING )
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor( "dk.cachet.carp.common.UUID", PrimitiveKind.STRING )
 
 
     override fun serialize( encoder: Encoder, value: UUID ) = encoder.encodeString( value.stringRepresentation )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
@@ -1,0 +1,27 @@
+package dk.cachet.carp.protocols.application
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
+import dk.cachet.carp.protocols.domain.devices.CustomProtocolDevice
+import dk.cachet.carp.protocols.domain.tasks.CustomProtocolTask
+
+
+/**
+ * Factory methods to create [StudyProtocolSnapshot]'s according to predefined templates.
+ */
+interface ProtocolFactoryService
+{
+    /**
+     * Create a study protocol to be deployed to a single device which has its own way of describing study protocols that
+     * deviates from the CARP core study protocol model.
+     *
+     * The [customProtocol] is stored in a single [CustomProtocolTask] which in the CARP study protocol model is described
+     * as being triggered at the start of the study for a [CustomProtocolDevice] with role name "Custom device".
+     */
+    suspend fun createCustomProtocol(
+        ownerId: UUID,
+        name: String,
+        customProtocol: String,
+        description: String = ""
+    ): StudyProtocolSnapshot
+}

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHost.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHost.kt
@@ -1,0 +1,43 @@
+package dk.cachet.carp.protocols.application
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.protocols.domain.ProtocolOwner
+import dk.cachet.carp.protocols.domain.StudyProtocol
+import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
+import dk.cachet.carp.protocols.domain.devices.CustomProtocolDevice
+import dk.cachet.carp.protocols.domain.tasks.CustomProtocolTask
+
+
+/**
+ * Implementation of [ProtocolFactoryService] which provides factory methods
+ * to create [StudyProtocolSnapshot]'s according to predefined templates.
+*/
+class ProtocolFactoryServiceHost : ProtocolFactoryService
+{
+    /**
+     * Create a study protocol to be deployed to a single device which has its own way of describing study protocols that
+     * deviates from the CARP core study protocol model.
+     *
+     * The [customProtocol] is stored in a single [CustomProtocolTask] which in the CARP study protocol model is described
+     * as being triggered at the start of the study for a [CustomProtocolDevice] with role name "Custom device".
+     */
+    override suspend fun createCustomProtocol(
+        ownerId: UUID,
+        name: String,
+        customProtocol: String,
+        description: String
+    ): StudyProtocolSnapshot
+    {
+        // Get protocol owner.
+        // TODO: If `ProtocolOwner` ever takes additional fields this needs to be retrieved from the repository.
+        val owner = ProtocolOwner( ownerId )
+
+        val protocol = StudyProtocol( owner, name, description )
+        val customDevice = CustomProtocolDevice( "Custom device" )
+        protocol.addMasterDevice( customDevice )
+        val task = CustomProtocolTask( "Custom device task", customProtocol )
+        protocol.addTriggeredTask( customDevice.atStartOfStudy(), task, customDevice )
+
+        return protocol.getSnapshot()
+    }
+}

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceRequest.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceRequest.kt
@@ -1,0 +1,21 @@
+package dk.cachet.carp.protocols.infrastructure
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.ddd.ServiceInvoker
+import dk.cachet.carp.common.ddd.createServiceInvoker
+import dk.cachet.carp.protocols.application.ProtocolFactoryService
+import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
+import kotlinx.serialization.Serializable
+
+
+/**
+ * Serializable application service requests to [ProtocolFactoryService] which can be executed on demand.
+ */
+@Serializable
+sealed class ProtocolFactoryServiceRequest
+{
+    @Serializable
+    data class CreateCustomProtocol( val ownerId: UUID, val name: String, val customProtocol: String, val description: String ) :
+        ProtocolFactoryServiceRequest(),
+        ServiceInvoker<ProtocolFactoryService, StudyProtocolSnapshot> by createServiceInvoker( ProtocolFactoryService::createCustomProtocol, ownerId, name, customProtocol, description )
+}

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHostTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHostTest.kt
@@ -1,0 +1,10 @@
+package dk.cachet.carp.protocols.application
+
+
+/**
+ * Tests for [ProtocolFactoryServiceHost].
+ */
+class ProtocolFactoryServiceHostTest : ProtocolFactoryServiceTest
+{
+    override fun createService(): ProtocolFactoryService = ProtocolFactoryServiceHost()
+}

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceTest.kt
@@ -1,0 +1,51 @@
+package dk.cachet.carp.protocols.application
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.protocols.domain.StudyProtocol
+import dk.cachet.carp.protocols.domain.tasks.CustomProtocolTask
+import dk.cachet.carp.test.runSuspendTest
+import kotlin.test.*
+
+
+/**
+ * Tests for implementations of [ProtocolFactoryService].
+ */
+interface ProtocolFactoryServiceTest
+{
+    /**
+     * Create the factory service to be used in the tests.
+     */
+    fun createService(): ProtocolFactoryService
+
+
+    @Test
+    fun createCustomProtocol_succeeds() = runSuspendTest {
+        val factory = createService()
+
+        val ownerId: UUID = UUID.randomUUID()
+        val name = "Custom protocol"
+        val customProtocol = "{...}"
+        val description = "Description"
+        val protocolSnapshot = factory.createCustomProtocol( ownerId, name, customProtocol, description )
+        val protocol = StudyProtocol.fromSnapshot( protocolSnapshot )
+
+        assertEquals( ownerId, protocol.owner.id )
+        assertEquals( name, protocol.name )
+        assertEquals( description, protocol.description )
+
+        assertEquals( 1, protocol.tasks.size )
+        val task = protocol.tasks.single()
+        assertTrue( task is CustomProtocolTask )
+        assertEquals( customProtocol, task.studyProtocol )
+    }
+
+    @Test
+    fun createCustomProtocol_contains_no_deployment_issues() = runSuspendTest {
+        val factory = createService()
+
+        val protocolSnapshot = factory.createCustomProtocol( UUID.randomUUID(), "Name", "{...}" )
+        val protocol = StudyProtocol.fromSnapshot( protocolSnapshot )
+
+        assertEquals( 0, protocol.getDeploymentIssues().count() )
+    }
+}

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceRequestsTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceRequestsTest.kt
@@ -1,0 +1,30 @@
+package dk.cachet.carp.protocols.infrastructure
+
+import dk.cachet.carp.common.UUID
+import kotlin.test.*
+
+
+/**
+ * Tests for [ProtocolFactoryServiceRequest]'s.
+ */
+class ProtocolFactoryServiceRequestsTest
+{
+    companion object
+    {
+        val requests: List<ProtocolFactoryServiceRequest> = listOf(
+            ProtocolFactoryServiceRequest.CreateCustomProtocol( UUID.randomUUID(), "Name", "...", "Description" )
+        )
+    }
+
+
+    @Test
+    fun can_serialize_and_deserialize_requests()
+    {
+        requests.forEach { request ->
+            val serializer = ProtocolFactoryServiceRequest.serializer()
+            val serialized = JSON.encodeToString( serializer, request )
+            val parsed = JSON.decodeFromString( serializer, serialized )
+            assertEquals( request, parsed )
+        }
+    }
+}

--- a/docs/carp-client.md
+++ b/docs/carp-client.md
@@ -1,0 +1,14 @@
+# carp.client [![Maven Central](https://maven-badges.herokuapp.com/maven-central/dk.cachet.carp.client/carp.client.core/badge.svg?color=orange)](https://mvnrepository.com/artifact/dk.cachet.carp.client) [![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/dk.cachet.carp.client/carp.client.core?server=https%3A%2F%2Foss.sonatype.org)](https://oss.sonatype.org/content/repositories/snapshots/dk/cachet/carp/client/) 
+
+This is the runtime which performs the actual data collection on a device (e.g., desktop computer or smartphone).
+This subsystem contains reusable components which understand the runtime configuration derived from a study protocol by the ‘deployment’ subsystem.
+Integrations with sensors are loaded through a 'device data collector' plug-in system to decouple sensing—not part of core—from sensing logic.
+
+[`ClientManager`](../carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/ClientManager.kt) is the main entry point into this subsystem.
+Concrete devices extend on it, e.g., [`SmartphoneClient`](../carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/SmartphoneClient.kt) manages data collection on a smartphone.
+
+## Study runtime state
+
+[`StudyRuntimeStatus`](../carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntimeStatus.kt) represents the status of a single study which runs on `ClientManager`.
+
+![Study deployment state machine](https://i.imgur.com/aBbsgqx.png)

--- a/docs/carp-deployment.md
+++ b/docs/carp-deployment.md
@@ -17,12 +17,12 @@ Most of the [the `DeploymentService` endpoints](#application-service) return the
 Depending on the current state of the deployment, different operations are available.
 This is represented by [`StudyDeploymentStatus`](../carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentStatus.kt), which reflects the underlying state machine:
 
-![Study deployment state machine](https://i.imgur.com/e6u5Om7.png)
+![Study deployment state machine](https://i.imgur.com/HGpF8BI.png)
 
 The overall deployment state depends on the aggregate of individual device deployment states.
 Each device within the study deployment has a corresponding [`DeviceDeploymentStatus`](../carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt):
 
-![Device deployment state machine](https://i.imgur.com/VRfD4wL.png)
+![Device deployment state machine](https://i.imgur.com/Mkb78W4.png)
 
 ## Application service
 

--- a/docs/carp-protocols.md
+++ b/docs/carp-protocols.md
@@ -92,8 +92,6 @@ Example: [`Geolocation`](../carp.protocols.core/src/commonMain/kotlin/dk/cachet/
 
 All extending classes (except `DataTypeSamplingScheme`) should be **immutable data classes**.
 The domain objects using them expect them to remain unchanged (they are [DDD value objects](https://deviq.com/value-object/)).
-To enforce correct implementation of extending objects, the `Immutable` base type they extend from uses reflection to verify whether the class is a data class and whether all members are immutable during initialization; if not, an exception is thrown.
-However, due to (current) limitations of Kotlin, the JS runtime currently does not verify this.
 
 Add a `@Serializable` annotation to the class so that it can be serialized by `kotlinx.serialization`.
 In most cases this is sufficient, but for more information, check [the serialization documentation for CARP developers](serialization.md).

--- a/docs/carp-protocols.md
+++ b/docs/carp-protocols.md
@@ -53,6 +53,7 @@ All of the built-in data types belong to the namespace: **dk.cachet.carp**.
 | --- | :---: | --- |
 | [Smartphone](../carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/Smartphone.kt) | Yes | An internet-connected phone with built-in sensors. |
 | [AltBeacon](../carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/AltBeacon.kt) | | A beacon meeting the open AltBeacon standard. |
+| [BLEHeartRateSensor](../carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/BLEHeartRateSensor.kt) | | A Bluetooth device which implements a Heart Rate service. |
 | [CustomProtocolDevice](../carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/CustomProtocolDevice.kt) | Yes | A master device which uses a single `CustomProtocolTask` to determine how to run a study on the device. |
 
 ### Tasks

--- a/docs/carp-protocols.md
+++ b/docs/carp-protocols.md
@@ -97,7 +97,7 @@ The domain objects using them expect them to remain unchanged (they are [DDD val
 Add a `@Serializable` annotation to the class so that it can be serialized by `kotlinx.serialization`.
 In most cases this is sufficient, but for more information, check [the serialization documentation for CARP developers](serialization.md).
 
-## Application service
+## Application services
 
 [ProtocolService](../carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt) allows managing multiple versions of study protocols.
 
@@ -113,3 +113,10 @@ In case you want to support organizations this could be the ID of the organizati
 | `getBy` | Find the study protocol with a specified protocol name owned by a specific owner. | protocol owner: `owner.id` | |
 | `getAllFor` | Find all study protocols owned by a specific owner. | protocol owner: `owner.id` | |
 | `getVersionHistoryFor` | Returns all stored versions for the study protocol with a given name owned by a specific owner. |  protocol owner: `owner.id` | |
+
+[ProtocolFactoryService](../carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt) provides factory methods to create common study protocols.
+To store these protocols, pass the returned protocols to `ProtocolService`.
+
+| Endpoint | Description |
+| --- | --- |
+| `createCustomProtocol` | Create a study protocol to be deployed to a single device which has its own way of describing study protocols that deviates from the CARP core study protocol model. |


### PR DESCRIPTION
Protocol subsystem change:

- Added `ProtocolFactoryService` as a new service which will create study protocols from templates so clients do not have to. The first factory method added now is `createCustomProtocol` which can be used to create a study protocol which has its own way of describing study protocols that deviates from the CARP core study protocol model. (https://github.com/cph-cachet/carp.core-kotlin/pull/187)

Client subsystem change:

- `ClientManager.stopStudy()` added to stop a study deployment from the client. (https://github.com/cph-cachet/carp.core-kotlin/pull/188)

Common:

- Bugfix; `DateTime` could't be serialized in formats other than JSON. (https://github.com/cph-cachet/carp.core-kotlin/commit/092d439351a9c5fa79d0fd7aa7992f23a67bdd5a)