### PR TITLE
`EventBus` abstraction and groundwork for `StudyService.remove`

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ApplicationService.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ApplicationService.kt
@@ -1,0 +1,10 @@
+package dk.cachet.carp.common.ddd
+
+
+/**
+ * Exposes interactions with internal domain objects which may raise [TIntegrationEvent]s.
+ */
+interface ApplicationService<
+    Self : ApplicationService<Self, TIntegrationEvent>,
+    in TIntegrationEvent : IntegrationEvent<Self>
+>

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBus.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBus.kt
@@ -1,0 +1,50 @@
+package dk.cachet.carp.common.ddd
+
+import kotlin.reflect.KClass
+
+
+/**
+ * An event bus which can be used by an [ApplicationService] to publish events associated with its service
+ * and subscribe to any other events.
+ */
+class ApplicationServiceEventBus<
+    TApplicationService : ApplicationService<TApplicationService, TEvent>,
+    TEvent : IntegrationEvent<TApplicationService>
+>( private val serviceKlass: KClass<TApplicationService>, private val eventBus: EventBus )
+{
+    /**
+     * Publish the specified [event].
+     */
+    suspend fun publish( event: TEvent ) = eventBus.publish( serviceKlass, event )
+
+    /**
+     * Subscribe to events of [eventType] belonging to [applicationServiceKlass] and handle them using [handler].
+     */
+    suspend fun <
+        TOtherService : ApplicationService<TOtherService, TOtherServiceEvent>,
+        TOtherServiceEvent : IntegrationEvent<TOtherService>> subscribe(
+        applicationServiceKlass: KClass<TOtherService>,
+        eventType: KClass<TOtherServiceEvent>,
+        handler: (TOtherServiceEvent) -> Unit
+    ) = eventBus.subscribe( applicationServiceKlass, eventType, handler )
+}
+
+/**
+ * Subscribe to events of type [TEvent] on this [ApplicationServiceEventBus] and handle them using [handler].
+ */
+suspend inline fun <
+    reified TApplicationService : ApplicationService<TApplicationService, TEvent>,
+    reified TEvent : IntegrationEvent<TApplicationService>
+> ApplicationServiceEventBus<*, *>.subscribe( noinline handler: (TEvent) -> Unit ) =
+    this.subscribe( TApplicationService::class, TEvent::class, handler )
+
+
+/**
+ * Create an adapter for this [EventBus] which can only publish events associated with [serviceKlass].
+ */
+fun <
+    TApplicationService : ApplicationService<TApplicationService, TEvent>,
+    TEvent : IntegrationEvent<TApplicationService>
+> EventBus.createApplicationServiceAdapter(
+    serviceKlass: KClass<TApplicationService>
+): ApplicationServiceEventBus<TApplicationService, TEvent> = ApplicationServiceEventBus( serviceKlass, this )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/EventBus.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/EventBus.kt
@@ -1,0 +1,33 @@
+package dk.cachet.carp.common.ddd
+
+import kotlin.reflect.KClass
+
+
+/**
+ * A message bus with a publish/subscribe mechanism to distribute integration events across application services.
+ */
+interface EventBus
+{
+    /**
+     * Publish the specified [event].
+     */
+    suspend fun publish( event: IntegrationEvent )
+
+    /**
+     * Subscribe to events of [eventType] and handle them using [handler].
+     */
+    suspend fun <TEvent : IntegrationEvent> subscribe( eventType: KClass<TEvent>, handler: (TEvent) -> Unit )
+}
+
+
+/**
+ * Subscribe to events of type [TEvent] on the specified [eventBus] and handle them using [handler].
+ */
+suspend inline fun <reified TEvent : IntegrationEvent> subscribeEvent(
+    eventBus: EventBus,
+    noinline handler: (TEvent) -> Unit
+)
+{
+    val eventType = TEvent::class
+    eventBus.subscribe( eventType, handler )
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/EventBus.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/EventBus.kt
@@ -25,6 +25,7 @@ interface EventBus
     > subscribe( applicationServiceKlass: KClass<TApplicationService>, eventType: KClass<TEvent>, handler: (TEvent) -> Unit )
 }
 
