### PR TITLE
Participant data endpoints

### DIFF
--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -54,14 +54,10 @@ class DeploymentServiceHost( private val repository: DeploymentRepository ) : De
      *
      * @throws IllegalArgumentException when [studyDeploymentIds] contains an ID for which no deployment exists.
      */
-    override suspend fun getStudyDeploymentStatusList( studyDeploymentIds: Set<UUID> ): List<StudyDeploymentStatus>
-    {
-        val deployments = repository.getStudyDeploymentsBy( studyDeploymentIds )
-        require( deployments.count() == studyDeploymentIds.count() )
-            { "No deployment exists for one of the specified studyDeploymentIds." }
-
-        return deployments.map{ it.getStatus() }
-    }
+    override suspend fun getStudyDeploymentStatusList( studyDeploymentIds: Set<UUID> ): List<StudyDeploymentStatus> =
+        repository
+            .getStudyDeploymentsOrThrowBy( studyDeploymentIds )
+            .map { it.getStatus() }
 
     /**
      * Register the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationService.kt
@@ -60,6 +60,7 @@ interface ParticipationService
      *   - there is no study deployment with [studyDeploymentId]
      *   - [inputDataType] is not configured as expected participant data in the study protocol
      *   - [data] is invalid data for [inputDataType]
+     * @return All data for the specified study deployment, including the newly set data.
      */
-    suspend fun setParticipantData( studyDeploymentId: UUID, inputDataType: InputDataType, data: Data? )
+    suspend fun setParticipantData( studyDeploymentId: UUID, inputDataType: InputDataType, data: Data? ): ParticipantData
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationService.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.data.Data
 import dk.cachet.carp.common.data.input.InputDataType
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
+import dk.cachet.carp.deployment.domain.users.ParticipantData
 import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 
@@ -42,7 +43,15 @@ interface ParticipationService
      *
      * @throws IllegalArgumentException when there is no study deployment with [studyDeploymentId].
      */
-    suspend fun getParticipantData( studyDeploymentId: UUID ): Map<InputDataType, Data?>
+    suspend fun getParticipantData( studyDeploymentId: UUID ): ParticipantData
+
+    /**
+     * Get currently set data for all expected participant data for a set of study deployments with [studyDeploymentIds].
+     * Data which is not set equals null.
+     *
+     * @throws IllegalArgumentException when [studyDeploymentIds] contains an ID for which no deployment exists.
+     */
+    suspend fun getParticipantDataList( studyDeploymentIds: Set<UUID> ): List<ParticipantData>
 
     /**
      * Set participant [data] for the given [inputDataType] in the study deployment with [studyDeploymentId].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHost.kt
@@ -162,8 +162,9 @@ class ParticipationServiceHost(
      *   - there is no study deployment with [studyDeploymentId]
      *   - [inputDataType] is not configured as expected participant data in the study protocol
      *   - [data] is invalid data for [inputDataType]
+     * @return All data for the specified study deployment, including the newly set data.
      */
-    override suspend fun setParticipantData( studyDeploymentId: UUID, inputDataType: InputDataType, data: Data? )
+    override suspend fun setParticipantData( studyDeploymentId: UUID, inputDataType: InputDataType, data: Data? ): ParticipantData
     {
         // Verify whether data is expected.
         val deployment = deploymentRepository.getStudyDeploymentOrThrowBy( studyDeploymentId )
@@ -173,5 +174,7 @@ class ParticipationServiceHost(
             ?: ParticipantGroup.fromDeployment( deployment )
         group.setData( participantDataInputTypes, inputDataType, data )
         participationRepository.putParticipantGroup( group )
+
+        return ParticipantData( group.studyDeploymentId, group.data.toMap() )
     }
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
@@ -32,6 +32,19 @@ interface DeploymentRepository
     suspend fun getStudyDeploymentsBy( ids: Set<UUID> ): List<StudyDeployment>
 
     /**
+     * Return all [StudyDeployment]s matching the specified [ids].
+     *
+     * @throws IllegalArgumentException when no deployment exists for one of the specified [ids].
+     */
+    suspend fun getStudyDeploymentsOrThrowBy( ids: Set<UUID> ): List<StudyDeployment>
+    {
+        val deployments = getStudyDeploymentsBy( ids )
+        require( ids.size == deployments.size ) { "No deployment exists for one of the specified studyDeploymentIds." }
+
+        return deployments
+    }
+
+    /**
      * Update a [studyDeployment] which is already stored in this repository.
      *
      * @param studyDeployment The updated version of the study deployment to store.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantData.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantData.kt
@@ -1,0 +1,14 @@
+package dk.cachet.carp.deployment.domain.users
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.data.Data
+import dk.cachet.carp.common.data.input.InputDataType
+import kotlinx.serialization.Serializable
+
+
+/**
+ * Set [data] for all expected participant data in the study deployment with [studyDeploymentId].
+ * Data which is not set equals null.
+ */
+@Serializable
+data class ParticipantData( val studyDeploymentId: UUID, val data: Map<InputDataType, Data?> )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepository.kt
@@ -21,6 +21,12 @@ interface ParticipationRepository
     suspend fun getParticipantGroup( studyDeploymentId: UUID ): ParticipantGroup?
 
     /**
+     * Return all [ParticipantGroup]s maching the specified [studyDeploymentIds].
+     * Ids that are not found are ignored.
+     */
+    suspend fun getParticipantGroupList( studyDeploymentIds: Set<UUID> ): List<ParticipantGroup>
+
+    /**
      * Adds or updates the participant [group] in this repository.
      *
      * @return the previous [ParticipantGroup] stored in the repository, or null if it was not present before.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryParticipationRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryParticipationRepository.kt
@@ -38,6 +38,15 @@ class InMemoryParticipationRepository : ParticipationRepository
         participantGroups[ studyDeploymentId ]?.let { ParticipantGroup.fromSnapshot( it ) }
 
     /**
+     * Return all [ParticipantGroup]s maching the specified [studyDeploymentIds].
+     * Ids that are not found are ignored.
+     */
+    override suspend fun getParticipantGroupList( studyDeploymentIds: Set<UUID> ): List<ParticipantGroup> =
+        participantGroups
+            .filter { it.key in studyDeploymentIds }
+            .map { ParticipantGroup.fromSnapshot( it.value ) }
+
+    /**
      * Adds or updates the participant [group] in this repository.
      *
      * @return the previous [ParticipantGroup] stored in the repository, or null if it was not present before.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipationServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipationServiceRequest.kt
@@ -8,6 +8,7 @@ import dk.cachet.carp.common.ddd.createServiceInvoker
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.application.ParticipationService
 import dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
+import dk.cachet.carp.deployment.domain.users.ParticipantData
 import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import kotlinx.serialization.Serializable
@@ -38,7 +39,12 @@ sealed class ParticipationServiceRequest
     @Serializable
     data class GetParticipantData( val studyDeploymentId: UUID ) :
         ParticipationServiceRequest(),
-        ParticipationServiceInvoker<Map<InputDataType, Data?>> by createServiceInvoker( ParticipationService::getParticipantData, studyDeploymentId )
+        ParticipationServiceInvoker<ParticipantData> by createServiceInvoker( ParticipationService::getParticipantData, studyDeploymentId )
+
+    @Serializable
+    data class GetParticipantDataList( val studyDeploymentIds: Set<UUID> ) :
+        ParticipationServiceRequest(),
+        ParticipationServiceInvoker<List<ParticipantData>> by createServiceInvoker( ParticipationService::getParticipantDataList, studyDeploymentIds )
 
     @Serializable
     data class SetParticipantData( val studyDeploymentId: UUID, val inputDataType: InputDataType, val data: Data? ) :

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipationServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipationServiceRequest.kt
@@ -49,5 +49,5 @@ sealed class ParticipationServiceRequest
     @Serializable
     data class SetParticipantData( val studyDeploymentId: UUID, val inputDataType: InputDataType, val data: Data? ) :
         ParticipationServiceRequest(),
-        ParticipationServiceInvoker<Unit> by createServiceInvoker( ParticipationService::setParticipantData, studyDeploymentId, inputDataType, data )
+        ParticipationServiceInvoker<ParticipantData> by createServiceInvoker( ParticipationService::setParticipantData, studyDeploymentId, inputDataType, data )
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/Serialization.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/Serialization.kt
@@ -7,6 +7,7 @@ import dk.cachet.carp.deployment.domain.StudyDeploymentSnapshot
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.common.users.Account
 import dk.cachet.carp.common.users.Username
+import dk.cachet.carp.deployment.domain.users.ParticipantData
 import dk.cachet.carp.deployment.domain.users.ParticipantGroupSnapshot
 import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
@@ -112,6 +113,18 @@ fun MasterDeviceDeployment.Companion.fromJson( json: String ): MasterDeviceDeplo
  */
 fun MasterDeviceDeployment.toJson(): String =
     JSON.encodeToString( MasterDeviceDeployment.serializer(), this )
+
+/**
+ * Create [ParticipantData] from JSON, serializer using the globally set infrastructure serializer ([JSON]).
+ */
+fun ParticipantData.Companion.fromJson( json: String ): ParticipantData =
+    JSON.decodeFromString( serializer(), json )
+
+/**
+ * Serializer to JSON, using the globally set infrastructure serializer ([JSON]).
+ */
+fun ParticipantData.toJson(): String =
+    JSON.encodeToString( ParticipantData.serializer(), this )
 
 /**
  * Create a [ParticipantGroupSnapshot] from JSON, serialized using the globally set infrastructure serializer ([JSON]).

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceMock.kt
@@ -18,7 +18,8 @@ import dk.cachet.carp.test.Mock
 class ParticipationServiceMock(
     private val getActiveParticipationInvitationResult: Set<ActiveParticipationInvitation> = emptySet(),
     private val getParticipantDataResult: ParticipantData = ParticipantData( UUID.randomUUID(), emptyMap() ),
-    private val getParticipantDataListResult: List<ParticipantData> = emptyList()
+    private val getParticipantDataListResult: List<ParticipantData> = emptyList(),
+    private val setParticipantDataResult: ParticipantData = ParticipantData( UUID.randomUUID(), emptyMap() )
 ) : Mock<ParticipationService>(), ParticipationService
 {
     override suspend fun addParticipation( studyDeploymentId: UUID, deviceRoleNames: Set<String>, identity: AccountIdentity, invitation: StudyInvitation ) =
@@ -38,5 +39,6 @@ class ParticipationServiceMock(
         .also { trackSuspendCall( ParticipationService::getParticipantDataList, studyDeploymentIds ) }
 
     override suspend fun setParticipantData( studyDeploymentId: UUID, inputDataType: InputDataType, data: Data? ) =
-        trackSuspendCall( ParticipationService::setParticipantData, studyDeploymentId, inputDataType, data )
+        setParticipantDataResult
+        .also { trackSuspendCall( ParticipationService::setParticipantData, studyDeploymentId, inputDataType, data ) }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceMock.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.data.Data
 import dk.cachet.carp.common.data.input.InputDataType
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
+import dk.cachet.carp.deployment.domain.users.ParticipantData
 import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
 import dk.cachet.carp.test.Mock
@@ -16,7 +17,8 @@ import dk.cachet.carp.test.Mock
 
 class ParticipationServiceMock(
     private val getActiveParticipationInvitationResult: Set<ActiveParticipationInvitation> = emptySet(),
-    private val getParticipantDataResult: Map<InputDataType, Data?> = emptyMap()
+    private val getParticipantDataResult: ParticipantData = ParticipantData( UUID.randomUUID(), emptyMap() ),
+    private val getParticipantDataListResult: List<ParticipantData> = emptyList()
 ) : Mock<ParticipationService>(), ParticipationService
 {
     override suspend fun addParticipation( studyDeploymentId: UUID, deviceRoleNames: Set<String>, identity: AccountIdentity, invitation: StudyInvitation ) =
@@ -27,9 +29,13 @@ class ParticipationServiceMock(
         getActiveParticipationInvitationResult
         .also { trackSuspendCall( ParticipationService::getActiveParticipationInvitations, accountId ) }
 
-    override suspend fun getParticipantData( studyDeploymentId: UUID ): Map<InputDataType, Data?> =
+    override suspend fun getParticipantData( studyDeploymentId: UUID ): ParticipantData =
         getParticipantDataResult
         .also { trackSuspendCall( ParticipationService::getParticipantData, studyDeploymentId ) }
+
+    override suspend fun getParticipantDataList( studyDeploymentIds: Set<UUID> ): List<ParticipantData> =
+        getParticipantDataListResult
+        .also { trackSuspendCall( ParticipationService::getParticipantDataList, studyDeploymentIds ) }
 
     override suspend fun setParticipantData( studyDeploymentId: UUID, inputDataType: InputDataType, data: Data? ) =
         trackSuspendCall( ParticipationService::setParticipantData, studyDeploymentId, inputDataType, data )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceTest.kt
@@ -198,9 +198,11 @@ abstract class ParticipationServiceTest
         val snapshot = protocol.getSnapshot()
         val status = deploymentService.createStudyDeployment( snapshot )
 
-        participationService.setParticipantData( status.studyDeploymentId, CarpInputDataTypes.SEX, Sex.Male )
-        val participantData = participationService.getParticipantData( status.studyDeploymentId )
-        assertEquals( Sex.Male, participantData.data[ CarpInputDataTypes.SEX ] )
+        val afterSet = participationService.setParticipantData( status.studyDeploymentId, CarpInputDataTypes.SEX, Sex.Male )
+        assertEquals( Sex.Male, afterSet.data[ CarpInputDataTypes.SEX ] )
+
+        val retrievedData = participationService.getParticipantData( status.studyDeploymentId )
+        assertEquals( afterSet, retrievedData )
     }
 
     @Test

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipantDataTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipantDataTest.kt
@@ -1,0 +1,29 @@
+package dk.cachet.carp.deployment.infrastructure
+
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.data.input.CarpInputDataTypes
+import dk.cachet.carp.common.data.input.Sex
+import dk.cachet.carp.deployment.domain.users.ParticipantData
+import dk.cachet.carp.protocols.infrastructure.test.STUBS_SERIAL_MODULE
+import kotlin.test.*
+
+
+/**
+ * Tests for [ParticipantData] relying on core infrastructure.
+ */
+class ParticipantDataTest
+{
+    @Test
+    fun can_serialize_and_deserialize_using_JSON()
+    {
+        JSON = createDeploymentSerializer( STUBS_SERIAL_MODULE )
+
+        val data = mapOf( CarpInputDataTypes.SEX to Sex.Male )
+        val participantData = ParticipantData( UUID.randomUUID(), data )
+
+        val serialized: String = participantData.toJson()
+        val parsed: ParticipantData = ParticipantData.fromJson( serialized )
+
+        assertEquals( participantData, parsed )
+    }
+}

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipationServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/ParticipationServiceRequestsTest.kt
@@ -23,6 +23,7 @@ class ParticipationServiceRequestsTest
             ParticipationServiceRequest.AddParticipation( UUID.randomUUID(), setOf( "Phone" ), UsernameAccountIdentity( "Test" ), StudyInvitation.empty() ),
             ParticipationServiceRequest.GetActiveParticipationInvitations( UUID.randomUUID() ),
             ParticipationServiceRequest.GetParticipantData( UUID.randomUUID() ),
+            ParticipationServiceRequest.GetParticipantDataList( emptySet() ),
             ParticipationServiceRequest.SetParticipantData( UUID.randomUUID(), CarpInputDataTypes.SEX, Sex.Male )
         )
     }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
@@ -1,8 +1,8 @@
 package dk.cachet.carp.protocols.application
 
 import dk.cachet.carp.common.DateTime