+
 /**
  * Publish the specified [event] on this [EventBus].
  */

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/IntegrationEvent.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/IntegrationEvent.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 
 
 /**
- * An event raised by an application service.
+ * An event raised by an application service [TApplicationService].
  *
  * Integration events need to be immutable.
  */
@@ -15,4 +15,4 @@ import kotlinx.serialization.Serializable
 @Polymorphic
 @Immutable
 @ImplementAsDataClass
-abstract class IntegrationEvent
+abstract class IntegrationEvent<TApplicationService : ApplicationService<TApplicationService, *>>

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/IntegrationEvent.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/IntegrationEvent.kt
@@ -1,0 +1,18 @@
+package dk.cachet.carp.common.ddd
+
+import dk.cachet.carp.common.Immutable
+import dk.cachet.carp.common.ImplementAsDataClass
+import kotlinx.serialization.Polymorphic
+import kotlinx.serialization.Serializable
+
+
+/**
+ * An event raised by an application service.
+ *
+ * Integration events need to be immutable.
+ */
+@Serializable
+@Polymorphic
+@Immutable
+@ImplementAsDataClass
+abstract class IntegrationEvent

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/IntegrationEvent.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/IntegrationEvent.kt
@@ -15,4 +15,4 @@ import kotlinx.serialization.Serializable
 @Polymorphic
 @Immutable
 @ImplementAsDataClass