+import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.ParticipantAttribute
-import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.ProtocolVersion
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
@@ -37,41 +37,40 @@ interface ProtocolService
     suspend fun addVersion( protocol: StudyProtocolSnapshot, versionTag: String = DateTime.now().toString() )
 
     /**
-     * Replace the expected participant data for the study protocol with the specified [protocolName], owned by [owner],
-     * and the specific [versionTag] with [expectedParticipantData].
+     * Replace the expected participant data for the study protocol with the specified [protocolId]
+     * and [versionTag] with [expectedParticipantData].
      *
      * @throws IllegalArgumentException when:
-     *   - no protocol with [protocolName], owned by [owner], and the specific [versionTag] is found
+     *   - no protocol with [protocolId] is found
      *   - [expectedParticipantData] contains two or more attributes with the same input type.
      * @return The updated [StudyProtocolSnapshot].
      */
     suspend fun updateParticipantDataConfiguration(
-        owner: ProtocolOwner,
-        protocolName: String,
+        protocolId: StudyProtocol.Id,
         versionTag: String,
         expectedParticipantData: Set<ParticipantAttribute>
     ): StudyProtocolSnapshot
 
     /**
-     * Return the [StudyProtocolSnapshot] with the specified [protocolName] owned by [owner],
+     * Return the [StudyProtocolSnapshot] with the specified [protocolId],
      *
      * @param versionTag The tag of the specific version of the protocol to return. The latest version is returned when not specified.
-     * @throws IllegalArgumentException when the [owner], [protocolName], or [versionTag] does not exist.
+     * @throws IllegalArgumentException when a protocol with [protocolId] or [versionTag] does not exist.
      */
-    suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? = null ): StudyProtocolSnapshot
+    suspend fun getBy( protocolId: StudyProtocol.Id, versionTag: String? = null ): StudyProtocolSnapshot
 
     /**
-     * Find all [StudyProtocolSnapshot]'s owned by [owner].
+     * Find all [StudyProtocolSnapshot]'s owned by the owner with [ownerId].
      *
-     * @return This returns the last version of each [StudyProtocolSnapshot] owned by the specified [owner],
+     * @return This returns the last version of each [StudyProtocolSnapshot] owned by the requested owner,
      *   or an empty list when none are found.
      */
-    suspend fun getAllFor( owner: ProtocolOwner ): List<StudyProtocolSnapshot>
+    suspend fun getAllFor( ownerId: UUID ): List<StudyProtocolSnapshot>
 
     /**
-     * Returns all stored versions for the [StudyProtocol] owned by [owner] with [protocolName].
+     * Returns all stored versions for the protocol with the specified [protocolId].
      *
-     * @throws IllegalArgumentException when a protocol with [protocolName] for [owner] does not exist.
+     * @throws IllegalArgumentException when a protocol with [protocolId] does not exist.
      */
-    suspend fun getVersionHistoryFor( owner: ProtocolOwner, protocolName: String ): List<ProtocolVersion>
+    suspend fun getVersionHistoryFor( protocolId: StudyProtocol.Id ): List<ProtocolVersion>
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.protocols.application
 
 import dk.cachet.carp.common.DateTime
+import dk.cachet.carp.common.users.ParticipantAttribute
 import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.ProtocolVersion
 import dk.cachet.carp.protocols.domain.StudyProtocol
@@ -34,6 +35,22 @@ interface ProtocolService
      *   - the [versionTag] is already in use
      */
     suspend fun addVersion( protocol: StudyProtocolSnapshot, versionTag: String = DateTime.now().toString() )
+
+    /**
+     * Replace the expected participant data for the study protocol with the specified [protocolName], owned by [owner],
+     * and the specific [versionTag] with [expectedParticipantData].
+     *
+     * @throws IllegalArgumentException when:
+     *   - no protocol with [protocolName], owned by [owner], and the specific [versionTag] is found
+     *   - [expectedParticipantData] contains two or more attributes with the same input type.
+     * @return The updated [StudyProtocolSnapshot].
+     */
+    suspend fun updateParticipantDataConfiguration(
+        owner: ProtocolOwner,
+        protocolName: String,
+        versionTag: String,
+        expectedParticipantData: Set<ParticipantAttribute>
+    ): StudyProtocolSnapshot
 
     /**
      * Return the [StudyProtocolSnapshot] with the specified [protocolName] owned by [owner],

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
@@ -24,16 +24,16 @@ interface ProtocolService
     suspend fun add( protocol: StudyProtocolSnapshot, versionTag: String = "Initial" )
 
     /**
-     * Store an updated version of the specified study [protocol].
+     * Add a new version for the specified study [protocol],
+     * of which a previous version with the same owner and name is already stored.
      *
-     * @param protocol An updated version of a [StudyProtocolSnapshot] already stored.
      * @param versionTag An optional unique label used to identify this specific version of the [protocol]. The current date/time by default.
      * @throws IllegalArgumentException when:
      *   - [protocol] is not yet stored in the repository
      *   - [protocol] is invalid
      *   - the [versionTag] is already in use
      */
-    suspend fun update( protocol: StudyProtocolSnapshot, versionTag: String = DateTime.now().toString() )
+    suspend fun addVersion( protocol: StudyProtocolSnapshot, versionTag: String = DateTime.now().toString() )
 
     /**
      * Find the [StudyProtocolSnapshot] with the specified [protocolName] owned by [owner].

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
@@ -36,7 +36,7 @@ interface ProtocolService
     suspend fun addVersion( protocol: StudyProtocolSnapshot, versionTag: String = DateTime.now().toString() )
 
     /**
-     * Find the [StudyProtocolSnapshot] with the specified [protocolName] owned by [owner].
+     * Return the [StudyProtocolSnapshot] with the specified [protocolName] owned by [owner],
      *
      * @param versionTag The tag of the specific version of the protocol to return. The latest version is returned when not specified.
      * @throws IllegalArgumentException when the [owner], [protocolName], or [versionTag] does not exist.
@@ -46,13 +46,15 @@ interface ProtocolService
     /**
      * Find all [StudyProtocolSnapshot]'s owned by [owner].
      *
-     * @throws IllegalArgumentException when the [owner] does not exist.
-     * @return This returns the last version of each [StudyProtocolSnapshot] owned by the specified [owner].
+     * @return This returns the last version of each [StudyProtocolSnapshot] owned by the specified [owner],
+     *   or an empty list when none are found.
      */
     suspend fun getAllFor( owner: ProtocolOwner ): List<StudyProtocolSnapshot>
 
     /**
      * Returns all stored versions for the [StudyProtocol] owned by [owner] with [protocolName].
+     *
+     * @throws IllegalArgumentException when a protocol with [protocolName] for [owner] does not exist.
      */
     suspend fun getVersionHistoryFor( owner: ProtocolOwner, protocolName: String ): List<ProtocolVersion>
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
@@ -51,27 +51,26 @@ class ProtocolServiceHost( private val repository: StudyProtocolRepository ) : P
      */
     override suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? ): StudyProtocolSnapshot
     {
-        val protocol: StudyProtocol = repository.getBy( owner, protocolName, versionTag )
+        val protocol: StudyProtocol? = repository.getBy( owner, protocolName, versionTag )
+        requireNotNull( protocol ) { "No protocol found for the specified owner with the given name and version." }
+
         return protocol.getSnapshot()
     }
 
     /**
      * Find all [StudyProtocolSnapshot]'s owned by [owner].
      *
-     * @throws IllegalArgumentException when the [owner] does not exist.
-     * @return This returns the last version of each [StudyProtocolSnapshot] owned by the specified [owner].
+     * @return This returns the last version of each [StudyProtocolSnapshot] owned by the specified [owner],
+     *   or an empty list when none are found.
      */
-    override suspend fun getAllFor( owner: ProtocolOwner ): List<StudyProtocolSnapshot>
-    {
-        val protocols: Sequence<StudyProtocol> = repository.getAllFor( owner )
-        return protocols.map { it.getSnapshot() }.toList()
-    }
+    override suspend fun getAllFor( owner: ProtocolOwner ): List<StudyProtocolSnapshot> =
+        repository.getAllFor( owner ).map { it.getSnapshot() }.toList()
 
     /**
      * Returns all stored versions for the [StudyProtocol] owned by [owner] with [protocolName].
+     *
+     * @throws IllegalArgumentException when a protocol with [protocolName] for [owner] does not exist.
      */
-    override suspend fun getVersionHistoryFor( owner: ProtocolOwner, protocolName: String ): List<ProtocolVersion>
-    {
-        return repository.getVersionHistoryFor( owner, protocolName )
-    }
+    override suspend fun getVersionHistoryFor( owner: ProtocolOwner, protocolName: String ): List<ProtocolVersion> =
+        repository.getVersionHistoryFor( owner, protocolName )
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
@@ -28,19 +28,19 @@ class ProtocolServiceHost( private val repository: StudyProtocolRepository ) : P
     }
 
     /**
-     * Store an updated version of the specified study [protocol].
+     * Add a new version for the specified study [protocol],
+     * of which a previous version with the same owner and name is already stored.
      *
-     * @param protocol An updated version of a [StudyProtocolSnapshot] already stored.
      * @param versionTag An optional unique label used to identify this specific version of the [protocol]. The current date/time by default.
      * @throws IllegalArgumentException when:
      *   - [protocol] is not yet stored in the repository
      *   - [protocol] is invalid
      *   - the [versionTag] is already in use
      */
-    override suspend fun update( protocol: StudyProtocolSnapshot, versionTag: String )
+    override suspend fun addVersion( protocol: StudyProtocolSnapshot, versionTag: String )
     {
         val initializedProtocol = StudyProtocol.fromSnapshot( protocol )
-        repository.update( initializedProtocol, versionTag )
+        repository.addVersion( initializedProtocol, versionTag )
     }
 
     /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
@@ -24,7 +24,7 @@ class ProtocolServiceHost( private val repository: StudyProtocolRepository ) : P
     override suspend fun add( protocol: StudyProtocolSnapshot, versionTag: String )
     {
         val initializedProtocol = StudyProtocol.fromSnapshot( protocol )
-        repository.add( initializedProtocol, versionTag )
+        repository.add( initializedProtocol, ProtocolVersion( versionTag ) )
     }
 
     /**
@@ -40,7 +40,7 @@ class ProtocolServiceHost( private val repository: StudyProtocolRepository ) : P
     override suspend fun addVersion( protocol: StudyProtocolSnapshot, versionTag: String )
     {
         val initializedProtocol = StudyProtocol.fromSnapshot( protocol )
-        repository.addVersion( initializedProtocol, versionTag )
+        repository.addVersion( initializedProtocol, ProtocolVersion( versionTag ) )
     }
 
     /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/ProtocolOwner.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/ProtocolOwner.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 
 /**
- * Uniquely identifies the person or group that created a [StudyProtocol].
+ * A person or group that created a [StudyProtocol].
  */
 @Serializable
 data class ProtocolOwner( val id: UUID = UUID.randomUUID() )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/ProtocolVersion.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/ProtocolVersion.kt
@@ -5,10 +5,9 @@ import kotlinx.serialization.Serializable
 
 
 /**
- * Specifies a specific version for a [StudyProtocol].
+ * Specifies a specific version for a [StudyProtocol], identified by a [tag].
  *
  * @param date The date when this version of the protocol was created.
- * @param tag A descriptive tag which uniquely identifies this protocol version.
  */
 @Serializable
-data class ProtocolVersion( val date: DateTime, val tag: String )
+data class ProtocolVersion( val tag: String, val date: DateTime = DateTime.now() )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -263,6 +263,30 @@ class StudyProtocol(
         super.removeExpectedParticipantData( attribute )
         .eventIf( true ) { Event.ExpectedParticipantDataRemoved( attribute ) }
 
+    /**
+     * Replace the expected participant data to be input by users with the specified [attributes].
+     *
+     * TODO: This is currently defined in `StudyProtocol` rather than `ParticipantDataConfiguration` due to the need to track events.
+     *   Once eventing is implemented on `ParticipantDataConfiguration`, this can be moved where it logically belongs.
+     *
+     * @throws IllegalArgumentException in case the specified [attributes] contain two or more attributes with the same input type.
+     * @return True if any attributes have been replaced; false if the specified [attributes] were the same as those already set.
+     */
+    fun replaceExpectedParticipantData( attributes: Set<ParticipantAttribute> ): Boolean
+    {
+        require( attributes.map { it.inputType }.toSet().size == attributes.size )
+            { "The specified attributes contain two or more attributes with the same input type." }
+
+        val toRemove = expectedParticipantData.minus( attributes )
+        val toAdd = attributes.minus( expectedParticipantData )
+
+        if ( toRemove.isEmpty() && toAdd.isEmpty() ) return false
+
+        toRemove.forEach { removeExpectedParticipantData( it ) }
+        toAdd.forEach { addExpectedParticipantData( it ) }
+        return true
+    }
+
 
     /**
      * All possible issues related to incomplete or problematic configuration of a [StudyProtocol] which might prevent deployment.

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.protocols.domain
 
+import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.DomainEvent
 import dk.cachet.carp.common.users.ParticipantAttribute
 import dk.cachet.carp.protocols.domain.deployment.DeploymentError
@@ -16,6 +17,7 @@ import dk.cachet.carp.protocols.domain.tasks.EmptyTaskConfiguration
 import dk.cachet.carp.protocols.domain.tasks.TaskDescriptor
 import dk.cachet.carp.protocols.domain.triggers.Trigger
 import dk.cachet.carp.protocols.domain.triggers.TriggeredTask
+import kotlinx.serialization.Serializable
 
 
 /**
@@ -97,6 +99,15 @@ class StudyProtocol(
             return protocol
         }
     }
+
+
+    @Serializable
+    data class Id( val ownerId: UUID, val name: String )
+
+    /**
+     * A study protocol is uniquely identified by the [owner] ID and it's [name].
+     */
+    val id: Id = Id( owner.id, name )
 
 
     /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
@@ -1,5 +1,7 @@
 package dk.cachet.carp.protocols.domain
 
+import dk.cachet.carp.common.UUID
+
 
 /**
  * A repository which handles persisting different versions of [StudyProtocol]s.
@@ -35,33 +37,32 @@ interface StudyProtocolRepository
     suspend fun replace( protocol: StudyProtocol, version: ProtocolVersion )
 
     /**
-     * Return the [StudyProtocol] with the specified [protocolName] owned by [owner],
-     * or null when no such protocol is found.
+     * Return the [StudyProtocol] with the specified protocol [id], or null when no such protocol is found.
      *
      * @param versionTag The tag of the specific version of the protocol to return. The latest version is returned when not specified.
      */
-    suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? = null ): StudyProtocol?
+    suspend fun getBy( id: StudyProtocol.Id, versionTag: String? = null ): StudyProtocol?
 
     /**
-     * Return the [StudyProtocol] with the specified [protocolName] owned by [owner].
+     * Return the [StudyProtocol] with the specified [id].
      *
      * @throws IllegalArgumentException when the requested protocol is not found.
      */
-    suspend fun getByOrThrow( owner: ProtocolOwner, protocolName: String, versionTag: String? = null ): StudyProtocol =
-        getBy( owner, protocolName, versionTag )
-            ?: throw IllegalArgumentException( "A protocol named \"$protocolName\" for owner with ID \"${owner.id}\" with the specified version tag does not exist." )
+    suspend fun getByOrThrow( id: StudyProtocol.Id, versionTag: String? = null ): StudyProtocol =
+        getBy( id, versionTag )
+            ?: throw IllegalArgumentException( "A protocol named \"${id.name}\" for owner with ID \"${id.ownerId}\" with the specified version tag does not exist." )
 
     /**
-     * Find all [StudyProtocol]'s owned by [owner], or an empty sequence if none are found.
+     * Find all [StudyProtocol]'s owned by the owner with [ownerId], or an empty sequence if none are found.
      *
-     * @return This returns the last version of each [StudyProtocol] owned by the specified [owner].
+     * @return This returns the last version of each [StudyProtocol] owned by the requested owner.
      */
-    suspend fun getAllFor( owner: ProtocolOwner ): Sequence<StudyProtocol>
+    suspend fun getAllFor( ownerId: UUID ): Sequence<StudyProtocol>
 
     /**
-     * Returns all stored versions for the [StudyProtocol] owned by [owner] with [protocolName].
+     * Returns all stored versions for the [StudyProtocol] with the specified [id].
      *
-     * @throws IllegalArgumentException when a protocol with [protocolName] for [owner] does not exist.
+     * @throws IllegalArgumentException when a protocol with the specified [id] does not exist.
      */
-    suspend fun getVersionHistoryFor( owner: ProtocolOwner, protocolName: String ): List<ProtocolVersion>
+    suspend fun getVersionHistoryFor( id: StudyProtocol.Id ): List<ProtocolVersion>
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
@@ -12,21 +12,20 @@ interface StudyProtocolRepository
     /**
      * Add the specified study [protocol] to the repository.
      *
-     * @param versionTag A label used to identify this first initial version of the [protocol].
+     * @param version Identifies this first initial version of the [protocol].
      * @throws IllegalArgumentException when a [protocol] with the same owner and name already exists.
      */
-    suspend fun add( protocol: StudyProtocol, versionTag: String )
+    suspend fun add( protocol: StudyProtocol, version: ProtocolVersion )
 
     /**
-     * Add a new version for the specified study [protocol] in the repository,
+     * Add a new [version] for the specified study [protocol] in the repository,
      * of which a previous version with the same owner and name is already stored.
      *
-     * @param versionTag A unique label used to identify this specific version of the [protocol].
      * @throws IllegalArgumentException when:
      *   - the [protocol] is not yet stored in the repository
-     *   - the [versionTag] is already in use
+     *   - the tag specified in [version] is already in use
      */
-    suspend fun addVersion( protocol: StudyProtocol, versionTag: String )
+    suspend fun addVersion( protocol: StudyProtocol, version: ProtocolVersion )
 
     /**
      * Return the [StudyProtocol] with the specified [protocolName] owned by [owner],

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
@@ -2,7 +2,7 @@ package dk.cachet.carp.protocols.domain
 
 
 /**
- * A repository which handles persisting [StudyProtocol]'s and store updated versions for them.
+ * A repository which handles persisting different versions of [StudyProtocol]s.
  *
  * Protocol names are unique to a [ProtocolOwner].
  * Version tags are unique to a [StudyProtocol].
@@ -12,26 +12,25 @@ interface StudyProtocolRepository
     /**
      * Add the specified study [protocol] to the repository.
      *
-     * @param protocol The [StudyProtocol] to add.
      * @param versionTag A label used to identify this first initial version of the [protocol].
      * @throws IllegalArgumentException when the [protocol] already exists.
      */
     suspend fun add( protocol: StudyProtocol, versionTag: String )
 
     /**
-     * Store an updated version of the specified study [protocol] in the repository.
+     * Add a new version for the specified study [protocol] in the repository,
+     * of which a previous version with the same owner and name is already stored.
      *
-     * @param protocol An updated version of a [StudyProtocol] already stored in the repository.
      * @param versionTag A unique label used to identify this specific version of the [protocol].
-     * @throws IllegalArgumentException when the [protocol] is not yet stored in the repository or when the [versionTag] is already in use.
+     * @throws IllegalArgumentException when:
+     *   - the [protocol] is not yet stored in the repository
+     *   - the [versionTag] is already in use
      */
-    suspend fun update( protocol: StudyProtocol, versionTag: String )
+    suspend fun addVersion( protocol: StudyProtocol, versionTag: String )
 
     /**
      * Find the [StudyProtocol] with the specified [protocolName] owned by [owner].
      *
-     * @param owner The owner of the protocol to return.
-     * @param protocolName The name of the protocol to return.
      * @param versionTag The tag of the specific version of the protocol to return. The latest version is returned when not specified.
      * @throws IllegalArgumentException when the [owner], [protocolName], or [versionTag] does not exist.
      */

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
@@ -29,17 +29,16 @@ interface StudyProtocolRepository
     suspend fun addVersion( protocol: StudyProtocol, versionTag: String )
 
     /**
-     * Find the [StudyProtocol] with the specified [protocolName] owned by [owner].
+     * Return the [StudyProtocol] with the specified [protocolName] owned by [owner],
+     * or null when no such protocol is found.
      *
      * @param versionTag The tag of the specific version of the protocol to return. The latest version is returned when not specified.
-     * @throws IllegalArgumentException when the [owner], [protocolName], or [versionTag] does not exist.
      */
-    suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? = null ): StudyProtocol
+    suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? = null ): StudyProtocol?
 
     /**
-     * Find all [StudyProtocol]'s owned by [owner].
+     * Find all [StudyProtocol]'s owned by [owner], or an empty sequence if none are found.
      *
-     * @throws IllegalArgumentException when the [owner] does not exist.
      * @return This returns the last version of each [StudyProtocol] owned by the specified [owner].
      */
     suspend fun getAllFor( owner: ProtocolOwner ): Sequence<StudyProtocol>

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
@@ -13,7 +13,7 @@ interface StudyProtocolRepository
      * Add the specified study [protocol] to the repository.
      *
      * @param versionTag A label used to identify this first initial version of the [protocol].
-     * @throws IllegalArgumentException when the [protocol] already exists.
+     * @throws IllegalArgumentException when a [protocol] with the same owner and name already exists.
      */
     suspend fun add( protocol: StudyProtocol, versionTag: String )
 
@@ -46,6 +46,8 @@ interface StudyProtocolRepository
 
     /**
      * Returns all stored versions for the [StudyProtocol] owned by [owner] with [protocolName].
+     *
+     * @throws IllegalArgumentException when a protocol with [protocolName] for [owner] does not exist.
      */
     suspend fun getVersionHistoryFor( owner: ProtocolOwner, protocolName: String ): List<ProtocolVersion>
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
@@ -28,12 +28,28 @@ interface StudyProtocolRepository
     suspend fun addVersion( protocol: StudyProtocol, version: ProtocolVersion )
 
     /**
+     * Replace a [version] of a [protocol], of which a previous version with the same owner and name is already stored.
+     *
+     * @throws IllegalArgumentException when the [protocol] with [version] to replace is not found.
+     */
+    suspend fun replace( protocol: StudyProtocol, version: ProtocolVersion )
+
+    /**
      * Return the [StudyProtocol] with the specified [protocolName] owned by [owner],
      * or null when no such protocol is found.
      *
      * @param versionTag The tag of the specific version of the protocol to return. The latest version is returned when not specified.
      */
     suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? = null ): StudyProtocol?
+
+    /**
+     * Return the [StudyProtocol] with the specified [protocolName] owned by [owner].
+     *
+     * @throws IllegalArgumentException when the requested protocol is not found.
+     */
+    suspend fun getByOrThrow( owner: ProtocolOwner, protocolName: String, versionTag: String? = null ): StudyProtocol =
+        getBy( owner, protocolName, versionTag )
+            ?: throw IllegalArgumentException( "A protocol named \"$protocolName\" for owner with ID \"${owner.id}\" with the specified version tag does not exist." )
 
     /**
      * Find all [StudyProtocol]'s owned by [owner], or an empty sequence if none are found.

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolSnapshot.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolSnapshot.kt
@@ -55,7 +55,7 @@ data class StudyProtocolSnapshot(
                 .associateBy { curTriggerId++ }
 
             return StudyProtocolSnapshot(
-                ownerId = protocol.owner.id,
+                ownerId = protocol.ownerId,
                 name = protocol.name,
                 description = protocol.description,
                 creationDate = protocol.creationDate,

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/InMemoryStudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/InMemoryStudyProtocolRepository.kt
@@ -1,0 +1,120 @@
+package dk.cachet.carp.protocols.infrastructure
+
+import dk.cachet.carp.common.DateTime
+import dk.cachet.carp.common.UUID
+import dk.cachet.carp.protocols.domain.ProtocolOwner
+import dk.cachet.carp.protocols.domain.ProtocolVersion
+import dk.cachet.carp.protocols.domain.StudyProtocol
+import dk.cachet.carp.protocols.domain.StudyProtocolRepository
+import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
+
+
+/**
+ * A [StudyProtocolRepository] which holds study protocols in memory as long as the instance is held in memory.
+ */
+class InMemoryStudyProtocolRepository : StudyProtocolRepository
+{
+    private data class StudyProtocolId( val ownerId: UUID, val name: String )
+
+
+    private val _protocols: MutableMap<StudyProtocolId, MutableMap<ProtocolVersion, StudyProtocolSnapshot>> = mutableMapOf()
+
+
+    /**
+     * Add the specified study [protocol] to the repository.
+     *
+     * @param versionTag A label used to identify this first initial version of the [protocol].
+     * @throws IllegalArgumentException when a [protocol] with the same owner and name already exists.
+     */
+    override suspend fun add( protocol: StudyProtocol, versionTag: String )
+    {
+        val id = getId( protocol )
+        require( !_protocols.containsKey( id ) )
+            { "A protocol with the same owner and name is already stored in this repository." }
+
+        val version = ProtocolVersion( DateTime.now(), versionTag )
+        val versions = mutableMapOf( version to protocol.getSnapshot() )
+        _protocols[ id ] = versions
+    }
+
+    /**
+     * Add a new version for the specified study [protocol] in the repository,
+     * of which a previous version with the same owner and name is already stored.
+     *
+     * @param versionTag A unique label used to identify this specific version of the [protocol].
+     * @throws IllegalArgumentException when:
+     *   - the [protocol] is not yet stored in the repository
+     *   - the [versionTag] is already in use
+     */
+    override suspend fun addVersion( protocol: StudyProtocol, versionTag: String )
+    {
+        val id = getId( protocol )
+        val versions = _protocols[ id ]
+        requireNotNull( versions ) { "The specified protocol is not stored in this repository." }
+        require( versions.keys.none { it.tag == versionTag } ) { "The version tag is already in use." }
+
+        val newVersion = ProtocolVersion( DateTime.now(), versionTag )
+        versions[ newVersion ] = protocol.getSnapshot()
+    }
+
+    /**
+     * Find the [StudyProtocol] with the specified [protocolName] owned by [owner].
+     *
+     * @param versionTag The tag of the specific version of the protocol to return. The latest version is returned when not specified.
+     * @throws IllegalArgumentException when the [owner], [protocolName], or [versionTag] does not exist.
+     */
+    override suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? ): StudyProtocol
+    {
+        val id = StudyProtocolId( owner.id, protocolName )
+        val versions = _protocols[ id ]
+        requireNotNull( versions ) { "A protocol with the specified owner and protocol name does not exist." }
+
+        val selectedVersion =
+            if ( versionTag == null ) versions.getLatest()
+            else
+            {
+                versions.keys.firstOrNull { it.tag == versionTag }
+            }
+        requireNotNull( selectedVersion ) { "No matching version for the requested protocol found." }
+
+        return StudyProtocol.fromSnapshot( versions[ selectedVersion ]!! )
+    }
+
+    /**
+     * Find all [StudyProtocol]'s owned by [owner].
+     *
+     * @throws IllegalArgumentException when the [owner] does not exist.
+     * @return This returns the last version of each [StudyProtocol] owned by the specified [owner].
+     */
+    override suspend fun getAllFor( owner: ProtocolOwner ): Sequence<StudyProtocol>
+    {
+        val ownerProtocols = _protocols
+            .filter { it.key.ownerId == owner.id }
+            .map {
+                val versions = it.value
+                val latest = versions.getLatest()
+                versions[ latest ]!!
+            }
+        require( ownerProtocols.isNotEmpty() ) { "There are no protocols for the specified owner." }
+
+        return ownerProtocols.asSequence().map { StudyProtocol.fromSnapshot( it ) }
+    }
+
+    /**
+     * Returns all stored versions for the [StudyProtocol] owned by [owner] with [protocolName].
+     *
+     * @throws IllegalArgumentException when a protocol with [protocolName] for [owner] does not exist.
+     */
+    override suspend fun getVersionHistoryFor( owner: ProtocolOwner, protocolName: String ): List<ProtocolVersion>
+    {
+        val id = StudyProtocolId( owner.id, protocolName )
+        val versions = _protocols[ id ]
+        requireNotNull( versions ) { "A protocol with the specified owner and protocol name does not exist." }
+
+        return versions.keys.toList()
+    }
+
+    private fun getId( protocol: StudyProtocol ) = StudyProtocolId( protocol.owner.id, protocol.name )
+    private fun MutableMap<ProtocolVersion, StudyProtocolSnapshot>.getLatest() =
+        this.keys.last() // Versions are always stored in order.
+}

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/InMemoryStudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/InMemoryStudyProtocolRepository.kt
@@ -105,5 +105,5 @@ class InMemoryStudyProtocolRepository : StudyProtocolRepository
 
     private fun getId( protocol: StudyProtocol ) = StudyProtocolId( protocol.owner.id, protocol.name )
     private fun MutableMap<ProtocolVersion, StudyProtocolSnapshot>.getLatest() =
-        this.keys.maxByOrNull { it.date.msSinceUTC }
+        this.keys.last() // Versions are stored in order added. Adding versions quickly (e.g., in tests) can result in same dates.
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
@@ -22,9 +22,9 @@ sealed class ProtocolServiceRequest
         ServiceInvoker<ProtocolService, Unit> by createServiceInvoker( ProtocolService::add, protocol, versionTag )
 
     @Serializable
-    data class Update( val protocol: StudyProtocolSnapshot, val versionTag: String = DateTime.now().toString() ) :
+    data class AddVersion( val protocol: StudyProtocolSnapshot, val versionTag: String = DateTime.now().toString() ) :
         ProtocolServiceRequest(),
-        ServiceInvoker<ProtocolService, Unit> by createServiceInvoker( ProtocolService::update, protocol, versionTag )
+        ServiceInvoker<ProtocolService, Unit> by createServiceInvoker( ProtocolService::addVersion, protocol, versionTag )
 
     @Serializable
     data class GetBy( val owner: ProtocolOwner, val protocolName: String, val versionTag: String? = null ) :

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
@@ -1,12 +1,13 @@
 package dk.cachet.carp.protocols.infrastructure
 
 import dk.cachet.carp.common.DateTime
+import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.createServiceInvoker
 import dk.cachet.carp.common.ddd.ServiceInvoker
 import dk.cachet.carp.common.users.ParticipantAttribute
 import dk.cachet.carp.protocols.application.ProtocolService
-import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.ProtocolVersion
+import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import kotlinx.serialization.Serializable
 
@@ -28,22 +29,22 @@ sealed class ProtocolServiceRequest
         ServiceInvoker<ProtocolService, Unit> by createServiceInvoker( ProtocolService::addVersion, protocol, versionTag )
 
     @Serializable
-    data class UpdateParticipantDataConfiguration( val owner: ProtocolOwner, val protocolName: String, val versionTag: String, val expectedParticipantData: Set<ParticipantAttribute> ) :
+    data class UpdateParticipantDataConfiguration( val protocolId: StudyProtocol.Id, val versionTag: String, val expectedParticipantData: Set<ParticipantAttribute> ) :
         ProtocolServiceRequest(),
-        ServiceInvoker<ProtocolService, StudyProtocolSnapshot> by createServiceInvoker( ProtocolService::updateParticipantDataConfiguration, owner, protocolName, versionTag, expectedParticipantData )
+        ServiceInvoker<ProtocolService, StudyProtocolSnapshot> by createServiceInvoker( ProtocolService::updateParticipantDataConfiguration, protocolId, versionTag, expectedParticipantData )
 
     @Serializable
-    data class GetBy( val owner: ProtocolOwner, val protocolName: String, val versionTag: String? = null ) :
+    data class GetBy( val protocolId: StudyProtocol.Id, val versionTag: String? = null ) :
         ProtocolServiceRequest(),
-        ServiceInvoker<ProtocolService, StudyProtocolSnapshot> by createServiceInvoker( ProtocolService::getBy, owner, protocolName, versionTag )
+        ServiceInvoker<ProtocolService, StudyProtocolSnapshot> by createServiceInvoker( ProtocolService::getBy, protocolId, versionTag )
 
     @Serializable