-abstract class IntegrationEvent<TApplicationService : ApplicationService<TApplicationService, *>>
+abstract class IntegrationEvent<out TApplicationService : ApplicationService<out TApplicationService, *>>

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBus.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBus.kt
@@ -1,0 +1,35 @@
+package dk.cachet.carp.common.ddd
+
+import kotlin.reflect.KClass
+
+
+/**
+ * A simple [EventBus] implementation for testing purposes which publishes and subscribes to events on the same thread.
+ */
+class SingleThreadedEventBus : EventBus
+{
+    private val eventHandlers: MutableMap<KClass<*>, MutableList<(IntegrationEvent) -> Unit>> = mutableMapOf()
+
+    /**
+     * Publish the specified [event] and instantly deliver it to all subscribers on the same thread as it is published on.
+     */
+    override suspend fun publish( event: IntegrationEvent )
+    {
+        // Get handlers for this event type.
+        val eventType = event::class
+        val handlers = eventHandlers[ eventType ]
+
+        handlers?.forEach { it( event ) }
+    }
+
+    /**
+     * Subscribe to events of [eventType] and handle them using [handler].
+     */
+    override suspend fun <TEvent : IntegrationEvent> subscribe( eventType: KClass<TEvent>, handler: (TEvent) -> Unit )
+    {
+        val handlers = eventHandlers.getOrPut( eventType, { mutableListOf() } )
+
+        @Suppress("UNCHECKED_CAST")
+        handlers.add( handler as (IntegrationEvent) -> Unit )
+    }
+}

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBusTest.kt
@@ -1,0 +1,62 @@
+package dk.cachet.carp.common.ddd
+
+import dk.cachet.carp.test.runSuspendTest
+import kotlinx.serialization.Serializable
+import kotlin.test.*
+
+
+/**
+ * Tests for [ApplicationServiceEventBus].
+ */
+class ApplicationServiceEventBusTest
+{
+    interface TestService : ApplicationService<TestService, Event>
+
+    @Serializable
+    sealed class Event : IntegrationEvent<TestService>()
+    {
+        @Serializable
+        object SomeEvent : Event()
+    }
+
+    interface OtherService : ApplicationService<OtherService, OtherEvent>
+
+    @Serializable
+    sealed class OtherEvent : IntegrationEvent<OtherService>()
+    {
+        @Serializable
+        object SomeOtherEvent : OtherEvent()
+    }
+
+
+    @Test
+    fun createApplicationServiceAdapter_succeeds()
+    {
+        val bus = SingleThreadedEventBus()
+        bus.createApplicationServiceAdapter( TestService::class )
+    }
+
+    @Test
+    fun publish_succeeds() = runSuspendTest {
+        val bus = SingleThreadedEventBus()
+        val serviceBus = bus.createApplicationServiceAdapter( TestService::class )
+
+        var eventReceived = false
+        bus.subscribe { _: Event.SomeEvent -> eventReceived = true }
+        serviceBus.publish( Event.SomeEvent )
+
+        assertTrue( eventReceived )
+    }
+
+    @Test
+    fun subscribe_succeeds() = runSuspendTest {
+        val bus = SingleThreadedEventBus()
+        val serviceBus = bus.createApplicationServiceAdapter( TestService::class )
+
+        var eventReceived = false
+        serviceBus.subscribe { _: OtherEvent -> eventReceived = true }
+        bus.publish( OtherEvent.SomeOtherEvent )
+
+        assertTrue( eventReceived )
+    }
+}

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/IntegrationEventTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/IntegrationEventTest.kt
@@ -1,0 +1,58 @@
+package dk.cachet.carp.common.ddd
+
+import dk.cachet.carp.common.serialization.NotSerializable
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlin.test.*
+
+
+/**
+ * Tests for [IntegrationEvent].
+ */
+class IntegrationEventTest
+{
+    interface Service : ApplicationService<Service, Service.Event>
+    {
+        @Serializable
+        sealed class Event : IntegrationEvent<Service>()
+        {
+            @Serializable
+            object SomeEvent : Event()
+        }
+    }
+
+
+    @Test
+    fun can_serialize_and_deserialize_application_service_event()
+    {
+        val event = Service.Event.SomeEvent
+
+        val json = Json { }
+        val serializer = Service.Event.serializer()
+        val serialized = json.encodeToString( serializer, event )
+        val parsed = json.decodeFromString( serializer, serialized )
+
+        assertEquals( event, parsed )
+    }
+
+    @Test
+    fun can_serialize_and_deserialize_base_IntegrationEvent()
+    {
+        val event: IntegrationEvent<*> = Service.Event.SomeEvent
+
+        val module = SerializersModule {
+            polymorphic( IntegrationEvent::class )
+            {
+                subclass( Service.Event.SomeEvent::class, Service.Event.SomeEvent.serializer() )
+            }
+        }
+        val json = Json { serializersModule = module }
+        val serializer = IntegrationEvent.serializer( NotSerializable )
+        val serialized = json.encodeToString( serializer, event )
+        val parsed = json.decodeFromString( serializer, serialized )
+
+        assertEquals( event, parsed )
+    }
+}

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBusTest.kt
@@ -1,0 +1,68 @@
+package dk.cachet.carp.common.ddd
+
+import dk.cachet.carp.test.runSuspendTest
+import kotlinx.serialization.Serializable
+import kotlin.test.*
+
+
+/**
+ * Tests for [SingleThreadedEventBus].
+ */
+class SingleThreadedEventBusTest
+{
+    @Serializable
+    data class SomeIntegrationEvent( val data: String ) : IntegrationEvent()
+
+    @Serializable
+    data class AnotherIntegrationEvent( val data: String ) : IntegrationEvent()
+
+    @Test
+    fun published_events_are_received_by_subscribers() = runSuspendTest {
+        val bus = SingleThreadedEventBus()
+
+        var receivedEventData: String? = null
+        bus.subscribe( SomeIntegrationEvent::class ) { event -> receivedEventData = event.data }
+        val sentData = "Data"
+
+        bus.publish( SomeIntegrationEvent( sentData ) )
+        assertEquals( "Data", receivedEventData )
+    }
+
+    @Test
+    fun subscribers_only_receive_requested_events() = runSuspendTest {
+        val bus = SingleThreadedEventBus()
+
+        var eventReceived = false
+        bus.subscribe( SomeIntegrationEvent::class ) { eventReceived = true }
+
+        bus.publish( AnotherIntegrationEvent( "Test" ) )
+        assertFalse( eventReceived )
+    }
+
+    @Test
+    fun multiple_subscribers_are_possible() = runSuspendTest {
+        val bus = SingleThreadedEventBus()
+
+        var receivedBySubscriber1 = false
+        bus.subscribe( SomeIntegrationEvent::class ) { receivedBySubscriber1 = true }
+        var receivedBySubscriber2 = false
+        bus.subscribe( SomeIntegrationEvent::class ) { receivedBySubscriber2 = true }
+
+        bus.publish( SomeIntegrationEvent( "Test" ) )
+        assertTrue( receivedBySubscriber1 )
+        assertTrue( receivedBySubscriber2 )
+    }
+
+    @Test
+    fun subscribeEvent_succeeds() = runSuspendTest {
+        val bus = SingleThreadedEventBus()
+
+        var receivedData: String? = null
+        subscribeEvent( bus ) { event: SomeIntegrationEvent ->
+            receivedData = event.data
+        }
+        bus.publish( SomeIntegrationEvent( "Test" ) )
+
+        assertEquals( "Test", receivedData )
+    }
+}

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -89,4 +89,11 @@ interface StudyService
      * @throws IllegalStateException when no study protocol for the given study is set yet.
      */
     suspend fun goLive( studyId: UUID ): StudyStatus
+
+    /**
+     * Remove the study with the specified [studyId].
+     *
+     * @return True when the study has been deleted, or false when there is no study to delete.
+     */
+    suspend fun remove( studyId: UUID ): Boolean
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
@@ -159,4 +159,12 @@ class StudyServiceHost( private val repository: StudyRepository ) : StudyService
 
         return study.getStatus()
     }
+
+    /**
+     * Remove the study with the specified [studyId].
+     *
+     * @return True when the study has been deleted, or false when there is no study to delete.
+     */
+    override suspend fun remove( studyId: UUID ): Boolean =
+        repository.remove( studyId )
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/StudyRepository.kt
@@ -32,4 +32,11 @@ interface StudyRepository
      * @throws IllegalArgumentException when no previous version of this study is stored in the repository.
      */
     suspend fun update( study: Study )
+
+    /**
+     * Remove the [Study] with the specified [studyId] from the repository.
+     *
+     * @return True when the study was removed; false when the study is not present in the repository.
+     */
+    suspend fun remove( studyId: UUID ): Boolean
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryStudyRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryStudyRepository.kt
@@ -52,4 +52,12 @@ class InMemoryStudyRepository : StudyRepository, ParticipantRepository by InMemo
 
         studies[ study.id ] = study.getSnapshot()
     }
+
+    /**
+     * Remove the [Study] with the specified [studyId] from the repository.
+     *
+     * @return True when the study was removed; false when the study is not present in the repository.
+     */
+    override suspend fun remove( studyId: UUID ): Boolean =
+        studies.remove( studyId ) != null
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -60,4 +60,9 @@ sealed class StudyServiceRequest
     data class GoLive( val studyId: UUID ) :
         StudyServiceRequest(),
         Invoker<StudyStatus> by createServiceInvoker( Service::goLive, studyId )