-    data class GetAllFor( val owner: ProtocolOwner ) :
+    data class GetAllFor( val ownerId: UUID ) :
         ProtocolServiceRequest(),
-        ServiceInvoker<ProtocolService, List<StudyProtocolSnapshot>> by createServiceInvoker( ProtocolService::getAllFor, owner )
+        ServiceInvoker<ProtocolService, List<StudyProtocolSnapshot>> by createServiceInvoker( ProtocolService::getAllFor, ownerId )
 
     @Serializable
-    data class GetVersionHistoryFor( val owner: ProtocolOwner, val protocolName: String ) :
+    data class GetVersionHistoryFor( val protocolId: StudyProtocol.Id ) :
         ProtocolServiceRequest(),
-        ServiceInvoker<ProtocolService, List<ProtocolVersion>> by createServiceInvoker( ProtocolService::getVersionHistoryFor, owner, protocolName )
+        ServiceInvoker<ProtocolService, List<ProtocolVersion>> by createServiceInvoker( ProtocolService::getVersionHistoryFor, protocolId )
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.protocols.infrastructure
 import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.ddd.createServiceInvoker
 import dk.cachet.carp.common.ddd.ServiceInvoker
+import dk.cachet.carp.common.users.ParticipantAttribute
 import dk.cachet.carp.protocols.application.ProtocolService
 import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.ProtocolVersion
@@ -25,6 +26,11 @@ sealed class ProtocolServiceRequest
     data class AddVersion( val protocol: StudyProtocolSnapshot, val versionTag: String = DateTime.now().toString() ) :
         ProtocolServiceRequest(),
         ServiceInvoker<ProtocolService, Unit> by createServiceInvoker( ProtocolService::addVersion, protocol, versionTag )