+
+    @Serializable
+    data class Remove( val studyId: UUID ) :
+        StudyServiceRequest(),
+        Invoker<Boolean> by createServiceInvoker( Service::remove, studyId )
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceMock.kt
@@ -24,7 +24,8 @@ class StudyServiceMock(
     private val getStudiesOverviewResult: List<StudyStatus> = emptyList(),
     private val setInvitationResult: StudyStatus = studyStatus,
     private val setProtocolResult: StudyStatus = studyStatus,
-    private val goLiveResult: StudyStatus = studyStatus
+    private val goLiveResult: StudyStatus = studyStatus,
+    private val removeResult: Boolean = true
 ) : Mock<Service>(), Service
 {
     companion object
@@ -69,4 +70,8 @@ class StudyServiceMock(
     override suspend fun goLive( studyId: UUID ) =
         goLiveResult
         .also { trackSuspendCall( Service::goLive, studyId ) }
+
+    override suspend fun remove( studyId: UUID ): Boolean =
+        removeResult
+        .also { trackSuspendCall( Service::remove, studyId ) }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceTest.kt
@@ -235,6 +235,31 @@ interface StudyServiceTest
         assertFailsWith<IllegalStateException> { service.goLive( status.studyId ) }
     }
 
+    @Test
+    fun remove_succeeds() = runSuspendTest {
+        val service = createService()
+        val owner = StudyOwner()
+        val status = service.createStudy( owner, "Test" )
+
+        val isRemoved = service.remove( status.studyId )
+
+        assertTrue( isRemoved )
+        val studies = service.getStudiesOverview( owner )
+        assertTrue( studies.isEmpty() )
+    }
+
+    @Test
+    fun remove_returns_false_when_already_removed() = runSuspendTest {
+        val service = createService()
+        val owner = StudyOwner()
+        val status = service.createStudy( owner, "Test" )
+        service.remove( status.studyId )
+
+        val isRemoved = service.remove( status.studyId )
+
+        assertFalse( isRemoved )
+    }
+
 
     private fun createDeployableProtocol(): StudyProtocolSnapshot
     {

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyRepositoryTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/StudyRepositoryTest.kt
@@ -85,4 +85,26 @@ interface StudyRepositoryTest
         val study = Study( StudyOwner(), "Test" )
         assertFailsWith<IllegalArgumentException> { repo.update( study ) }
     }
+
+    @Test
+    fun remove_succeeds() = runSuspendTest {
+        val repo = createRepository()
+        val study = Study( StudyOwner(), "Test" )
+        repo.add( study )
+
+        val isRemoved = repo.remove( study.id )
+        assertTrue( isRemoved )
+        assertNull( repo.getById( study.id ) )
+    }
+
+    @Test
+    fun remove_returns_false_when_study_not_present() = runSuspendTest {
+        val repo = createRepository()
+        val study = Study( StudyOwner(), "Test")
+        repo.add( study )
+        repo.remove( study.id )
+
+        val isRemoved = repo.remove( study.id )
+        assertFalse( isRemoved )
+    }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequestsTest.kt
@@ -29,7 +29,8 @@ class StudyServiceRequestsTest
             StudyServiceRequest.GetStudiesOverview( StudyOwner() ),
             StudyServiceRequest.SetInvitation( studyId, StudyInvitation.empty() ),
             StudyServiceRequest.SetProtocol( studyId, StudyProtocol( ProtocolOwner(), "Test" ).getSnapshot() ),
-            StudyServiceRequest.GoLive( studyId )
+            StudyServiceRequest.GoLive( studyId ),
+            StudyServiceRequest.Remove( studyId )
         )
     }
 

--- a/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
@@ -202,6 +202,10 @@ declare module 'carp.core-kotlin-carp.studies.core'
             {
                 constructor( studyId: UUID )
             }
+            class Remove extends StudyServiceRequest
+            {
+                constructor( studyId: UUID )
+            }
         }
 
 


### PR DESCRIPTION
`StudyService.remove` currently only removes the study from `StudyRepository`. This change needs to be propagated to `ParticipantService` and subsequently the deployments subsystem.

Therefore, I started adding the `EventBus` abstraction, which is the main bulk of this PR I already talked about extensively with @ltj . @ltj ; you could have a quick look at the first commit, which is the only one you did not yet look at. :)