+
+    @Serializable
+    data class UpdateParticipantDataConfiguration( val owner: ProtocolOwner, val protocolName: String, val versionTag: String, val expectedParticipantData: Set<ParticipantAttribute> ) :
+        ProtocolServiceRequest(),
+        ServiceInvoker<ProtocolService, StudyProtocolSnapshot> by createServiceInvoker( ProtocolService::updateParticipantDataConfiguration, owner, protocolName, versionTag, expectedParticipantData )
 
     @Serializable
     data class GetBy( val owner: ProtocolOwner, val protocolName: String, val versionTag: String? = null ) :

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/CreateTestObjects.kt
@@ -68,12 +68,12 @@ val STUBS_SERIAL_MODULE = SerializersModule {
  * Creates a study protocol using the default initialization (no devices, tasks, or triggers),
  * and initializes the infrastructure serializer to be aware about polymorph stub testing classes.
  */
-fun createEmptyProtocol(): StudyProtocol
+fun createEmptyProtocol( name: String = "Test protocol" ): StudyProtocol
 {
     JSON = createProtocolsSerializer( STUBS_SERIAL_MODULE )
 
     val alwaysSameOwner = ProtocolOwner( UUID( "27879e75-ccc1-4866-9ab3-4ece1b735052" ) )
-    return StudyProtocol( alwaysSameOwner, "Test protocol", "Test description" )
+    return StudyProtocol( alwaysSameOwner, name, "Test description" )
 }
 
 /**

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceTest.kt
@@ -29,7 +29,7 @@ interface ProtocolFactoryServiceTest
         val protocolSnapshot = factory.createCustomProtocol( ownerId, name, customProtocol, description )
         val protocol = StudyProtocol.fromSnapshot( protocolSnapshot )
 
-        assertEquals( ownerId, protocol.owner.id )
+        assertEquals( ownerId, protocol.ownerId )
         assertEquals( name, protocol.name )
         assertEquals( description, protocol.description )
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHostTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHostTest.kt
@@ -1,0 +1,12 @@
+package dk.cachet.carp.protocols.application
+
+import dk.cachet.carp.protocols.infrastructure.InMemoryStudyProtocolRepository
+
+
+/**
+ * Tests for [ProtocolServiceHost].
+ */
+class ProtocolServiceHostTest : ProtocolServiceTest
+{
+    override fun createService(): ProtocolService = ProtocolServiceHost( InMemoryStudyProtocolRepository() )
+}

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceMock.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceMock.kt
@@ -16,8 +16,8 @@ class ProtocolServiceMock(
     override suspend fun add( protocol: StudyProtocolSnapshot, versionTag: String ) =
         trackSuspendCall( ProtocolService::add, protocol, versionTag )
 
-    override suspend fun update( protocol: StudyProtocolSnapshot, versionTag: String ) =
-        trackSuspendCall( ProtocolService::update, protocol, versionTag )
+    override suspend fun addVersion( protocol: StudyProtocolSnapshot, versionTag: String ) =
+        trackSuspendCall( ProtocolService::addVersion, protocol, versionTag )
 
     override suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? ): StudyProtocolSnapshot
     {

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceMock.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceMock.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.protocols.application
 
+import dk.cachet.carp.common.users.ParticipantAttribute
 import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.ProtocolVersion
 import dk.cachet.carp.protocols.domain.StudyProtocol
@@ -8,6 +9,7 @@ import dk.cachet.carp.test.Mock
 
 
 class ProtocolServiceMock(
+    val updateParticipantDataConfigurationResult: StudyProtocolSnapshot = StudyProtocol( ProtocolOwner(), "Mock" ).getSnapshot(),
     val getByResult: StudyProtocolSnapshot = StudyProtocol( ProtocolOwner(), "Mock" ).getSnapshot(),
     val getAllForResult: List<StudyProtocolSnapshot> = listOf(),
     val getVersionHistoryForResult: List<ProtocolVersion> = listOf()
@@ -18,6 +20,17 @@ class ProtocolServiceMock(
 
     override suspend fun addVersion( protocol: StudyProtocolSnapshot, versionTag: String ) =
         trackSuspendCall( ProtocolService::addVersion, protocol, versionTag )
+
+    override suspend fun updateParticipantDataConfiguration(
+        owner: ProtocolOwner,
+        protocolName: String,
+        versionTag: String,
+        expectedParticipantData: Set<ParticipantAttribute>
+    ): StudyProtocolSnapshot
+    {
+        trackSuspendCall( ProtocolService::updateParticipantDataConfiguration, owner, protocolName, versionTag, expectedParticipantData )
+        return updateParticipantDataConfigurationResult
+    }
 
     override suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? ): StudyProtocolSnapshot
     {

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceMock.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceMock.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.protocols.application
 
+import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.users.ParticipantAttribute
 import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.ProtocolVersion
@@ -22,31 +23,30 @@ class ProtocolServiceMock(
         trackSuspendCall( ProtocolService::addVersion, protocol, versionTag )
 
     override suspend fun updateParticipantDataConfiguration(
-        owner: ProtocolOwner,
-        protocolName: String,
+        protocolId: StudyProtocol.Id,
         versionTag: String,
         expectedParticipantData: Set<ParticipantAttribute>
     ): StudyProtocolSnapshot
     {
-        trackSuspendCall( ProtocolService::updateParticipantDataConfiguration, owner, protocolName, versionTag, expectedParticipantData )
+        trackSuspendCall( ProtocolService::updateParticipantDataConfiguration, protocolId, versionTag, expectedParticipantData )
         return updateParticipantDataConfigurationResult
     }
 
-    override suspend fun getBy( owner: ProtocolOwner, protocolName: String, versionTag: String? ): StudyProtocolSnapshot
+    override suspend fun getBy( protocolId: StudyProtocol.Id, versionTag: String? ): StudyProtocolSnapshot
     {
-        trackSuspendCall( ProtocolService::getBy, owner, protocolName, versionTag )
+        trackSuspendCall( ProtocolService::getBy, protocolId, versionTag )
         return getByResult
     }
 
-    override suspend fun getAllFor( owner: ProtocolOwner ): List<StudyProtocolSnapshot>
+    override suspend fun getAllFor( ownerId: UUID ): List<StudyProtocolSnapshot>
     {
-        trackSuspendCall( ProtocolService::getAllFor, owner )
+        trackSuspendCall( ProtocolService::getAllFor, ownerId )
         return getAllForResult
     }
 
-    override suspend fun getVersionHistoryFor( owner: ProtocolOwner, protocolName: String ): List<ProtocolVersion>
+    override suspend fun getVersionHistoryFor( protocolId: StudyProtocol.Id ): List<ProtocolVersion>
     {
-        trackSuspendCall( ProtocolService::getVersionHistoryFor, owner, protocolName )
+        trackSuspendCall( ProtocolService::getVersionHistoryFor, protocolId )
         return getVersionHistoryForResult
     }
 }

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceTest.kt
@@ -154,8 +154,8 @@ interface ProtocolServiceTest
         modifyProtocol( protocol2 )
         service.addVersion( protocol2.getSnapshot(), "Version 2" )
 
-        val owner = protocol1.owner // Also owner of protocol2; `createEmptyProtocol` has a fixed owner.
-        val protocols = service.getAllFor( owner.id )
+        val ownerId = protocol1.ownerId // Also owner of protocol2; `createEmptyProtocol` has a fixed owner.
+        val protocols = service.getAllFor( ownerId )
         assertEquals( setOf( protocol1.getSnapshot(), protocol2.getSnapshot() ), protocols.toSet() )
     }
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceTest.kt
@@ -1,0 +1,158 @@
+package dk.cachet.carp.protocols.application
+
+import dk.cachet.carp.protocols.domain.ProtocolOwner
+import dk.cachet.carp.protocols.domain.StudyProtocol
+import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
+import dk.cachet.carp.protocols.infrastructure.test.StubMasterDeviceDescriptor
+import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
+import dk.cachet.carp.test.runSuspendTest
+import kotlin.test.*
+
+
+/**
+ * Tests for implementations of [ProtocolService].
+ */
+interface ProtocolServiceTest
+{
+    /**
+     * Create a study service to be used in the tests.
+     */
+    fun createService(): ProtocolService
+
+
+    @Test
+    fun add_protocol_and_retrieving_it_succeeds() = runSuspendTest {
+        val service = createService()
+        val protocol = createEmptyProtocol()
+        val snapshot = protocol.getSnapshot()
+
+        service.add( snapshot, "Initial" )
+        val retrieved = service.getBy( protocol.owner, protocol.name, "Initial" )
+        assertEquals( snapshot, retrieved )
+    }
+
+    @Test
+    fun add_fails_when_protocol_already_exists() = runSuspendTest {
+        val service = createService()
+        val protocol = createEmptyProtocol().getSnapshot()
+        service.add( protocol )
+
+        assertFailsWith<IllegalArgumentException> { service.add( protocol ) }
+    }
+
+    @Test
+    fun addVersion_succeeds() = runSuspendTest {
+        val service = createService()
+        val protocol = createEmptyProtocol()
+        service.add( protocol.getSnapshot() )
+
+        modifyProtocol( protocol )
+        val version2Snapshot = protocol.getSnapshot()
+        service.addVersion( version2Snapshot, "Version 2" )
+
+        val retrieved = service.getBy( protocol.owner, protocol.name, "Version 2" )
+        assertEquals( version2Snapshot, retrieved )
+    }
+
+    @Test
+    fun addVersion_fails_when_protocol_does_not_exist() = runSuspendTest {
+        val service = createService()
+        val protocol = createEmptyProtocol()
+
+        assertFailsWith<IllegalArgumentException> { service.addVersion( protocol.getSnapshot() ) }
+    }
+
+    @Test
+    fun addVersion_fails_when_version_tag_in_use() = runSuspendTest {
+        val service = createService()
+        val protocol = createEmptyProtocol()
+        service.add( protocol.getSnapshot(), "In use" )
+        modifyProtocol( protocol )
+
+        val newSnapshot = protocol.getSnapshot()
+        assertFailsWith<IllegalArgumentException> { service.addVersion( newSnapshot, "In use" ) }
+    }
+
+    @Test
+    fun add_and_addVersion_fail_when_protocol_is_invalid() = runSuspendTest {
+        val service = createService()
+        val protocol = createEmptyProtocol()
+        service.add( protocol.getSnapshot() )
+
+        val invalidSnapshot = protocol.getSnapshot().copy(
+            triggeredTasks = listOf(
+                StudyProtocolSnapshot.TriggeredTask( 0, "Non-existing", "Not a device" )
+            )
+        )
+
+        assertFailsWith<IllegalArgumentException> { service.add( invalidSnapshot ) }
+        assertFailsWith<IllegalArgumentException> { service.addVersion( invalidSnapshot, "New version" ) }
+    }
+
+    @Test
+    fun getBy_returns_latest_version_when_no_version_specified() = runSuspendTest {
+        val service = createService()
+        val protocol = createEmptyProtocol()
+        service.add( protocol.getSnapshot(), "In use" )
+        modifyProtocol( protocol )
+        val lastSnapshot = protocol.getSnapshot()
+        service.addVersion( lastSnapshot, "Version 2" )
+
+        val retrieved = service.getBy( protocol.owner, protocol.name )
+        assertEquals( lastSnapshot, retrieved )
+    }
+
+    @Test
+    fun getBy_fails_for_nonexisting_protocol() = runSuspendTest {
+        val service = createService()
+
+        val unknownOwner = ProtocolOwner()
+        assertFailsWith<IllegalArgumentException> { service.getBy( unknownOwner, "Nope" ) }
+    }
+
+    @Test
+    fun getAllFor_returns_last_version_of_each_protocol() = runSuspendTest {
+        val service = createService()
+        val protocol1 = createEmptyProtocol( "Protocol 1" )
+        service.add( protocol1.getSnapshot() )
+        val protocol2 = createEmptyProtocol( "Protocol 2" )
+        service.add( protocol2.getSnapshot() )
+        modifyProtocol( protocol2 )
+        service.addVersion( protocol2.getSnapshot(), "Version 2" )
+
+        val owner = protocol1.owner // Also owner of protocol2; `createEmptyProtocol` has a fixed owner.
+        val protocols = service.getAllFor( owner )
+        assertEquals( setOf( protocol1.getSnapshot(), protocol2.getSnapshot() ), protocols.toSet() )
+    }
+
+    @Test
+    fun getAllFor_returns_empty_list_when_none_found() = runSuspendTest {
+        val service = createService()
+
+        val unknown = ProtocolOwner()
+        assertTrue( service.getAllFor( unknown ).isEmpty() )
+    }
+
+    @Test
+    fun getVersionHistoryFor_succeeds() = runSuspendTest {
+        val service = createService()
+        val protocol = createEmptyProtocol()
+        service.add( protocol.getSnapshot(), "1" )
+        modifyProtocol( protocol )
+        service.addVersion( protocol.getSnapshot(), "2" )
+
+        val history = service.getVersionHistoryFor( protocol.owner, protocol.name )
+        assertEquals( setOf( "1", "2" ), history.map { it.tag }.toSet() )
+    }
+
+    @Test
+    fun getVersionHistoryFor_fails_when_protocol_not_found() = runSuspendTest {
+        val service = createService()
+
+        val unknown = ProtocolOwner()
+        assertFailsWith<IllegalArgumentException> { service.getVersionHistoryFor( unknown, "Unknown" ) }
+    }
+
+    private fun modifyProtocol( protocol: StudyProtocol ): StudyProtocol =
+        protocol.apply { addMasterDevice( StubMasterDeviceDescriptor() ) }
+}

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
@@ -26,6 +26,7 @@ interface StudyProtocolRepositoryTest
         repo.add( protocol, "Initial" )
         val retrieved = repo.getBy( owner, name )
 
+        assertNotNull( retrieved )
         assertNotSame( protocol, retrieved )
         assertEquals( protocol.getSnapshot(), retrieved.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
     }
@@ -51,6 +52,7 @@ interface StudyProtocolRepositoryTest
         repo.addVersion( protocol, "New version" )
 
         val retrieved = repo.getBy( owner, name, "New version" )
+        assertNotNull( retrieved )
         assertEquals( protocol.getSnapshot(), retrieved.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
     }
 
@@ -86,6 +88,7 @@ interface StudyProtocolRepositoryTest
         repo.addVersion( protocol2, "New version" )
 
         val retrieved = repo.getBy( owner, name )
+        assertNotNull( retrieved )
         assertNotSame( protocol2, retrieved )
         assertEquals( protocol2.getSnapshot(), retrieved.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
     }
@@ -107,37 +110,38 @@ interface StudyProtocolRepositoryTest
         protocol3.addMasterDevice( StubMasterDeviceDescriptor( "Other device" ) )
         repo.addVersion( protocol3, "Version 3" )
 
-        val retrievedProtocol = repo.getBy( owner, name, "Version 2" )
-        assertNotSame( protocol2, retrievedProtocol )
-        assertEquals( protocol2.getSnapshot(), retrievedProtocol.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
+        val retrieved = repo.getBy( owner, name, "Version 2" )
+        assertNotNull ( retrieved )
+        assertNotSame( protocol2, retrieved )
+        assertEquals( protocol2.getSnapshot(), retrieved.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
     }
 
     @Test
-    fun getBy_fails_for_owner_which_does_not_exist() = runSuspendTest {
+    fun getBy_returns_null_for_owner_which_does_not_exist() = runSuspendTest {
         val repo = createRepository()
 
-        assertFailsWith<IllegalArgumentException> { repo.getBy( ProtocolOwner(), "Study" ) }
+        assertNull( repo.getBy( ProtocolOwner(), "Study" ) )
     }
 
     @Test
-    fun getBy_fails_for_name_which_does_not_exist() = runSuspendTest {
+    fun getBy_returns_null_for_name_which_does_not_exist() = runSuspendTest {
         val repo = createRepository()
         val owner = ProtocolOwner()
         val protocol = StudyProtocol( owner, "Study" )
         repo.add( protocol, "Initial" )
 
-        assertFailsWith<IllegalArgumentException> { repo.getBy( owner, "Non-existing study" ) }
+        assertNull( repo.getBy( owner, "Non-existing study" ) )
     }
 
     @Test
-    fun getBy_fails_for_version_which_does_not_exist() = runSuspendTest {
+    fun getBy_returns_null_for_version_which_does_not_exist() = runSuspendTest {
         val repo = createRepository()
         val owner = ProtocolOwner()
         val protocol = StudyProtocol( owner, "Study" )
         repo.add( protocol, "Initial" )
         repo.addVersion( protocol, "Update" )
 
-        assertFailsWith<IllegalArgumentException> { repo.getBy( owner, "Study", "Non-existing version" ) }
+        assertNull( repo.getBy( owner, "Study", "Non-existing version" ) )
     }
 
     @Test
@@ -163,10 +167,11 @@ interface StudyProtocolRepositoryTest
     }
 
     @Test
-    fun getAllFor_fails_for_owner_which_does_not_exist() = runSuspendTest {
+    fun getAllFor_is_empty_when_no_protocols_are_stored_for_owner() = runSuspendTest {
         val repo = createRepository()
 
-        assertFailsWith<IllegalArgumentException> { repo.getAllFor( ProtocolOwner() ) }
+        val protocols = repo.getAllFor( ProtocolOwner() )
+        assertTrue( protocols.count() == 0 )
     }
 
     @Test

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
@@ -36,11 +36,11 @@ interface StudyProtocolRepositoryTest
 
         val protocol2 = StudyProtocol( owner, "Study" )
         protocol2.addMasterDevice( StubMasterDeviceDescriptor( "Device" ) )
-        repo.update( protocol2, "Version 2" )
+        repo.addVersion( protocol2, "Version 2" )
 
         val protocol3 = StudyProtocol( owner, "Study" )
         protocol3.addMasterDevice( StubMasterDeviceDescriptor( "Other device" ) )
-        repo.update( protocol3, "Version 3" )
+        repo.addVersion( protocol3, "Version 3" )
 
         val retrievedProtocol = repo.getBy( owner, "Study", "Version 2" )
         assertEquals( protocol2.getSnapshot(), retrievedProtocol.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
@@ -87,7 +87,7 @@ interface StudyProtocolRepositoryTest
         val owner = ProtocolOwner()
         val protocol = StudyProtocol( owner, "Study" )
         repo.add( protocol, "Initial" )
-        repo.update( protocol, "Update" )
+        repo.addVersion( protocol, "Update" )
 
         assertFailsWith<IllegalArgumentException>
         {
@@ -96,14 +96,14 @@ interface StudyProtocolRepositoryTest
     }
 
     @Test
-    fun update_study_protocol_succeeds() = runSuspendTest {
+    fun addVersion_to_study_protocol_succeeds() = runSuspendTest {
         val repo = createRepository()
         val owner = ProtocolOwner()
         val protocol = StudyProtocol( owner, "Study" )
         repo.add( protocol, "Initial" )
 
         protocol.addMasterDevice( StubMasterDeviceDescriptor() )
-        repo.update( protocol, "New version" )
+        repo.addVersion( protocol, "New version" )
         val retrieved = repo.getBy( owner, "Study" )
         assertEquals( protocol.getSnapshot(), retrieved.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
     }
@@ -115,7 +115,7 @@ interface StudyProtocolRepositoryTest
         val protocol = StudyProtocol( ProtocolOwner(), "Study" )
         assertFailsWith<IllegalArgumentException>
         {
-            repo.update( protocol, "New version" )
+            repo.addVersion( protocol, "New version" )
         }
     }
 
@@ -128,7 +128,7 @@ interface StudyProtocolRepositoryTest
         repo.add( protocol1, "Initial" )
         repo.add( protocol2, "Initial" )
         protocol2.addMasterDevice( StubMasterDeviceDescriptor() )
-        repo.update( protocol2, "Latest should be retrieved" )
+        repo.addVersion( protocol2, "Latest should be retrieved" )
 
         // StudyProtocol does not implement equals, but snapshot does, so compare snapshots.
         val protocols: List<StudyProtocolSnapshot> = repo.getAllFor( owner ).map { it.getSnapshot() }.toList()
@@ -152,8 +152,8 @@ interface StudyProtocolRepositoryTest
         val owner = ProtocolOwner()
         val protocol = StudyProtocol( owner, "Study" )
         repo.add( protocol, "Initial" )
-        repo.update( protocol, "Version 1" )
-        repo.update( protocol, "Version 2" )
+        repo.addVersion( protocol, "Version 1" )
+        repo.addVersion( protocol, "Version 2" )
 
         val history: List<ProtocolVersion> = repo.getVersionHistoryFor( owner, "Study" )
         val historyVersions: List<String> = history.map { it.tag }.toList()

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
@@ -79,6 +79,30 @@ interface StudyProtocolRepositoryTest
     }
 
     @Test
+    fun replace_succeeds() = runSuspendTest {
+        val repo = createRepository()
+        val protocol = StudyProtocol( ProtocolOwner(), "Study" )
+        val version = ProtocolVersion( "Version" )
+        repo.add( protocol, version )
+
+        protocol.addMasterDevice( StubMasterDeviceDescriptor() )
+        repo.replace( protocol, version )
+
+        val retrieved = repo.getBy( protocol.owner, protocol.name, "Version" )
+        assertNotNull( retrieved )
+        assertNotSame( protocol, retrieved )
+        assertEquals( protocol.getSnapshot(), retrieved.getSnapshot() )
+    }
+
+    @Test
+    fun replace_fails_for_protocol_which_does_not_exist() = runSuspendTest {
+        val repo = createRepository()
+
+        val protocol = StudyProtocol( ProtocolOwner(), "Study")
+        assertFailsWith<IllegalArgumentException> { repo.replace( protocol, ProtocolVersion( "Version" )) }
+    }
+
+    @Test
     fun getBy_gets_latest_when_version_not_specified() = runSuspendTest {
         val repo = createRepository()
         val owner = ProtocolOwner()

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
@@ -17,147 +17,180 @@ interface StudyProtocolRepositoryTest
 
 
     @Test
-    fun adding_study_protocol_and_retrieving_it_succeeds() = runSuspendTest {
+    fun add_protocol_and_retrieving_it_succeeds() = runSuspendTest {
         val repo = createRepository()
         val owner = ProtocolOwner()
-        val protocol = StudyProtocol( owner, "Study" )
+        val name = "Study"
+        val protocol = StudyProtocol( owner, name )
 
         repo.add( protocol, "Initial" )
-        val retrieved = repo.getBy( owner, "Study" )
+        val retrieved = repo.getBy( owner, name )
+
+        assertNotSame( protocol, retrieved )
         assertEquals( protocol.getSnapshot(), retrieved.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
     }
 
     @Test
-    fun getBy_for_a_specific_protocol_version_succeeds() = runSuspendTest {
-        val repo = createRepository()
-        val owner = ProtocolOwner()
-        val protocol1 = StudyProtocol( owner, "Study" )
-        repo.add( protocol1, "Initial" )
-
-        val protocol2 = StudyProtocol( owner, "Study" )
-        protocol2.addMasterDevice( StubMasterDeviceDescriptor( "Device" ) )
-        repo.addVersion( protocol2, "Version 2" )
-
-        val protocol3 = StudyProtocol( owner, "Study" )
-        protocol3.addMasterDevice( StubMasterDeviceDescriptor( "Other device" ) )
-        repo.addVersion( protocol3, "Version 3" )
-
-        val retrievedProtocol = repo.getBy( owner, "Study", "Version 2" )
-        assertEquals( protocol2.getSnapshot(), retrievedProtocol.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
-    }
-
-    @Test
-    fun cant_add_study_protocol_which_already_exists() = runSuspendTest {
+    fun add_fails_for_existing_protocol() = runSuspendTest {
         val repo = createRepository()
         val protocol = StudyProtocol( ProtocolOwner(), "Study" )
         repo.add( protocol, "Initial" )
 
-        assertFailsWith<IllegalArgumentException>
-        {
-            repo.add( protocol, "Version tag is not checked." )
-        }
+        assertFailsWith<IllegalArgumentException> { repo.add( protocol, "Version doesn't determine identity." ) }
     }
 
     @Test
-    fun cant_getBy_owner_which_does_not_exist() = runSuspendTest {
+    fun addVersion_succeeds() = runSuspendTest {
+        val repo = createRepository()
+        val owner = ProtocolOwner()
+        val name = "Study"
+        val protocol = StudyProtocol( owner, name )
+        repo.add( protocol, "Initial" )
+
+        protocol.addMasterDevice( StubMasterDeviceDescriptor() )
+        repo.addVersion( protocol, "New version" )
+
+        val retrieved = repo.getBy( owner, name, "New version" )
+        assertEquals( protocol.getSnapshot(), retrieved.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
+    }
+
+    @Test
+    fun addVersion_fails_for_protocol_which_does_not_exist() = runSuspendTest {
         val repo = createRepository()
 
-        assertFailsWith<IllegalArgumentException>
-        {
-            repo.getBy( ProtocolOwner(), "Study" )
-        }
+        val protocol = StudyProtocol( ProtocolOwner(), "Study" )
+        assertFailsWith<IllegalArgumentException> { repo.addVersion( protocol, "New version" ) }
     }
 
     @Test
-    fun cant_getBy_study_which_does_not_exist() = runSuspendTest {
+    fun addVersion_fails_for_version_which_is_already_in_use() = runSuspendTest {
+        val repo = createRepository()
+        val protocol = StudyProtocol( ProtocolOwner(), "Study" )
+        repo.add( protocol, "Version" )
+
+        protocol.addMasterDevice( StubMasterDeviceDescriptor() )
+        assertFailsWith<IllegalArgumentException> { repo.addVersion( protocol, "Version" ) }
+    }
+
+    @Test
+    fun getBy_gets_latest_when_version_not_specified() = runSuspendTest {
+        val repo = createRepository()
+        val owner = ProtocolOwner()
+        val name = "Study"
+
+        val protocol = StudyProtocol( owner, name )
+        repo.add( protocol, "Initial" )
+
+        val protocol2 = StudyProtocol( owner, name )
+        protocol2.addMasterDevice( StubMasterDeviceDescriptor() )
+        repo.addVersion( protocol2, "New version" )
+
+        val retrieved = repo.getBy( owner, name )
+        assertNotSame( protocol2, retrieved )
+        assertEquals( protocol2.getSnapshot(), retrieved.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
+    }
+
+    @Test
+    fun getBy_for_a_specific_version_succeeds() = runSuspendTest {
+        val repo = createRepository()
+        val owner = ProtocolOwner()
+        val name = "Study"
+
+        val protocol1 = StudyProtocol( owner, name )
+        repo.add( protocol1, "Initial" )
+
+        val protocol2 = StudyProtocol( owner, name )
+        protocol2.addMasterDevice( StubMasterDeviceDescriptor( "Device" ) )
+        repo.addVersion( protocol2, "Version 2" )
+
+        val protocol3 = StudyProtocol( owner, name )
+        protocol3.addMasterDevice( StubMasterDeviceDescriptor( "Other device" ) )
+        repo.addVersion( protocol3, "Version 3" )
+
+        val retrievedProtocol = repo.getBy( owner, name, "Version 2" )
+        assertNotSame( protocol2, retrievedProtocol )
+        assertEquals( protocol2.getSnapshot(), retrievedProtocol.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
+    }
+
+    @Test
+    fun getBy_fails_for_owner_which_does_not_exist() = runSuspendTest {
+        val repo = createRepository()
+
+        assertFailsWith<IllegalArgumentException> { repo.getBy( ProtocolOwner(), "Study" ) }
+    }
+
+    @Test
+    fun getBy_fails_for_name_which_does_not_exist() = runSuspendTest {
         val repo = createRepository()
         val owner = ProtocolOwner()
         val protocol = StudyProtocol( owner, "Study" )
         repo.add( protocol, "Initial" )
 
-        assertFailsWith<IllegalArgumentException>
-        {
-            repo.getBy( owner, "Non-existing study" )
-        }
+        assertFailsWith<IllegalArgumentException> { repo.getBy( owner, "Non-existing study" ) }
     }
 
     @Test
-    fun cant_getBy_version_which_does_not_exist() = runSuspendTest {
+    fun getBy_fails_for_version_which_does_not_exist() = runSuspendTest {
         val repo = createRepository()
         val owner = ProtocolOwner()
         val protocol = StudyProtocol( owner, "Study" )
         repo.add( protocol, "Initial" )
         repo.addVersion( protocol, "Update" )
 
-        assertFailsWith<IllegalArgumentException>
-        {
-            repo.getBy( owner, "Study", "Non-existing version" )
-        }
-    }
-
-    @Test
-    fun addVersion_to_study_protocol_succeeds() = runSuspendTest {
-        val repo = createRepository()
-        val owner = ProtocolOwner()
-        val protocol = StudyProtocol( owner, "Study" )
-        repo.add( protocol, "Initial" )
-
-        protocol.addMasterDevice( StubMasterDeviceDescriptor() )
-        repo.addVersion( protocol, "New version" )
-        val retrieved = repo.getBy( owner, "Study" )
-        assertEquals( protocol.getSnapshot(), retrieved.getSnapshot() ) // StudyProtocol does not implement equals, but snapshot does.
-    }
-
-    @Test
-    fun cant_update_study_protocol_which_does_not_yet_exist() = runSuspendTest {
-        val repo = createRepository()
-
-        val protocol = StudyProtocol( ProtocolOwner(), "Study" )
-        assertFailsWith<IllegalArgumentException>
-        {
-            repo.addVersion( protocol, "New version" )
-        }
+        assertFailsWith<IllegalArgumentException> { repo.getBy( owner, "Study", "Non-existing version" ) }
     }
 
     @Test
     fun getAllFor_owner_succeeds() = runSuspendTest {
         val repo = createRepository()
         val owner = ProtocolOwner()
+
         val protocol1 = StudyProtocol( owner, "Study 1" )
-        val protocol2 = StudyProtocol( owner, "Study 2" )
         repo.add( protocol1, "Initial" )
+
+        val protocol2 = StudyProtocol( owner, "Study 2" )
         repo.add( protocol2, "Initial" )
-        protocol2.addMasterDevice( StubMasterDeviceDescriptor() )
-        repo.addVersion( protocol2, "Latest should be retrieved" )
+        val protocol2Latest = StudyProtocol( owner, "Study 2" )
+        protocol2Latest.addMasterDevice( StubMasterDeviceDescriptor() )
+        repo.addVersion( protocol2Latest, "Latest should be retrieved" )
+
+        val protocols: Sequence<StudyProtocol> = repo.getAllFor( owner )
 
         // StudyProtocol does not implement equals, but snapshot does, so compare snapshots.
-        val protocols: List<StudyProtocolSnapshot> = repo.getAllFor( owner ).map { it.getSnapshot() }.toList()
-        val expected = listOf( protocol1.getSnapshot(), protocol2.getSnapshot() )
-        assertEquals( expected.count(), protocols.intersect( expected ).count() )
+        val snapshots: Set<StudyProtocolSnapshot> = protocols.map { it.getSnapshot() }.toSet()
+        val expected = setOf( protocol1.getSnapshot(), protocol2Latest.getSnapshot() )
+        assertEquals( expected, snapshots )
     }
 
     @Test
-    fun cant_getAllFor_owner_which_does_not_exist() = runSuspendTest {
+    fun getAllFor_fails_for_owner_which_does_not_exist() = runSuspendTest {
         val repo = createRepository()
 
-        assertFailsWith<IllegalArgumentException>
-        {
-            repo.getAllFor( ProtocolOwner() )
-        }
+        assertFailsWith<IllegalArgumentException> { repo.getAllFor( ProtocolOwner() ) }
     }
 
     @Test
     fun getVersionHistoryFor_succeeds() = runSuspendTest {
         val repo = createRepository()
         val owner = ProtocolOwner()
-        val protocol = StudyProtocol( owner, "Study" )
+        val name = "Study"
+        val protocol = StudyProtocol( owner, name )
         repo.add( protocol, "Initial" )
         repo.addVersion( protocol, "Version 1" )
         repo.addVersion( protocol, "Version 2" )
 
-        val history: List<ProtocolVersion> = repo.getVersionHistoryFor( owner, "Study" )
-        val historyVersions: List<String> = history.map { it.tag }.toList()
-        val expectedVersions: List<String> = listOf( "Initial", "Version 1", "Version 2" )
-        assertEquals( expectedVersions.count(), historyVersions.intersect( expectedVersions ).count() )
+        val history: List<ProtocolVersion> = repo.getVersionHistoryFor( owner, name )
+
+        val historyVersions: Set<String> = history.map { it.tag }.toSet()
+        val expectedVersions = setOf( "Initial", "Version 1", "Version 2" )
+        assertEquals( expectedVersions, historyVersions )
+    }
+
+    @Test
+    fun getVersionHistoryFor_fails_when_protocol_does_not_exist() = runSuspendTest {
+        val repo = createRepository()
+
+        val unknownOwner = ProtocolOwner()
+        assertFailsWith<IllegalArgumentException> { repo.getVersionHistoryFor( unknownOwner, "Unknown" ) }
     }
 }

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
@@ -102,6 +102,15 @@ class StudyProtocolTest
 
 
     @Test
+    fun id_set_to_ownerId_and_name()
+    {
+        val owner = ProtocolOwner()
+        val protocol = StudyProtocol( owner, "Name" )
+
+        assertEquals( StudyProtocol.Id( owner.id, "Name" ), protocol.id )
+    }
+
+    @Test
     fun one_master_device_needed_for_deployment()
     {
         // By default, no master device is defined in a study protocol.
@@ -111,7 +120,6 @@ class StudyProtocolTest
         assertFalse( protocol.isDeployable() )
         assertEquals( 1, protocol.getDeploymentIssues().filterIsInstance<NoMasterDeviceError>().count() )
     }
-
 
     @Test
     fun addTrigger_succeeds()
@@ -431,6 +439,7 @@ class StudyProtocolTest
         assertEquals( protocol.expectedParticipantData, fromSnapshot.expectedParticipantData )
         assertEquals( 0, fromSnapshot.consumeEvents().size )
     }
+
 
     private fun connectedDevicesAreSame( protocol: StudyProtocol, fromSnapshot: StudyProtocol, masterDevice: AnyMasterDeviceDescriptor ): Boolean
     {

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
@@ -423,7 +423,7 @@ class StudyProtocolTest
         val snapshot: StudyProtocolSnapshot = protocol.getSnapshot()
         val fromSnapshot = StudyProtocol.fromSnapshot( snapshot )
 
-        assertEquals( protocol.owner, fromSnapshot.owner )
+        assertEquals( protocol.ownerId, fromSnapshot.ownerId )
         assertEquals( protocol.name, fromSnapshot.name )
         assertEquals( protocol.description, fromSnapshot.description )
         assertEquals( protocol.creationDate, fromSnapshot.creationDate )

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/InMemoryStudyProtocolRepositoryTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/InMemoryStudyProtocolRepositoryTest.kt
@@ -1,0 +1,13 @@
+package dk.cachet.carp.protocols.infrastructure
+
+import dk.cachet.carp.protocols.domain.StudyProtocolRepository
+import dk.cachet.carp.protocols.domain.StudyProtocolRepositoryTest
+
+
+/**
+ * Tests whether [InMemoryStudyProtocolRepository] is implemented correctly.
+ */
+class InMemoryStudyProtocolRepositoryTest : StudyProtocolRepositoryTest
+{
+    override fun createRepository(): StudyProtocolRepository = InMemoryStudyProtocolRepository()
+}

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
@@ -19,6 +19,7 @@ class ProtocolServiceRequestsTest
         val requests: List<ProtocolServiceRequest> = listOf(
             ProtocolServiceRequest.Add( createComplexProtocol().getSnapshot(), "Initial" ),
             ProtocolServiceRequest.AddVersion( createComplexProtocol().getSnapshot(), "Updated" ),
+            ProtocolServiceRequest.UpdateParticipantDataConfiguration( ProtocolOwner(), "Name", "Version", emptySet() ),
             ProtocolServiceRequest.GetBy( ProtocolOwner(), "Name", "Version" ),
             ProtocolServiceRequest.GetAllFor( ProtocolOwner() ),
             ProtocolServiceRequest.GetVersionHistoryFor( ProtocolOwner(), "Name" )

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
@@ -1,9 +1,10 @@
 package dk.cachet.carp.protocols.infrastructure
 
+import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.ServiceInvoker
 import dk.cachet.carp.protocols.application.ProtocolService
 import dk.cachet.carp.protocols.application.ProtocolServiceMock
-import dk.cachet.carp.protocols.domain.ProtocolOwner
+import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createComplexProtocol
 import dk.cachet.carp.test.runSuspendTest
 import kotlin.test.*
@@ -19,10 +20,10 @@ class ProtocolServiceRequestsTest
         val requests: List<ProtocolServiceRequest> = listOf(
             ProtocolServiceRequest.Add( createComplexProtocol().getSnapshot(), "Initial" ),
             ProtocolServiceRequest.AddVersion( createComplexProtocol().getSnapshot(), "Updated" ),
-            ProtocolServiceRequest.UpdateParticipantDataConfiguration( ProtocolOwner(), "Name", "Version", emptySet() ),
-            ProtocolServiceRequest.GetBy( ProtocolOwner(), "Name", "Version" ),
-            ProtocolServiceRequest.GetAllFor( ProtocolOwner() ),
-            ProtocolServiceRequest.GetVersionHistoryFor( ProtocolOwner(), "Name" )
+            ProtocolServiceRequest.UpdateParticipantDataConfiguration( StudyProtocol.Id( UUID.randomUUID(), "Name" ), "Version", emptySet() ),
+            ProtocolServiceRequest.GetBy( StudyProtocol.Id( UUID.randomUUID(), "Name" ), "Version" ),
+            ProtocolServiceRequest.GetAllFor( UUID.randomUUID() ),
+            ProtocolServiceRequest.GetVersionHistoryFor( StudyProtocol.Id( UUID.randomUUID(), "Name" ) )
         )
     }
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequestsTest.kt
@@ -18,7 +18,7 @@ class ProtocolServiceRequestsTest
     {
         val requests: List<ProtocolServiceRequest> = listOf(
             ProtocolServiceRequest.Add( createComplexProtocol().getSnapshot(), "Initial" ),
-            ProtocolServiceRequest.Update( createComplexProtocol().getSnapshot(), "Updated" ),
+            ProtocolServiceRequest.AddVersion( createComplexProtocol().getSnapshot(), "Updated" ),
             ProtocolServiceRequest.GetBy( ProtocolOwner(), "Name", "Version" ),
             ProtocolServiceRequest.GetAllFor( ProtocolOwner() ),
             ProtocolServiceRequest.GetVersionHistoryFor( ProtocolOwner(), "Name" )

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolVersionTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolVersionTest.kt
@@ -13,7 +13,7 @@ class ProtocolVersionTest
     @Test
     fun can_serialize_and_deserialize_protocol_version_using_JSON()
     {
-        val version = ProtocolVersion( DateTime.now(), "Test" )
+        val version = ProtocolVersion( "Test", DateTime.now() )
 
         val serialized: String = version.toJson()
         val parsed: ProtocolVersion = ProtocolVersion.fromJson( serialized )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/ParticipantService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/ParticipantService.kt
@@ -2,6 +2,8 @@ package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.data.Data
+import dk.cachet.carp.common.data.input.InputDataType
 import dk.cachet.carp.studies.domain.ParticipantGroupStatus
 import dk.cachet.carp.studies.domain.users.AssignParticipantDevices
 import dk.cachet.carp.studies.domain.users.Participant
@@ -64,4 +66,15 @@ interface ParticipantService
      * @throws IllegalArgumentException when a study with [studyId] or participant group with [groupId] does not exist.
      */
     suspend fun stopParticipantGroup( studyId: UUID, groupId: UUID ): ParticipantGroupStatus
+
+    /**
+     * Set participant [data] for the given [inputDataType],
+     * related to participants of the participant group with [groupId] in the study with the specified [studyId].
+     *
+     * @throws IllegalArgumentException when:
+     *   - a study with [studyId] or participant group with [groupId] does not exist.
+     *   - [inputDataType] is not configured as expected participant data in the study protocol
+     *   - [data] is invalid data for [inputDataType]
+     */
+    suspend fun setParticipantGroupData( studyId: UUID, groupId: UUID, inputDataType: InputDataType, data: Data? ): ParticipantGroupStatus
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/ParticipantServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/ParticipantServiceHost.kt
@@ -204,11 +204,9 @@ class ParticipantServiceHost(
     {
         val participations = getStudyParticipationsOrThrow( studyId, groupId )
 
-        participationService.setParticipantData( groupId, inputDataType, data )
-
         val deploymentStatus = deploymentService.getStudyDeploymentStatus( groupId )
-        val participantData = participationService.getParticipantData( groupId )
-        return ParticipantGroupStatus( deploymentStatus, participations, participantData.data )
+        val newData = participationService.setParticipantData( groupId, inputDataType, data )
+        return ParticipantGroupStatus( deploymentStatus, participations, newData.data )
     }
 
     private suspend fun getStudyOrThrow( studyId: UUID ): Study = studyRepository.getById( studyId )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/ParticipantGroupStatus.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/ParticipantGroupStatus.kt
@@ -1,6 +1,8 @@
 package dk.cachet.carp.studies.domain
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.data.Data
+import dk.cachet.carp.common.data.input.InputDataType
 import dk.cachet.carp.deployment.domain.StudyDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
@@ -20,7 +22,12 @@ data class ParticipantGroupStatus(
     /**
      * The participants and assigned anonymized participation IDs that are part of this deployment.
      */
-    val participants: Set<DeanonymizedParticipation>
+    val participants: Set<DeanonymizedParticipation>,
+    /**
+     * Configurable data related to the participants in this participant group.
+     * Data which is not set equals null.
+     */
+    val data: Map<InputDataType, Data?>
 )
 {
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantServiceRequest.kt
@@ -2,6 +2,8 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.data.Data
+import dk.cachet.carp.common.data.input.InputDataType
 import dk.cachet.carp.common.ddd.ServiceInvoker
 import dk.cachet.carp.common.ddd.createServiceInvoker
 import dk.cachet.carp.studies.application.ParticipantService
@@ -52,4 +54,9 @@ sealed class ParticipantServiceRequest
     data class StopParticipantGroup( val studyId: UUID, val groupId: UUID ) :
         ParticipantServiceRequest(),
         ParticipantServiceInvoker<ParticipantGroupStatus> by createServiceInvoker( ParticipantService::stopParticipantGroup, studyId, groupId )
+
+    @Serializable
+    data class SetParticipantGroupData( val studyId: UUID, val groupId: UUID, val inputDataType: InputDataType, val data: Data? ) :
+        ParticipantServiceRequest(),
+        ParticipantServiceInvoker<ParticipantGroupStatus> by createServiceInvoker( ParticipantService::setParticipantGroupData, studyId, groupId, inputDataType, data )
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/ParticipantServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/ParticipantServiceMock.kt
@@ -2,6 +2,8 @@ package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.data.Data
+import dk.cachet.carp.common.data.input.InputDataType
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.studies.domain.ParticipantGroupStatus
@@ -20,14 +22,16 @@ class ParticipantServiceMock(
     private val getParticipantsResult: List<Participant> = emptyList(),
     private val deployParticipantResult: ParticipantGroupStatus = groupStatus,
     private val getParticipantGroupStatusListResult: List<ParticipantGroupStatus> = emptyList(),
-    private val stopParticipantGroupResult: ParticipantGroupStatus = groupStatus
+    private val stopParticipantGroupResult: ParticipantGroupStatus = groupStatus,
+    private val setParticipantGroupDataResult: ParticipantGroupStatus = groupStatus
 ) : Mock<ParticipantService>(), ParticipantService
 {
     companion object
     {
         private val groupStatus = ParticipantGroupStatus(
             StudyDeploymentStatus.Invited( UUID.randomUUID(), emptyList(), null ),
-            emptySet() )
+            emptySet(),
+            emptyMap() )
     }
 
 
@@ -54,4 +58,8 @@ class ParticipantServiceMock(
     override suspend fun stopParticipantGroup( studyId: UUID, groupId: UUID ) =
         stopParticipantGroupResult
         .also { trackSuspendCall( ParticipantService::stopParticipantGroup, studyId, groupId ) }
+
+    override suspend fun setParticipantGroupData( studyId: UUID, groupId: UUID, inputDataType: InputDataType, data: Data? ) =
+        setParticipantGroupDataResult
+        .also { trackSuspendCall( ParticipantService::setParticipantGroupData, studyId, groupId, inputDataType, data ) }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
@@ -1,6 +1,8 @@
 package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.data.input.CarpInputDataTypes
+import dk.cachet.carp.common.data.input.Sex
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.studies.domain.ParticipantGroupStatus
 import dk.cachet.carp.studies.domain.users.DeanonymizedParticipation
@@ -18,7 +20,8 @@ class ParticipantGroupStatusTest
         val studyDeploymentId = UUID.randomUUID()
         val deploymentStatus = StudyDeploymentStatus.Invited( studyDeploymentId, listOf(), null )
         val participants = setOf( DeanonymizedParticipation( UUID.randomUUID(), UUID.randomUUID() ) )
-        val groupStatus = ParticipantGroupStatus( deploymentStatus, participants )
+        val someData = mapOf( CarpInputDataTypes.SEX to Sex.Female )
+        val groupStatus = ParticipantGroupStatus( deploymentStatus, participants, someData )
 
         val serialized: String = JSON.encodeToString( ParticipantGroupStatus.serializer(), groupStatus )
         val parsed: ParticipantGroupStatus = JSON.decodeFromString( ParticipantGroupStatus.serializer(), serialized )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantServiceRequestsTest.kt
@@ -2,6 +2,8 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.data.input.CustomInput
+import dk.cachet.carp.common.data.input.InputDataType
 import dk.cachet.carp.common.ddd.ServiceInvoker
 import dk.cachet.carp.studies.application.ParticipantService
 import dk.cachet.carp.studies.application.ParticipantServiceMock
@@ -24,7 +26,8 @@ class ParticipantServiceRequestsTest
             ParticipantServiceRequest.GetParticipants( studyId ),
             ParticipantServiceRequest.DeployParticipantGroup( studyId, setOf() ),
             ParticipantServiceRequest.GetParticipantGroupStatusList( studyId ),
-            ParticipantServiceRequest.StopParticipantGroup( studyId, UUID.randomUUID() )
+            ParticipantServiceRequest.StopParticipantGroup( studyId, UUID.randomUUID() ),
+            ParticipantServiceRequest.SetParticipantGroupData( studyId, UUID.randomUUID(), InputDataType( "some", "type" ), CustomInput( "Test" ) )
         )
     }
 

--- a/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
@@ -1,6 +1,8 @@
 declare module 'carp.core-kotlin-carp.common'
 {
+    import { kotlin } from 'kotlin'
     import { Long } from 'kotlin'
+    import HashSet = kotlin.collections.HashSet
     import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
     import Json = kotlinx.serialization.json.Json
     
@@ -33,6 +35,18 @@ declare module 'carp.core-kotlin-carp.common'
             readonly address: string
         }
         interface EmailAddress$Companion { serializer(): any }
+
+
+        class NamespacedId
+        {
+            constructor( namespace: string, name: string )
+
+            static get Companion(): NamespacedId$Companion
+
+            readonly namespace: string
+            readonly name: string
+        }
+        interface NamespacedId$Companion { serializer(): any }
 
 
         class TimeSpan
@@ -79,6 +93,10 @@ declare module 'carp.core-kotlin-carp.common'
 
     namespace dk.cachet.carp.common.users
     {
+        import InputElement = dk.cachet.carp.common.data.input.InputElement
+        import InputDataTypeList = dk.cachet.carp.common.data.input.InputDataTypeList
+
+
         abstract class AccountIdentity
         {
             static get Factory(): AccountIdentity$Factory
@@ -109,6 +127,78 @@ declare module 'carp.core-kotlin-carp.common'
             readonly username: string
         } 
         interface UsernameAccountIdentity$Companion { serializer(): any }
+
+
+        abstract class ParticipantAttribute
+        {
+            static get Companion(): ParticipantAttribute$Companion
+
+            readonly inputType: NamespacedId
+
+            getInputElement_zbztje$( registeredInputDataTypes: InputDataTypeList ): InputElement
+            isValidInput_jon1ci$( registeredInputDataTypes: InputDataTypeList, input: any ): boolean
+            inputToData_jon1ci$( registeredInputDataTypes: InputDataTypeList, input: any ): any
+            isValidData_1evfk3$( registeredInputDataTypes: InputDataTypeList, data: any ): boolean
+            dataToInput_1evfk3$( registeredInputDataTypes: InputDataTypeList, data: any ): any
+        }
+        interface ParticipantAttribute$Companion { serializer(): any }
+
+        namespace ParticipantAttribute
+        {
+            class DefaultParticipantAttribute extends ParticipantAttribute
+            {
+                constructor( inputType: NamespacedId )
+            }
+
+            class CustomParticipantAttribute extends ParticipantAttribute
+            {
+                constructor( input: InputElement )
+            }
+        }
+    }
+
+
+    namespace dk.cachet.carp.common.data.input
+    {
+        interface InputElement
+        {
+            readonly name: string
+
+            isValid_trkh7z$( input: any ): boolean
+        }
+
+        // No need to initialize this from TypeScript right now. Access to `CarpInputDataTypes` is sufficient.
+        class InputDataTypeList { constructor() }
+        const CarpInputDataTypes: InputDataTypeList
+    }
+
+    namespace dk.cachet.carp.common.data.input.element
+    {
+        import InputElement = dk.cachet.carp.common.data.input.InputElement
+
+        
+        class Text implements InputElement
+        {
+            constructor( name: string )
+
+            static get Companion(): Text$Companion
+
+            readonly name: string
+            isValid_trkh7z$( input: any ): boolean
+        }
+        interface Text$Companion { serializer(): any }
+
+        class SelectOne implements InputElement
+        {
+            constructor( name: string, options: HashSet<string> )
+
+            static get Companion(): SelectOne$Companion
+
+            readonly name: string
+            readonly options: HashSet<string>
+            isValid_trkh7z$( input: any ): boolean
+        }
+        interface SelectOne$Companion { serializer(): any }
     }
 
 

--- a/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
@@ -1,10 +1,14 @@
 declare module 'carp.core-kotlin-carp.protocols.core'
 {
+    import { kotlin } from 'kotlin'
+    import ArrayList = kotlin.collections.ArrayList
+    import HashSet = kotlin.collections.HashSet
     import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
     import Json = kotlinx.serialization.json.Json
     import { dk as cdk } from 'carp.core-kotlin-carp.common'
     import DateTime = cdk.cachet.carp.common.DateTime
     import UUID = cdk.cachet.carp.common.UUID
+    import ParticipantAttribute = cdk.cachet.carp.common.users.ParticipantAttribute
 
 
     namespace dk.cachet.carp.protocols.domain
@@ -28,14 +32,19 @@ declare module 'carp.core-kotlin-carp.protocols.core'
             constructor( id?: UUID )
 
             static get Companion(): ProtocolOwner$Companion
+
+            readonly id: UUID
         }
         interface ProtocolOwner$Companion { serializer(): any }
 
         class ProtocolVersion
         {
-            constructor( date: DateTime, tag: string )
+            constructor( tag: string, date?: DateTime )
 
             static get Companion(): ProtocolVersion$Companion
+
+            readonly tag: string
+            readonly date: DateTime
         }
         interface ProtocolVersion$Companion { serializer(): any }
 
@@ -45,6 +54,12 @@ declare module 'carp.core-kotlin-carp.protocols.core'
             private constructor()
 
             static get Companion(): StudyProtocolSnapshot$Companion
+
+            readonly ownerId: UUID
+            readonly name: string
+            readonly description: string
+            readonly creationDate: DateTime
+            readonly expectedParticipantData: ArrayList<ParticipantAttribute>
         }
         interface StudyProtocolSnapshot$Companion { serializer(): any }
     }
@@ -53,7 +68,6 @@ declare module 'carp.core-kotlin-carp.protocols.core'
     namespace dk.cachet.carp.protocols.infrastructure
     {
         import ProtocolId = dk.cachet.carp.protocols.domain.StudyProtocol.Id
-        import ProtocolOwner = dk.cachet.carp.protocols.domain.ProtocolOwner
         import StudyProtocolSnapshot = dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 
         
@@ -73,6 +87,10 @@ declare module 'carp.core-kotlin-carp.protocols.core'
             {
                 constructor( protocol: StudyProtocolSnapshot, versionTag?: string )
             }
+            class UpdateParticipantDataConfiguration extends ProtocolServiceRequest
+            {
+                constructor( protocolId: ProtocolId, versionTag: string, expectedParticipantData: HashSet<ParticipantAttribute> )
+            }
             class GetBy extends ProtocolServiceRequest
             {
                 constructor( protocolId: ProtocolId, versionTag?: string )
@@ -86,6 +104,22 @@ declare module 'carp.core-kotlin-carp.protocols.core'
                 constructor( protocolId: ProtocolId )
             }
         }
+
+
+        abstract class ProtocolFactoryServiceRequest
+        {
+            static Companion(): ProtocolFactoryServiceRequest$Companion
+        }
+        interface ProtocolFactoryServiceRequest$Companion { serializer(): any }
+
+        namespace ProtocolFactoryServiceRequest
+        {
+            class CreateCustomProtocol extends ProtocolFactoryServiceRequest
+            {
+                constructor( ownerId: UUID, name: string, customProtocol: string, description: string )
+            }
+        }
+
 
         function createProtocolsSerializer_18xi4u$(): Json
     }

--- a/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
@@ -54,7 +54,7 @@ declare module 'carp.core-kotlin-carp.protocols.core'
             {
                 constructor( protocol: StudyProtocolSnapshot, versionTag?: string )
             }
-            class Update extends ProtocolServiceRequest
+            class AddVersion extends ProtocolServiceRequest
             {
                 constructor( protocol: StudyProtocolSnapshot, versionTag?: string )
             }

--- a/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
@@ -9,6 +9,20 @@ declare module 'carp.core-kotlin-carp.protocols.core'
 
     namespace dk.cachet.carp.protocols.domain
     {
+        namespace StudyProtocol
+        {
+            class Id
+            {
+                constructor( ownerId: UUID, name: string )
+
+                static get Companion(): Id$Companion
+    
+                readonly ownerId: UUID
+                readonly name: string
+            }
+            interface Id$Companion { serializer(): any }
+        }
+
         class ProtocolOwner
         {
             constructor( id?: UUID )
@@ -38,6 +52,7 @@ declare module 'carp.core-kotlin-carp.protocols.core'
 
     namespace dk.cachet.carp.protocols.infrastructure
     {
+        import ProtocolId = dk.cachet.carp.protocols.domain.StudyProtocol.Id
         import ProtocolOwner = dk.cachet.carp.protocols.domain.ProtocolOwner
         import StudyProtocolSnapshot = dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 
@@ -60,15 +75,15 @@ declare module 'carp.core-kotlin-carp.protocols.core'
             }
             class GetBy extends ProtocolServiceRequest
             {
-                constructor( owner: ProtocolOwner, protocolName: string, versionTag?: string )
+                constructor( protocolId: ProtocolId, versionTag?: string )
             }
             class GetAllFor extends ProtocolServiceRequest
             {
-                constructor( owner: ProtocolOwner )
+                constructor( ownerId: UUID )
             }
             class GetVersionHistoryFor extends ProtocolServiceRequest
             {
-                constructor( owner: ProtocolOwner, protocolName: string )
+                constructor( protocolId: ProtocolId )
             }
         }
 

--- a/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
@@ -3,17 +3,19 @@ declare module 'carp.core-kotlin-carp.studies.core'
     import { kotlin } from 'kotlin'
     import ArrayList = kotlin.collections.ArrayList
     import HashSet = kotlin.collections.HashSet
+    import HashMap = kotlin.collections.HashMap
     import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
     import Json = kotlinx.serialization.json.Json
     import { dk as cdk } from 'carp.core-kotlin-carp.common'
     import DateTime = cdk.cachet.carp.common.DateTime
     import EmailAddress = cdk.cachet.carp.common.EmailAddress
+    import NamespacedId = cdk.cachet.carp.common.NamespacedId
     import UUID = cdk.cachet.carp.common.UUID
     import AccountIdentity = cdk.cachet.carp.common.users.AccountIdentity
     import { dk as pdk } from 'carp.core-kotlin-carp.protocols.core'
     import StudyProtocolSnapshot = pdk.cachet.carp.protocols.domain.StudyProtocolSnapshot
     import { dk as ddk } from 'carp.core-kotlin-carp.deployment.core'
-    import Participation = ddk.cachet.carp.deployment.domain.users.Participation
+
     import StudyDeploymentStatus = ddk.cachet.carp.deployment.domain.StudyDeploymentStatus
     import StudyInvitation = ddk.cachet.carp.deployment.domain.users.StudyInvitation
 
@@ -26,12 +28,13 @@ declare module 'carp.core-kotlin-carp.studies.core'
 
         class ParticipantGroupStatus
         {
-            constructor( studyDeploymentStatus: StudyDeploymentStatus, participants: HashSet<DeanonymizedParticipation> )
+            constructor( studyDeploymentStatus: StudyDeploymentStatus, participants: HashSet<DeanonymizedParticipation>, data: HashMap<NamespacedId, any> )
 
             static get Companion(): ParticipantGroupStatus$Companion
 
             readonly studyDeploymentStatus: StudyDeploymentStatus
             readonly participants: HashSet<DeanonymizedParticipation>
+            readonly data: any
         }
         interface ParticipantGroupStatus$Companion { serializer(): any }
 
@@ -169,7 +172,7 @@ declare module 'carp.core-kotlin-carp.studies.core'
         {
             class CreateStudy extends StudyServiceRequest
             {
-                constructor( owner: StudyOwner, name: string, description: string, invitation: StudyInvitation )
+                constructor( owner: StudyOwner, name: string, description?: string, invitation?: StudyInvitation )
             }
             class SetInternalDescription extends StudyServiceRequest
             {
@@ -214,21 +217,29 @@ declare module 'carp.core-kotlin-carp.studies.core'
             {
                 constructor( studyId: UUID, email: EmailAddress )
             }
+            class GetParticipant extends ParticipantServiceRequest
+            {
+                constructor( studyId: UUID, participantId: UUID )
+            }
             class GetParticipants extends ParticipantServiceRequest
             {
                 constructor( studyId: UUID )
             }
-            class DeployParticipantGroup extends StudyServiceRequest
+            class DeployParticipantGroup extends ParticipantServiceRequest
             {
                 constructor( studyId: UUID, group: HashSet<AssignParticipantDevices> )
             }
-            class GetParticipantGroupStatusList extends StudyServiceRequest
+            class GetParticipantGroupStatusList extends ParticipantServiceRequest
             {
                 constructor( studyId: UUID )
             }
-            class StopParticipantGroup extends StudyServiceRequest
+            class StopParticipantGroup extends ParticipantServiceRequest
             {
                 constructor( studyId: UUID, groupId: UUID )
+            }
+            class SetParticipantGroupData extends ParticipantServiceRequest
+            {
+                constructor( studyId: UUID, groupId: UUID, inputDataType: NamespacedId, data?: any )
             }
         }
 

--- a/typescript-declarations/@types/kotlin/index.d.ts
+++ b/typescript-declarations/@types/kotlin/index.d.ts
@@ -8,8 +8,23 @@ declare module 'kotlin'
     }
 
 
+    namespace kotlin
+    {
+        class Pair<TFirst, TSecond>
+        {
+            constructor( first: TFirst, second: TSecond )
+
+            readonly first: TFirst
+            readonly second: TSecond
+        }
+    }
+
+
     namespace kotlin.collections
     {
+        import Pair = kotlin.Pair
+
+
         class ArrayList<T>
         {
             constructor( array: T[] )
@@ -28,5 +43,8 @@ declare module 'kotlin'
             contains_11rb$( element: T ): boolean
         }
         function toSet_us0mfu$<T>( array: T[] ): HashSet<T>
+
+        class HashMap<TKey, TValue> {}
+        function toMap_v2dak7$<TKey, TValue>( pairs: Pair<TKey, TValue>[] ): HashMap<TKey, TValue>
     }
 }

--- a/typescript-declarations/tests/VerifyModule.ts
+++ b/typescript-declarations/tests/VerifyModule.ts
@@ -15,6 +15,7 @@ import {
     TypeElement }
     from "@typescript-eslint/types/dist/ts-estree"
 import * as fs from 'fs'
+import { getEffectiveTypeParameterDeclarations } from 'typescript'
 
 
 export default class VerifyModule
@@ -68,6 +69,17 @@ export default class VerifyModule
                 const interfaceName = statement.id.name
                 const instance = this.getInstance( interfaceName )
                 this.verifyBody( statement.body, instance )
+                break;
+            }
+            case AST_NODE_TYPES.VariableDeclaration:
+            {   
+                const declarations = statement.declarations
+                if ( declarations.length != 1 )
+                {
+                    throw( Error( `Only one declarator expected. Support for none or more not implemented.` ) )
+                }
+                const declaratorId = declarations[ 0 ].id as Identifier
+                this.verifyIdentifier( declaratorId, scope )
                 break;
             }
             case AST_NODE_TYPES.ImportDeclaration:

--- a/typescript-declarations/tests/carp.common.ts
+++ b/typescript-declarations/tests/carp.common.ts
@@ -1,12 +1,15 @@
 import { expect } from 'chai'
 import VerifyModule from './VerifyModule'
 
+import { kotlin } from 'kotlin'
 import { Long } from 'kotlin'
+import toSet = kotlin.collections.toSet_us0mfu$
 import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
 import Json = kotlinx.serialization.json.Json
-import { dk } from "carp.core-kotlin-carp.common"
+import { dk } from 'carp.core-kotlin-carp.common'
 import DateTime = dk.cachet.carp.common.DateTime
 import EmailAddress = dk.cachet.carp.common.EmailAddress
+import NamespacedId = dk.cachet.carp.common.NamespacedId
 import TimeSpan = dk.cachet.carp.common.TimeSpan
 import Trilean = dk.cachet.carp.common.Trilean
 import toTrilean = dk.cachet.carp.common.toTrilean_1v8dcc$
@@ -16,6 +19,10 @@ import EmailAccountIdentity = dk.cachet.carp.common.users.EmailAccountIdentity
 import emailAccountIdentityFromString = dk.cachet.carp.common.users.EmailAccountIdentity_init_61zpoe$
 import UsernameAccountIdentity = dk.cachet.carp.common.users.UsernameAccountIdentity
 import createDefaultJSON = dk.cachet.carp.common.serialization.createDefaultJSON_18xi4u$
+import ParticipantAttribute = dk.cachet.carp.common.users.ParticipantAttribute
+import SelectOne = dk.cachet.carp.common.data.input.element.SelectOne
+import Text = dk.cachet.carp.common.data.input.element.Text
+import CarpInputDataTypes = dk.cachet.carp.common.data.input.CarpInputDataTypes
 
 
 describe( "carp.common", () => {
@@ -25,6 +32,8 @@ describe( "carp.common", () => {
             DateTime.Companion,
             new EmailAddress( "test@test.com" ),
             EmailAddress.Companion,
+            new NamespacedId( "namespace", "type" ),
+            NamespacedId.Companion,
             TimeSpan.Companion.INFINITE,
             TimeSpan.Companion,
             UUID.Companion.randomUUID(),
@@ -33,7 +42,14 @@ describe( "carp.common", () => {
             new EmailAccountIdentity( new EmailAddress( "test@test.com" ) ),
             EmailAccountIdentity.Companion,
             new UsernameAccountIdentity( "Test" ),
-            UsernameAccountIdentity.Companion
+            UsernameAccountIdentity.Companion,
+            [ "ParticipantAttribute", new ParticipantAttribute.DefaultParticipantAttribute( new NamespacedId( "namespace", "type" ) ) ],
+            ParticipantAttribute.Companion,
+            [ "InputElement", new Text( "How are you feeling?" ) ],
+            SelectOne.Companion,
+            new SelectOne( "Sex", toSet( [ "Male", "Female" ] ) ),
+            Text.Companion,
+            new Text( "How are you feeling?" )
         ]
 
         const moduleVerifier = new VerifyModule( 'carp.core-kotlin-carp.common', instances )
@@ -86,6 +102,28 @@ describe( "carp.common", () => {
         it( "can initialize from string", () => {
             const identity = emailAccountIdentityFromString( "test@test.com" )
             expect( identity.emailAddress ).instanceOf( EmailAddress )
+        } )
+    } )
+
+    describe( "ParticipantAttribute", () => {
+        const attribute = new ParticipantAttribute.CustomParticipantAttribute( new Text( "Name" ) )
+
+        it( "getInputElement works", () => {
+            const inputElement = attribute.getInputElement_zbztje$( CarpInputDataTypes )
+            expect( inputElement ).instanceOf( Text )
+        } )
+
+        it( "isValidInput works", () => {
+            const isNumberValid = attribute.isValidInput_jon1ci$( CarpInputDataTypes, 42 )
+            expect( isNumberValid ).is.false
+
+            const isStringValid = attribute.isValidInput_jon1ci$( CarpInputDataTypes, "Steven" )
+            expect( isStringValid ).is.true
+        } )
+
+        it( "inputToData works", () => {
+            const data = attribute.inputToData_jon1ci$( CarpInputDataTypes, "Steven" )
+            expect( data ).is.not.undefined
         } )
     } )
 } )

--- a/typescript-declarations/tests/carp.deployment.core.ts
+++ b/typescript-declarations/tests/carp.deployment.core.ts
@@ -2,7 +2,6 @@ import VerifyModule from './VerifyModule'
 
 import { kotlin } from 'kotlin'
 import ArrayList = kotlin.collections.ArrayList
-import HashSet = kotlin.collections.HashSet
 import toSet = kotlin.collections.toSet_us0mfu$
 import { dk as dkc } from 'carp.core-kotlin-carp.common'
 import UUID = dkc.cachet.carp.common.UUID

--- a/typescript-declarations/tests/carp.protocols.core.ts
+++ b/typescript-declarations/tests/carp.protocols.core.ts
@@ -3,7 +3,10 @@ import VerifyModule from './VerifyModule'
 
 import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
 import Json = kotlinx.serialization.json.Json
+import { dk as dkc } from 'carp.core-kotlin-carp.common'
+import UUID = dkc.cachet.carp.common.UUID
 import { dk } from 'carp.core-kotlin-carp.protocols.core'
+import ProtocolId = dk.cachet.carp.protocols.domain.StudyProtocol.Id
 import ProtocolOwner = dk.cachet.carp.protocols.domain.ProtocolOwner
 import ProtocolVersion = dk.cachet.carp.protocols.domain.ProtocolVersion
 import StudyProtocolSnapshot = dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
@@ -16,6 +19,8 @@ const serializedSnapshot = `{"ownerId":"27879e75-ccc1-4866-9ab3-4ece1b735052","n
 describe( "carp.protocols.core", () => {
     it( "verify module declarations", async () => {
         const instances = [
+            new ProtocolId( UUID.Companion.randomUUID(), "Name" ),
+            [ "Id$Companion", ProtocolId.Companion ],
             StudyProtocolSnapshot.Companion,
             ProtocolVersion.Companion,
             ProtocolServiceRequest.Companion,

--- a/typescript-declarations/tests/carp.protocols.core.ts
+++ b/typescript-declarations/tests/carp.protocols.core.ts
@@ -12,18 +12,28 @@ import ProtocolVersion = dk.cachet.carp.protocols.domain.ProtocolVersion
 import StudyProtocolSnapshot = dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import createProtocolsSerializer = dk.cachet.carp.protocols.infrastructure.createProtocolsSerializer_18xi4u$
 import ProtocolServiceRequest = dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest
+import ProtocolFactoryServiceRequest = dk.cachet.carp.protocols.infrastructure.ProtocolFactoryServiceRequest
 
 const serializedSnapshot = `{"ownerId":"27879e75-ccc1-4866-9ab3-4ece1b735052","name":"Test protocol","description":"Test description","creationDate":"2020-12-05T21:55:59.454Z","masterDevices":[{"$type":"dk.cachet.carp.protocols.infrastructure.test.StubMasterDeviceDescriptor","isMasterDevice":true,"roleName":"Stub master device","samplingConfiguration":{},"supportedDataTypes":["dk.cachet.carp.stub"]}],"connectedDevices":[{"$type":"dk.cachet.carp.protocols.infrastructure.test.StubDeviceDescriptor","roleName":"Stub device","samplingConfiguration":{},"supportedDataTypes":["dk.cachet.carp.stub"]},{"$type":"dk.cachet.carp.protocols.infrastructure.test.StubMasterDeviceDescriptor","isMasterDevice":true,"roleName":"Chained master","samplingConfiguration":{},"supportedDataTypes":["dk.cachet.carp.stub"]},{"$type":"dk.cachet.carp.protocols.infrastructure.test.StubDeviceDescriptor","roleName":"Chained connected","samplingConfiguration":{},"supportedDataTypes":["dk.cachet.carp.stub"]}],"connections":[{"roleName":"Stub device","connectedToRoleName":"Stub master device"},{"roleName":"Chained master","connectedToRoleName":"Stub master device"},{"roleName":"Chained connected","connectedToRoleName":"Chained master"}],"tasks":[{"$type":"dk.cachet.carp.protocols.infrastructure.test.StubTaskDescriptor","name":"Task","measures":[{"$type":"dk.cachet.carp.protocols.infrastructure.test.StubMeasure","type":"dk.cachet.carp.stub","uniqueProperty":"Unique"}]}],"triggers":{"0":{"$type":"dk.cachet.carp.protocols.infrastructure.test.StubTrigger","sourceDeviceRoleName":"Stub device","uniqueProperty":"Unique"}},"triggeredTasks":[{"triggerId":0,"taskName":"Task","targetDeviceRoleName":"Stub master device"}],"expectedParticipantData":[{"$type":"dk.cachet.carp.common.users.ParticipantAttribute.DefaultParticipantAttribute","inputType":"some.type"}]}`
 
 
 describe( "carp.protocols.core", () => {
     it( "verify module declarations", async () => {
+        // Create `StudyProtocolSnapshot` instance.
+        const json: Json = createProtocolsSerializer()
+        const serializer = StudyProtocolSnapshot.Companion.serializer()
+        const studyProtocolSnapshot = json.decodeFromString_awif5v$( serializer, serializedSnapshot )
+
         const instances = [
             new ProtocolId( UUID.Companion.randomUUID(), "Name" ),
             [ "Id$Companion", ProtocolId.Companion ],
+            studyProtocolSnapshot,
             StudyProtocolSnapshot.Companion,
+            new ProtocolVersion( "Version" ),
             ProtocolVersion.Companion,
             ProtocolServiceRequest.Companion,
+            ProtocolFactoryServiceRequest.Companion,
+            new ProtocolOwner(),
             ProtocolOwner.Companion
         ]
 
@@ -42,7 +52,11 @@ describe( "carp.protocols.core", () => {
 
     describe( "ProtocolServiceRequest", () => {
         it( "add request has default version tag", () => {
-            const addProtocol = new ProtocolServiceRequest.Add( serializedSnapshot )
+            const json: Json = createProtocolsSerializer()
+            const serializer = StudyProtocolSnapshot.Companion.serializer()
+            const snapshot = json.decodeFromString_awif5v$( serializer, serializedSnapshot )
+
+            const addProtocol = new ProtocolServiceRequest.Add( snapshot )
             const versionTag = (addProtocol as any).versionTag
             expect( versionTag ).equals( "Initial" )
         } )

--- a/typescript-declarations/tests/carp.studies.core.ts
+++ b/typescript-declarations/tests/carp.studies.core.ts
@@ -2,19 +2,24 @@ import { expect } from 'chai'
 import VerifyModule from './VerifyModule'
 
 import { kotlin } from 'kotlin'
+import Pair = kotlin.Pair
 import ArrayList = kotlin.collections.ArrayList
 import HashSet = kotlin.collections.HashSet
 import toSet = kotlin.collections.toSet_us0mfu$
+import toMap = kotlin.collections.toMap_v2dak7$
 import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
 import Json = kotlinx.serialization.json.Json
 import { kotlinx as kotlinxcore } from 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
 import ListSerializer = kotlinxcore.serialization.builtins.ListSerializer_swdriu$
 import { dk as cdk } from 'carp.core-kotlin-carp.common'
 import DateTime = cdk.cachet.carp.common.DateTime
+import NamespacedId = cdk.cachet.carp.common.NamespacedId
 import UUID = cdk.cachet.carp.common.UUID
 import UsernameIdentity = cdk.cachet.carp.common.users.UsernameAccountIdentity
+import ParticipantAttribute = cdk.cachet.carp.common.users.ParticipantAttribute
+import CarpInputDataTypes = cdk.cachet.carp.common.data.input.CarpInputDataTypes
+import Text = cdk.cachet.carp.common.data.input.element.Text
 import { dk as ddk } from 'carp.core-kotlin-carp.deployment.core'
-import Participation = ddk.cachet.carp.deployment.domain.users.Participation
 import StudyInvitation = ddk.cachet.carp.deployment.domain.users.StudyInvitation
 import StudyDeploymentStatus = ddk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import { dk } from 'carp.core-kotlin-carp.studies.core'
@@ -43,7 +48,7 @@ describe( "carp.studies.core", () => {
             Participant.Companion,
             new StudyOwner(),
             StudyOwner.Companion,
-            new ParticipantGroupStatus( new StudyDeploymentStatus(), new HashSet<DeanonymizedParticipant>() ),
+            new ParticipantGroupStatus( new StudyDeploymentStatus(), new HashSet<DeanonymizedParticipant>(), toMap( [] ) ),
             ParticipantGroupStatus.Companion,
             new StudyDetails( UUID.Companion.randomUUID(), new StudyOwner(), "Name", DateTime.Companion.now(), "Description", StudyInvitation.Companion.empty(), null ),
             StudyDetails.Companion,
@@ -142,6 +147,23 @@ describe( "carp.studies.core", () => {
             const json: Json = createStudiesSerializer()
             const serializer = ParticipantServiceRequest.Companion.serializer()
             const serialized = json.encodeToString_tf03ej$( serializer, deployGroup )
+            expect( serialized ).is.not.undefined
+        } )
+
+        it( "can serialize ParticipantGroupStatus", () => {
+            const deploymentStatus = new StudyDeploymentStatus.DeploymentReady( UUID.Companion.randomUUID(), new ArrayList( [] ), DateTime.Companion.now() )
+            const participants = toSet( [ new DeanonymizedParticipant( UUID.Companion.randomUUID(), UUID.Companion.randomUUID() ) ] )
+
+            // Initialize data through a participant attribute. TypeScript does not have to initialize data objects directly.
+            const attribute = new ParticipantAttribute.CustomParticipantAttribute( new Text( "Name" ) )
+            const inputData = attribute.inputToData_jon1ci$( CarpInputDataTypes, "Steven" )
+            const data = toMap( [ new Pair( new NamespacedId( "namespace", "type" ), inputData ) ] )
+
+            const group = new ParticipantGroupStatus( deploymentStatus, participants, data )
+
+            const json: Json = createStudiesSerializer()
+            const serializer = ParticipantGroupStatus.Companion.serializer()
+            const serialized = json.encodeToString_tf03ej$( serializer, group )
             expect( serialized ).is.not.undefined
         } )
     } )

--- a/typescript-declarations/tests/kotlin.ts
+++ b/typescript-declarations/tests/kotlin.ts
@@ -3,6 +3,7 @@ import VerifyModule from './VerifyModule'
 
 import { Long } from 'kotlin'
 import { kotlin } from 'kotlin'
+import Pair = kotlin.Pair
 import ArrayList = kotlin.collections.ArrayList
 import HashSet = kotlin.collections.HashSet
 import toSet = kotlin.collections.toSet_us0mfu$
@@ -11,6 +12,7 @@ import toSet = kotlin.collections.toSet_us0mfu$
 describe( "kotlin", () => {
     it( "verify module declarations", async () => {
         const instances = [
+            new Pair( "key", "value" ),
             new HashSet(),
             new ArrayList( [ "One", "Two", "Three" ] )
         ]


### PR DESCRIPTION
This adds `ProtocolService.updateParticipantDataConfiguration` and also refactors some of the other existing `ProtocolService` endpoints.

Refactoring includes:

- Rename of `update` to `addVersion`.
- Return null results and empty list in the repository instead of `IllegalArgumentException`. The service decides whether this means they are incorrect arguments.
- Use newly introduced `StudyProtocol.Id` in endpoints rather than separate `ProtocolOwner` and protocol name parameters.  Also, protocol owner id is now passed, rather than the full `ProtocolOwner` object which will likely evolve into a domain object later on.
- Added tests for `ProtocolService`, as part of which an in-memory implementation of `StudyProtocolRepository` was added.

Todo:

- [x] Add participant data to `ParticipantGroupStatus` (#207)
- [x] Do not store `ProtocolOwner` in `StudyProtocol`, only UUID. Protocol may still be initialized from this domain object.
- [x] TypeScript declarations (#208)

Fixes #206
Fixes #207
Fixes #208 