### PR TITLE
Handle participations in `ParticipantGroup` rather than `StudyDeployment`.

### DIFF
--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/ClientCodeSamples.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/ClientCodeSamples.kt
@@ -7,6 +7,8 @@ import dk.cachet.carp.client.domain.data.DataListener
 import dk.cachet.carp.client.infrastructure.InMemoryClientRepository
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.data.CarpDataTypes
+import dk.cachet.carp.common.ddd.SingleThreadedEventBus
+import dk.cachet.carp.common.ddd.createApplicationServiceAdapter
 import dk.cachet.carp.common.users.Account
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.application.DeploymentService
@@ -69,10 +71,19 @@ class ClientCodeSamples
 
     private suspend fun createEndpoints(): Pair<ParticipationService, DeploymentService>
     {
+        val eventBus = SingleThreadedEventBus()
+
         val deploymentRepository = InMemoryDeploymentRepository()
-        val deploymentService = DeploymentServiceHost( deploymentRepository )
+        val deploymentService = DeploymentServiceHost(
+            deploymentRepository,
+            eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
+
         val participationRepository = InMemoryParticipationRepository()
-        val participationService = ParticipationServiceHost( deploymentRepository, participationRepository, accountService )
+        val participationService = ParticipationServiceHost(
+            deploymentRepository,
+            participationRepository,
+            accountService,
+            eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 
         // Create deployment for the example protocol.
         val protocol = createExampleProtocol()

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/ClientCodeSamples.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/ClientCodeSamples.kt
@@ -73,15 +73,12 @@ class ClientCodeSamples
     {
         val eventBus = SingleThreadedEventBus()
 
-        val deploymentRepository = InMemoryDeploymentRepository()
         val deploymentService = DeploymentServiceHost(
-            deploymentRepository,
+            InMemoryDeploymentRepository(),
             eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
-        val participationRepository = InMemoryParticipationRepository()
         val participationService = ParticipationServiceHost(
-            deploymentRepository,
-            participationRepository,
+            InMemoryParticipationRepository(),
             accountService,
             eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/ClientRepositoryTest.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/ClientRepositoryTest.kt
@@ -2,6 +2,8 @@ package dk.cachet.carp.client.domain
 
 import dk.cachet.carp.client.domain.data.DataListener
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.ddd.SingleThreadedEventBus
+import dk.cachet.carp.common.ddd.createApplicationServiceAdapter
 import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.deployment.application.DeploymentServiceHost
 import dk.cachet.carp.deployment.infrastructure.InMemoryDeploymentRepository
@@ -19,7 +21,11 @@ interface ClientRepositoryTest
 
     private fun createDependencies(): Triple<ClientRepository, DeploymentService, DataListener>
     {
-        val deploymentService = DeploymentServiceHost( InMemoryDeploymentRepository() )
+        val eventBus = SingleThreadedEventBus()
+
+        val deploymentService = DeploymentServiceHost(
+            InMemoryDeploymentRepository(),
+            eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
         return Triple( createRepository(), deploymentService, createDataListener() )
     }
 

--- a/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/CreateTestObjects.kt
+++ b/carp.client.core/src/commonTest/kotlin/dk/cachet/carp/client/domain/CreateTestObjects.kt
@@ -6,6 +6,8 @@ import dk.cachet.carp.client.domain.data.DeviceDataCollectorFactory
 import dk.cachet.carp.client.domain.data.StubDeviceDataCollector
 import dk.cachet.carp.client.domain.data.StubDeviceDataCollectorFactory
 import dk.cachet.carp.common.data.DataType
+import dk.cachet.carp.common.ddd.SingleThreadedEventBus
+import dk.cachet.carp.common.ddd.createApplicationServiceAdapter
 import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.deployment.application.DeploymentServiceHost
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
@@ -60,7 +62,11 @@ fun createDependentSmartphoneStudy(): StudyProtocol
  */
 suspend fun createStudyDeployment( protocol: StudyProtocol ): Pair<DeploymentService, StudyDeploymentStatus>
 {
-    val deploymentService = DeploymentServiceHost( InMemoryDeploymentRepository() )
+    val eventBus = SingleThreadedEventBus()
+
+    val deploymentService = DeploymentServiceHost(
+        InMemoryDeploymentRepository(),
+        eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
     val status = deploymentService.createStudyDeployment( protocol.getSnapshot() )
     return Pair( deploymentService, status )
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.ApplicationService
 import dk.cachet.carp.common.ddd.IntegrationEvent
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
+import dk.cachet.carp.deployment.domain.StudyDeploymentSnapshot
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
@@ -19,6 +20,10 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
 {
     @Serializable
     sealed class Event : IntegrationEvent<DeploymentService>()
+    {
+        @Serializable
+        data class StudyDeploymentCreated( val deployment: StudyDeploymentSnapshot ) : Event()
+    }
 
 
     /**

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -23,6 +23,8 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
     {
         @Serializable
         data class StudyDeploymentCreated( val deployment: StudyDeploymentSnapshot ) : Event()
+        @Serializable
+        data class StudyDeploymentStopped( val studyDeploymentId: UUID ) : Event()
     }
 
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -2,18 +2,25 @@ package dk.cachet.carp.deployment.application
 
 import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.ddd.ApplicationService
+import dk.cachet.carp.common.ddd.IntegrationEvent
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
+import kotlinx.serialization.Serializable
 
 
 /**
  * Application service which allows deploying [StudyProtocol]'s
  * and retrieving [MasterDeviceDeployment]'s for participating master devices as defined in the protocol.
  */
-interface DeploymentService
+interface DeploymentService : ApplicationService<DeploymentService, DeploymentService.Event>
 {
+    @Serializable
+    sealed class Event : IntegrationEvent<DeploymentService>()
+
+
     /**
      * Instantiate a study deployment for a given [StudyProtocolSnapshot].
      *

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -8,6 +8,7 @@ import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentSnapshot
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
+import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
 import kotlinx.serialization.Serializable
 
@@ -25,6 +26,12 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
         data class StudyDeploymentCreated( val deployment: StudyDeploymentSnapshot ) : Event()
         @Serializable
         data class StudyDeploymentStopped( val studyDeploymentId: UUID ) : Event()
+        @Serializable
+        data class DeviceRegistrationChanged(
+            val studyDeploymentId: UUID,
+            val device: AnyDeviceDescriptor,
+            val registration: DeviceRegistration?
+        ) : Event()
     }
 
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.deployment.application
 
 import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.ddd.ApplicationServiceEventBus
 import dk.cachet.carp.deployment.domain.DeploymentRepository
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.RegistrableDevice
@@ -18,7 +19,10 @@ import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
  * Application service which allows deploying [StudyProtocol]'s
  * and retrieving [MasterDeviceDeployment]'s for participating master devices as defined in the protocol.
  */
-class DeploymentServiceHost( private val repository: DeploymentRepository ) : DeploymentService
+class DeploymentServiceHost(
+    private val repository: DeploymentRepository,
+    private val eventBus: ApplicationServiceEventBus<DeploymentService, DeploymentService.Event>
+) : DeploymentService
 {
     /**
      * Instantiate a study deployment for a given [StudyProtocolSnapshot].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -173,6 +173,7 @@ class DeploymentServiceHost(
         {
             deployment.stop()
             repository.update( deployment )
+            eventBus.publish( DeploymentService.Event.StudyDeploymentStopped( studyDeploymentId ) )
         }
 
         return deployment.getStatus()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -35,6 +35,7 @@ class DeploymentServiceHost(
         val newDeployment = StudyDeployment( protocol )
 
         repository.add( newDeployment )
+        eventBus.publish( DeploymentService.Event.StudyDeploymentCreated( newDeployment.getSnapshot() ) )
 
         return newDeployment.getStatus()
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationService.kt
@@ -3,19 +3,26 @@ package dk.cachet.carp.deployment.application
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.data.Data
 import dk.cachet.carp.common.data.input.InputDataType
+import dk.cachet.carp.common.ddd.ApplicationService
+import dk.cachet.carp.common.ddd.IntegrationEvent
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployment.domain.users.ParticipantData
 import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.deployment.domain.users.StudyInvitation
+import kotlinx.serialization.Serializable
 
 
 /**
  * Application service which allows inviting participants, retrieving participations for study deployments,
  * and managing data related to participants which is input by users.
  */
-interface ParticipationService
+interface ParticipationService : ApplicationService<ParticipationService, ParticipationService.Event>
 {
+    @Serializable
+    sealed class Event : IntegrationEvent<ParticipationService>()
+
+
     /**
      * Let the person with the specified [identity] participate in the study deployment with [studyDeploymentId],
      * using the master devices with the specified [deviceRoleNames].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHost.kt
@@ -44,6 +44,14 @@ class ParticipationServiceHost(
             val group = ParticipantGroup.fromDeployment( created.deployment.toObject() )
             participationRepository.putParticipantGroup( group )
         }
+
+        // Notify participant group that associated study deployment has stopped.
+        eventBus.subscribe { stopped: DeploymentService.Event.StudyDeploymentStopped ->
+            val group = participationRepository.getParticipantGroup( stopped.studyDeploymentId )
+            checkNotNull( group )
+            group.studyDeploymentStopped()
+            participationRepository.putParticipantGroup( group )
+        }
     }
 
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHost.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.data.Data
 import dk.cachet.carp.common.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.data.input.InputDataType
 import dk.cachet.carp.common.data.input.InputDataTypeList
+import dk.cachet.carp.common.ddd.ApplicationServiceEventBus
 import dk.cachet.carp.common.users.AccountIdentity
 import dk.cachet.carp.deployment.domain.DeploymentRepository
 import dk.cachet.carp.deployment.domain.users.AccountService
@@ -28,6 +29,7 @@ class ParticipationServiceHost(
     private val deploymentRepository: DeploymentRepository,
     private val participationRepository: ParticipationRepository,
     private val accountService: AccountService,
+    private val eventBus: ApplicationServiceEventBus<ParticipationService, ParticipationService.Event>,
     /**
      * Supported [InputDataType]'s for participant data input by users.
      */

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -6,9 +6,6 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.AggregateRoot
 import dk.cachet.carp.common.ddd.DomainEvent
 import dk.cachet.carp.common.serialization.UnknownPolymorphicWrapper
-import dk.cachet.carp.common.users.Account
-import dk.cachet.carp.deployment.domain.users.AccountParticipation
-import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
@@ -23,7 +20,6 @@ import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
  * I.e., a [StudyDeployment] is responsible for registering the physical devices described in the [StudyProtocol],
  * enabling a connection between them, tracking device connection issues, and assessing data quality.
  */
-@Suppress( "TooManyFunctions" ) // TODO: Can this be decomposed a bit? Participation management will be moved to `ParticipantGroup`.
 class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID = UUID.randomUUID() ) :
     AggregateRoot<StudyDeployment, StudyDeploymentSnapshot, StudyDeployment.Event>()
 {
@@ -37,7 +33,6 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
         // TODO: Immutable base class does not allow this to be defined as `object Stopped : Event()`.
         //       It requires a data class, but that does not make sense since an object would still be immutable.
         data class Stopped( private val ignored: Unit = Unit ) : Event()
-        data class ParticipationAdded( val accountParticipation: AccountParticipation ) : Event()
     }
 
 
@@ -80,11 +75,6 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
                     ?: throw IllegalArgumentException( "Can't find deployed device with role name '$invalidatedRoleName' in snapshot." )
             }
             deployment._invalidatedDeployedDevices.addAll( invalidatedDevices )
-
-            // Add participations.
-            snapshot.participations.forEach { p ->
-                deployment._participations.add( AccountParticipation( p.accountId, p.participationId ) )
-            }
 
             // In case the deployment has been stopped, stop it.
             if ( snapshot.isStopped ) deployment.stop()
@@ -158,14 +148,6 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
      */
     var isStopped: Boolean = false
         private set
-
-    /**
-     * The account IDs participating in this study deployment and the pseudonym IDs assigned to them.
-     */
-    val participations: Set<AccountParticipation>
-        get() = _participations
-
-    private val _participations: MutableSet<AccountParticipation> = mutableSetOf()
 
     init
     {
@@ -426,34 +408,6 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
             event( Event.Stopped() )
         }
     }
-
-    /**
-     * Add [participation] details for a given [account] to this study deployment.
-     *
-     * @throws IllegalArgumentException if the specified [account] already participates in this deployment,
-     * or if the [participation] details do not match this study deployment.
-     * @throws IllegalStateException when this deployment has stopped.
-     */
-    fun addParticipation( account: Account, participation: Participation )
-    {
-        require( id == participation.studyDeploymentId ) { "The specified participation details do not match this study deployment." }
-        require( _participations.none { it.accountId == account.id } ) { "The specified account already participates in this study deployment." }
-        check( !isStopped ) { "Cannot add participations after a study deployment has stopped." }
-
-        val accountParticipation = AccountParticipation( account.id, participation.id )
-        _participations.add( accountParticipation )
-        event( Event.ParticipationAdded( accountParticipation ) )
-    }
-
-    /**
-     * Get the participation details for a given [account] in this study deployment,
-     * or null in case the [account] does not participate in this study deployment.
-     */
-    fun getParticipation( account: Account ): Participation? =
-        _participations
-            .filter { it.accountId == account.id }
-            .map { Participation( id, it.participationId ) }
-            .singleOrNull()
 
 
     /**

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
@@ -3,7 +3,6 @@ package dk.cachet.carp.deployment.domain
 import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.Snapshot
-import dk.cachet.carp.deployment.domain.users.AccountParticipation
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistrationSerializer
@@ -23,8 +22,7 @@ data class StudyDeploymentSnapshot(
     val deployedDevices: Set<String>,
     val invalidatedDeployedDevices: Set<String>,
     val startTime: DateTime?,
-    val isStopped: Boolean,
-    val participations: Set<AccountParticipation>
+    val isStopped: Boolean
 ) : Snapshot<StudyDeployment>
 {
     companion object
@@ -45,8 +43,7 @@ data class StudyDeploymentSnapshot(
                 studyDeployment.deployedDevices.map { it.roleName }.toSet(),
                 studyDeployment.invalidatedDeployedDevices.map { it.roleName }.toSet(),
                 studyDeployment.startTime,
-                studyDeployment.isStopped,
-                studyDeployment.participations )
+                studyDeployment.isStopped )
         }
     }
 

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ActiveParticipationInvitation.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ActiveParticipationInvitation.kt
@@ -1,8 +1,5 @@
 package dk.cachet.carp.deployment.domain.users
 
-import dk.cachet.carp.deployment.domain.DeviceDeploymentStatus
-import dk.cachet.carp.deployment.domain.StudyDeployment
-import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import kotlinx.serialization.Serializable
 
 
@@ -35,29 +32,31 @@ data class ActiveParticipationInvitation(
  * This subset is returned as [ActiveParticipationInvitation]s,
  * appending the current device registration status to the devices the participant was invited to use.
  *
- * @throws IllegalArgumentException when a deployment for one of the [invitations] is missing in [deployments],
- * or when the device roles specified in [invitations] do not match the deployment.
+ * @throws IllegalArgumentException when a participant group for one of the [invitations] is missing in [groups],
+ * or when the device roles specified in [invitations] do not match the assigned devices.
  */
 internal fun filterActiveParticipationInvitations(
     invitations: Set<ParticipationInvitation>,
-    deployments: List<StudyDeployment>
+    groups: List<ParticipantGroup>
 ): Set<ActiveParticipationInvitation>
 {
     return invitations
         .map { it to (
-            deployments.firstOrNull { d -> d.id == it.participation.studyDeploymentId }
-                ?.getStatus()
+            groups.firstOrNull { g -> g.studyDeploymentId == it.participation.studyDeploymentId }
                 ?: throw IllegalArgumentException( "No deployment is passed to pair with one of the given invitations." )
         ) }
-        .filter { it.second !is StudyDeploymentStatus.Stopped }
+        .filter { !it.second.isStudyDeploymentStopped }
         .map {
             ActiveParticipationInvitation(
                 it.first.participation,
                 it.first.invitation,
                 it.first.deviceRoleNames.map { deviceRoleName ->
+                    val assignedDevice =
+                        it.second.assignedMasterDevices.firstOrNull { a -> a.device.roleName == deviceRoleName }
+                    requireNotNull( assignedDevice ) { "Device in invitation with role name \"$deviceRoleName\" is not an assigned device." }
                     ActiveParticipationInvitation.DeviceInvitation(
                         deviceRoleName,
-                        it.second.getDeviceStatus( deviceRoleName ) is DeviceDeploymentStatus.Registered
+                        assignedDevice.registration != null
                     )
                 }.toSet()
             )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/AssignedMasterDevice.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/AssignedMasterDevice.kt
@@ -1,0 +1,19 @@
+package dk.cachet.carp.deployment.domain.users
+
+import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
+import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
+import dk.cachet.carp.protocols.domain.devices.DeviceRegistrationSerializer
+import dk.cachet.carp.protocols.domain.devices.MasterDeviceDescriptorSerializer
+import kotlinx.serialization.Serializable
+
+
+/**
+ * Master [device] and its current [registration] assigned to participants as part of a [ParticipantGroup].
+ */
+@Serializable
+data class AssignedMasterDevice(
+    @Serializable( MasterDeviceDescriptorSerializer::class )
+    val device: AnyMasterDeviceDescriptor,
+    @Serializable( DeviceRegistrationSerializer::class )
+    val registration: DeviceRegistration?
+)

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantGroupSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantGroupSnapshot.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.Serializable
 data class ParticipantGroupSnapshot(
     override val creationDate: DateTime,
     val studyDeploymentId: UUID,
+    val assignedMasterDevices: Set<AssignedMasterDevice>,
     val isStudyDeploymentStopped: Boolean,
     val expectedData: Set<ParticipantAttribute>,
     val participations: Set<AccountParticipation>,
@@ -31,6 +32,7 @@ data class ParticipantGroupSnapshot(
             ParticipantGroupSnapshot(
                 group.creationDate,
                 group.studyDeploymentId,
+                group.assignedMasterDevices.toSet(),
                 group.isStudyDeploymentStopped,
                 group.expectedData.toSet(),
                 group.participations.toSet(),

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantGroupSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantGroupSnapshot.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.Serializable
 data class ParticipantGroupSnapshot(
     override val creationDate: DateTime,
     val studyDeploymentId: UUID,
+    val isStudyDeploymentStopped: Boolean,
     val expectedData: Set<ParticipantAttribute>,
     val participations: Set<AccountParticipation>,
     val data: Map<InputDataType, Data?>
@@ -30,6 +31,7 @@ data class ParticipantGroupSnapshot(
             ParticipantGroupSnapshot(
                 group.creationDate,
                 group.studyDeploymentId,
+                group.isStudyDeploymentStopped,
                 group.expectedData.toSet(),
                 group.participations.toSet(),
                 group.data.toMap()

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantGroupSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantGroupSnapshot.kt
@@ -17,6 +17,7 @@ data class ParticipantGroupSnapshot(
     override val creationDate: DateTime,
     val studyDeploymentId: UUID,
     val expectedData: Set<ParticipantAttribute>,
+    val participations: Set<AccountParticipation>,
     val data: Map<InputDataType, Data?>
 ) : Snapshot<ParticipantGroup>
 {
@@ -30,6 +31,7 @@ data class ParticipantGroupSnapshot(
                 group.creationDate,
                 group.studyDeploymentId,
                 group.expectedData.toSet(),
+                group.participations.toSet(),
                 group.data.toMap()
             )
     }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepository.kt
@@ -21,10 +21,32 @@ interface ParticipationRepository
     suspend fun getParticipantGroup( studyDeploymentId: UUID ): ParticipantGroup?
 
     /**
-     * Return all [ParticipantGroup]s maching the specified [studyDeploymentIds].
+     * Return the [ParticipantGroup] for the specified [studyDeploymentId].
+     *
+     * @throws IllegalArgumentException when no participant group for the specified [studyDeploymentId] is found.
+     */
+    suspend fun getParticipantGroupOrThrowBy( studyDeploymentId: UUID ): ParticipantGroup =
+        getParticipantGroup( studyDeploymentId )
+            ?: throw IllegalArgumentException( "A participant group for the study deployment with ID '$studyDeploymentId' does not exist." )
+
+    /**
+     * Return all [ParticipantGroup]s matching the specified [studyDeploymentIds].
      * Ids that are not found are ignored.
      */
     suspend fun getParticipantGroupList( studyDeploymentIds: Set<UUID> ): List<ParticipantGroup>
+
+    /**
+     * Return all [ParticipantGroup]s matching the specified [studyDeploymentIds].
+     *
+     * @throws IllegalArgumentException when no participant group exists for one of the passed [studyDeploymentIds].
+     */
+    suspend fun getParticipantGroupListOrThrow( studyDeploymentIds: Set<UUID> ): List<ParticipantGroup>
+    {
+        val groups = getParticipantGroupList( studyDeploymentIds )
+        require( studyDeploymentIds.size == groups.size ) { "A study deployment ID has been passed for which no participant group exists." }
+
+        return groups
+    }
 
     /**
      * Adds or updates the participant [group] in this repository.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryParticipationRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryParticipationRepository.kt
@@ -38,7 +38,7 @@ class InMemoryParticipationRepository : ParticipationRepository
         participantGroups[ studyDeploymentId ]?.let { ParticipantGroup.fromSnapshot( it ) }
 
     /**
-     * Return all [ParticipantGroup]s maching the specified [studyDeploymentIds].
+     * Return all [ParticipantGroup]s matching the specified [studyDeploymentIds].
      * Ids that are not found are ignored.
      */
     override suspend fun getParticipantGroupList( studyDeploymentIds: Set<UUID> ): List<ParticipantGroup> =

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/DeploymentCodeSamples.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/DeploymentCodeSamples.kt
@@ -1,6 +1,9 @@
 package dk.cachet.carp.deployment
 
 import dk.cachet.carp.common.DateTime
+import dk.cachet.carp.common.ddd.EventBus
+import dk.cachet.carp.common.ddd.SingleThreadedEventBus
+import dk.cachet.carp.common.ddd.createApplicationServiceAdapter
 import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.deployment.application.DeploymentServiceHost
 import dk.cachet.carp.deployment.domain.DeviceDeploymentStatus
@@ -67,5 +70,8 @@ class DeploymentCodeSamples
         return protocol
     }
 
-    private fun createDeploymentEndpoint(): DeploymentService = DeploymentServiceHost( InMemoryDeploymentRepository() )
+    private val eventBus: EventBus = SingleThreadedEventBus()
+    private fun createDeploymentEndpoint(): DeploymentService = DeploymentServiceHost(
+        InMemoryDeploymentRepository(),
+        eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHostTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHostTest.kt
@@ -1,5 +1,8 @@
 package dk.cachet.carp.deployment.application
 
+import dk.cachet.carp.common.ddd.EventBus
+import dk.cachet.carp.common.ddd.SingleThreadedEventBus
+import dk.cachet.carp.common.ddd.createApplicationServiceAdapter
 import dk.cachet.carp.deployment.infrastructure.InMemoryDeploymentRepository
 
 
@@ -8,5 +11,9 @@ import dk.cachet.carp.deployment.infrastructure.InMemoryDeploymentRepository
  */
 class DeploymentServiceHostTest : DeploymentServiceTest()
 {
-    override fun createService(): DeploymentService = DeploymentServiceHost( InMemoryDeploymentRepository() )
+    private val eventBus: EventBus = SingleThreadedEventBus()
+
+    override fun createService(): DeploymentService = DeploymentServiceHost(
+        InMemoryDeploymentRepository(),
+        eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
@@ -32,17 +32,14 @@ class HostsIntegrationTest
         eventBus = SingleThreadedEventBus()
 
         // Create deployment service.
-        val deploymentRepo = InMemoryDeploymentRepository()
         deploymentService = DeploymentServiceHost(
-            deploymentRepo,
+            InMemoryDeploymentRepository(),
             eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
         // Create participation service.
         accountService = InMemoryAccountService()
-        val participationRepository = InMemoryParticipationRepository()
         participationService = ParticipationServiceHost(
-            deploymentRepo,
-            participationRepository,
+            InMemoryParticipationRepository(),
             accountService,
             eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
     }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
@@ -1,0 +1,61 @@
+package dk.cachet.carp.deployment.application
+
+import dk.cachet.carp.common.ddd.EventBus
+import dk.cachet.carp.common.ddd.SingleThreadedEventBus
+import dk.cachet.carp.common.ddd.createApplicationServiceAdapter
+import dk.cachet.carp.deployment.infrastructure.InMemoryAccountService
+import dk.cachet.carp.deployment.infrastructure.InMemoryDeploymentRepository
+import dk.cachet.carp.deployment.infrastructure.InMemoryParticipationRepository
+import dk.cachet.carp.protocols.infrastructure.test.createComplexProtocol
+import dk.cachet.carp.test.runSuspendTest
+import kotlin.test.*
+
+
+/**
+ * Tests whether different application service hosts in the deployments subsystem
+ * are correctly integrated through integration events.
+ */
+class HostsIntegrationTest
+{
+    lateinit var eventBus: EventBus
+
+    lateinit var deploymentService: DeploymentService
+    lateinit var participationService: ParticipationService
+
+    @BeforeTest
+    fun startServices()
+    {
+        eventBus = SingleThreadedEventBus()
+
+        // Create deployment service.
+        val deploymentRepo = InMemoryDeploymentRepository()
+        deploymentService = DeploymentServiceHost(
+            deploymentRepo,
+            eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
+
+        // Create participation service.
+        val accountService = InMemoryAccountService()
+        val participationRepository = InMemoryParticipationRepository()
+        participationService = ParticipationServiceHost(
+            deploymentRepo,
+            participationRepository,
+            accountService,
+            eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
+    }
+
+    @Test
+    fun create_deployment_creates_participant_group() = runSuspendTest {
+        var deploymentCreated: DeploymentService.Event.StudyDeploymentCreated? = null
+        eventBus.subscribe( DeploymentService::class, DeploymentService.Event.StudyDeploymentCreated::class )
+        {
+            deploymentCreated = it
+        }
+
+        val protocol = createComplexProtocol().getSnapshot()
+        val deployment = deploymentService.createStudyDeployment( protocol )
+        val participantGroupData = participationService.getParticipantData( deployment.studyDeploymentId )
+
+        assertEquals( deployment.studyDeploymentId, deploymentCreated?.deployment?.studyDeploymentId )
+        assertEquals( protocol.expectedParticipantData.size, participantGroupData.data.size )
+    }
+}

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHostTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHostTest.kt
@@ -21,17 +21,14 @@ class ParticipationServiceHostTest : ParticipationServiceTest()
     {
         val eventBus: EventBus = SingleThreadedEventBus()
 
-        val deploymentRepository = InMemoryDeploymentRepository()
         val deploymentService = DeploymentServiceHost(
-            deploymentRepository,
+            InMemoryDeploymentRepository(),
             eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
         val accountService = InMemoryAccountService()
 
-        val participationRepository = InMemoryParticipationRepository()
         val participationService = ParticipationServiceHost(
-            deploymentRepository,
-            participationRepository,
+            InMemoryParticipationRepository(),
             accountService,
             eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHostTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHostTest.kt
@@ -1,6 +1,9 @@
 package dk.cachet.carp.deployment.application
 
 import dk.cachet.carp.common.data.input.InputDataTypeList
+import dk.cachet.carp.common.ddd.EventBus
+import dk.cachet.carp.common.ddd.SingleThreadedEventBus
+import dk.cachet.carp.common.ddd.createApplicationServiceAdapter
 import dk.cachet.carp.deployment.domain.users.AccountService
 import dk.cachet.carp.deployment.infrastructure.InMemoryAccountService
 import dk.cachet.carp.deployment.infrastructure.InMemoryDeploymentRepository
@@ -16,8 +19,12 @@ class ParticipationServiceHostTest : ParticipationServiceTest()
         participantDataInputTypes: InputDataTypeList
     ): Triple<ParticipationService, DeploymentService, AccountService>
     {
+        val eventBus: EventBus = SingleThreadedEventBus()
+
         val deploymentRepository = InMemoryDeploymentRepository()
-        val deploymentService = DeploymentServiceHost( deploymentRepository )
+        val deploymentService = DeploymentServiceHost(
+            deploymentRepository,
+            eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
         val accountService = InMemoryAccountService()
 
@@ -25,7 +32,8 @@ class ParticipationServiceHostTest : ParticipationServiceTest()
         val participationService = ParticipationServiceHost(
             deploymentRepository,
             participationRepository,
-            accountService )
+            accountService,
+            eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 
         return Triple( participationService, deploymentService, accountService )
     }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -83,6 +83,7 @@ fun createComplexParticipantGroup(): ParticipantGroup
         addParticipation( Account.withEmailIdentity( "test@test.com" ), Participation( studyDeploymentId ) )
         setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
         setData( CarpInputDataTypes, customAttribute.inputType, CustomInput( "Steven" ) )
+        studyDeploymentStopped()
     }
 }
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -34,11 +34,6 @@ fun createComplexDeployment(): StudyDeployment
     deployment.registerDevice( master, master.createRegistration() )
     deployment.registerDevice( connected, connected.createRegistration() )
 
-    // Add a participation.
-    val account = Account.withUsernameIdentity( "test" )
-    val participation = Participation( deployment.id )
-    deployment.addParticipation( account, participation )
-
     // Deploy a device.
     val deviceDeployment = deployment.getDeviceDeploymentFor( master )
     deployment.deviceDeployed( master, deviceDeployment.lastUpdateDate )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/CreateTestObjects.kt
@@ -80,6 +80,7 @@ fun createComplexParticipantGroup(): ParticipantGroup
     val deployment = StudyDeployment( protocol.getSnapshot() )
 
     return ParticipantGroup.fromDeployment( deployment ).apply {
+        addParticipation( Account.withEmailIdentity( "test@test.com" ), Participation( studyDeploymentId ) )
         setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
         setData( CarpInputDataTypes, customAttribute.inputType, CustomInput( "Steven" ) )
     }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
@@ -1,8 +1,6 @@
 package dk.cachet.carp.deployment.domain
 
 import dk.cachet.carp.common.UUID
-import dk.cachet.carp.common.users.Account
-import dk.cachet.carp.deployment.domain.users.Participation
 import dk.cachet.carp.protocols.infrastructure.test.createSingleMasterWithConnectedDeviceProtocol
 import dk.cachet.carp.test.runSuspendTest
 import kotlin.test.*
@@ -113,8 +111,6 @@ interface DeploymentRepositoryTest
 
             val deviceDeployment = deployment.getDeviceDeploymentFor( masterDevice )
             deviceDeployed( masterDevice, deviceDeployment.lastUpdateDate )
-
-            addParticipation( Account.withUsernameIdentity( "Test" ), Participation( deployment.id ) )
 
             stop()
         }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ActiveParticipationInvitationTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ActiveParticipationInvitationTest.kt
@@ -2,7 +2,6 @@ package dk.cachet.carp.deployment.domain.users
 
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.deployment.domain.createActiveDeployment
-import dk.cachet.carp.deployment.domain.createStoppedDeployment
 import kotlin.test.*
 
 
@@ -15,15 +14,16 @@ class ActiveParticipationInvitationTest
     fun filterActiveParticipationInvitations_only_returns_active_deployments()
     {
         val deviceRole = "Participant's phone"
-        val activeDeployment = createActiveDeployment( deviceRole )
-        val stoppedDeployment = createStoppedDeployment( deviceRole )
+        val activeGroup = ParticipantGroup.fromDeployment( createActiveDeployment( deviceRole ) )
+        val stoppedGroup = ParticipantGroup.fromDeployment( createActiveDeployment( deviceRole ) )
+        stoppedGroup.studyDeploymentStopped()
 
-        val participation = Participation( activeDeployment.id )
+        val participation = Participation( activeGroup.studyDeploymentId )
         val invitation = ParticipationInvitation( participation, StudyInvitation.empty(), setOf( deviceRole ) )
 
         val activeInvitations = filterActiveParticipationInvitations(
             setOf( invitation ),
-            listOf( activeDeployment, stoppedDeployment )
+            listOf( activeGroup, stoppedGroup )
         )
 
         assertEquals( participation, activeInvitations.single().participation )
@@ -34,23 +34,24 @@ class ActiveParticipationInvitationTest
     {
         val deviceRole = "Participant's phone"
         val deployment = createActiveDeployment( deviceRole )
+        val group = ParticipantGroup.fromDeployment( deployment )
 
-        val participation = Participation( deployment.id )
+        val participation = Participation( group.studyDeploymentId )
         val invitation = ParticipationInvitation( participation, StudyInvitation.empty(), setOf( deviceRole ) )
 
         // When the device is not registered in the deployment, this is communicated in the active invitation.
         var activeInvitation = filterActiveParticipationInvitations(
             setOf( invitation ),
-            listOf( deployment )
+            listOf( group )
         ).first()
         assertFalse( activeInvitation.devices.first { it.deviceRoleName == deviceRole }.isRegistered )
 
         // Once the device is registered, this is communicated in the active invitation.
-        val toRegister = deployment.registrableDevices.first { it.device.roleName == deviceRole }.device
-        deployment.registerDevice( toRegister, toRegister.createRegistration() )
+        val toRegister = group.assignedMasterDevices.first { it.device.roleName == deviceRole }.device
+        group.updateDeviceRegistration( toRegister, toRegister.createRegistration() )
         activeInvitation = filterActiveParticipationInvitations(
             setOf( invitation ),
-            listOf( deployment )
+            listOf( group )
         ).first()
         assertTrue( activeInvitation.devices.first { it.deviceRoleName == deviceRole }.isRegistered )
     }
@@ -71,14 +72,14 @@ class ActiveParticipationInvitationTest
     @Test
     fun filterActiveParticipationInvitations_fails_when_participation_device_role_does_not_match()
     {
-        val deployment = createActiveDeployment( "Master" )
+        val group = ParticipantGroup.fromDeployment( createActiveDeployment( "Master" ) )
 
-        val participation = Participation( deployment.id )
+        val participation = Participation( group.studyDeploymentId )
         val invitation = ParticipationInvitation( participation, StudyInvitation.empty(), setOf( "Incorrect device role" ) )
 
         assertFailsWith<IllegalArgumentException>
         {
-            filterActiveParticipationInvitations( setOf( invitation ), listOf( deployment ) )
+            filterActiveParticipationInvitations( setOf( invitation ), listOf( group ) )
         }
     }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantGroupTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ParticipantGroupTest.kt
@@ -1,12 +1,15 @@
 package dk.cachet.carp.deployment.domain.users
 
+import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.data.Data
 import dk.cachet.carp.common.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.data.input.InputDataType
 import dk.cachet.carp.common.data.input.Sex
+import dk.cachet.carp.common.users.Account
 import dk.cachet.carp.common.users.ParticipantAttribute
 import dk.cachet.carp.deployment.domain.StudyDeployment
 import dk.cachet.carp.deployment.domain.createComplexParticipantGroup
+import dk.cachet.carp.deployment.domain.studyDeploymentFor
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSingleMasterDeviceProtocol
 import kotlin.test.*
@@ -28,6 +31,7 @@ class ParticipantGroupTest
 
         assertEquals( deployment.id, group.studyDeploymentId )
         assertEquals( mapOf( expectedData to null ), group.data )
+        assertEquals( 0, group.participations.size )
         assertEquals( 0, group.consumeEvents().size )
     }
 
@@ -40,12 +44,72 @@ class ParticipantGroupTest
 
         assertEquals( group.creationDate, fromSnapshot.creationDate )
         assertEquals( group.studyDeploymentId, fromSnapshot.studyDeploymentId )
+        assertEquals( group.participations, fromSnapshot.participations )
         assertEquals( group.expectedData, fromSnapshot.expectedData )
         assertEquals(
             group.data.map { it.key to it.value }.toSet(),
             fromSnapshot.data.map { it.key to it.value }.toSet()
         )
         assertEquals( 0, fromSnapshot.consumeEvents().size )
+    }
+
+    @Test
+    fun addParticipation_and_retrieving_it_succeeds()
+    {
+        val protocol: StudyProtocol = createSingleMasterDeviceProtocol()
+        val deployment = StudyDeployment( protocol.getSnapshot() )
+        val group = ParticipantGroup.fromDeployment( deployment )
+
+        val account = Account.withUsernameIdentity( "test" )
+        val participation = Participation( group.studyDeploymentId )
+        group.addParticipation( account, participation )
+        val retrievedParticipation = group.getParticipation( account )
+
+        assertEquals( participation, retrievedParticipation )
+        val expectedParticipation = AccountParticipation( account.id, participation.id )
+        assertEquals( ParticipantGroup.Event.ParticipationAdded( expectedParticipation ), group.consumeEvents().last() )
+    }
+
+    @Test
+    fun addParticipation_for_incorrect_study_deployment_fails()
+    {
+        val protocol: StudyProtocol = createSingleMasterDeviceProtocol()
+        val deployment = studyDeploymentFor( protocol )
+        val group = ParticipantGroup.fromDeployment( deployment )
+
+        val account = Account.withUsernameIdentity( "test" )
+        val incorrectDeploymentId = UUID.randomUUID()
+        val participation = Participation( incorrectDeploymentId )
+        assertFailsWith<IllegalArgumentException> { group.addParticipation( account, participation ) }
+        assertEquals( 0, group.consumeEvents().filterIsInstance<ParticipantGroup.Event.ParticipationAdded>().count() )
+    }
+
+    @Test
+    fun addParticipation_for_existing_account_fails()
+    {
+        val protocol: StudyProtocol = createSingleMasterDeviceProtocol()
+        val deployment = StudyDeployment( protocol.getSnapshot() )
+        val group = ParticipantGroup.fromDeployment( deployment )
+        val account = Account.withUsernameIdentity( "test" )
+        group.addParticipation( account, Participation( group.studyDeploymentId ) )
+
+        assertFailsWith<IllegalArgumentException>
+        {
+            group.addParticipation( account, Participation( group.studyDeploymentId ) )
+        }
+        assertEquals( 1, group.consumeEvents().filterIsInstance<ParticipantGroup.Event.ParticipationAdded>().count() )
+    }
+
+    @Test
+    fun getParticipation_for_non_participating_account_returns_null()
+    {
+        val protocol: StudyProtocol = createSingleMasterDeviceProtocol()
+        val deployment = StudyDeployment( protocol.getSnapshot() )
+        val group = ParticipantGroup.fromDeployment( deployment )
+
+        val account = Account.withUsernameIdentity( "test" )
+        val participation = group.getParticipation( account )
+        assertNull( participation )
     }
 
     @Test

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepositoryTest.kt
@@ -78,7 +78,10 @@ interface ParticipationRepositoryTest
         repo.putParticipantGroup( group2 )
 
         val groups = repo.getParticipantGroupList( setOf( deployment1.id, deployment2.id ) )
-        assertEquals( setOf( group1, group2 ), groups.toSet() )
+        assertEquals( // ParticipantGroup does not implement equals, but snapshot does.
+            arrayOf( group1, group2 ).map { it.getSnapshot() }.toSet(),
+            groups.map { it.getSnapshot() }.toSet()
+        )
     }
 
     @Test
@@ -97,8 +100,7 @@ interface ParticipationRepositoryTest
         val noPrevious = repo.putParticipantGroup( group )
         assertNull( noPrevious )
 
-        val group2 = createComplexParticipantGroup()
-        val previous = repo.putParticipantGroup( group2 )
+        val previous = repo.putParticipantGroup( group )
         assertNotNull( previous )
         assertEquals( group.creationDate, previous.creationDate )
     }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryParticipationRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryParticipationRepositoryTest.kt
@@ -1,0 +1,13 @@
+package dk.cachet.carp.deployment.infrastructure
+
+import dk.cachet.carp.deployment.domain.users.ParticipationRepository
+import dk.cachet.carp.deployment.domain.users.ParticipationRepositoryTest
+
+
+/**
+ * Tests whether [InMemoryDeploymentRepository] is implemented correctly.
+ */
+class InMemoryParticipationRepositoryTest : ParticipationRepositoryTest
+{
+    override fun createRepository(): ParticipationRepository = InMemoryParticipationRepository()
+}

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
@@ -4,7 +4,9 @@ import dk.cachet.carp.common.EmailAddress
 import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.SingleThreadedEventBus
 import dk.cachet.carp.common.ddd.createApplicationServiceAdapter
+import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.deployment.application.DeploymentServiceHost
+import dk.cachet.carp.deployment.application.ParticipationService
 import dk.cachet.carp.deployment.application.ParticipationServiceHost
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.deployment.infrastructure.InMemoryAccountService
@@ -75,17 +77,23 @@ class StudiesCodeSamples
     private fun createEndpoints(): Pair<StudyService, ParticipantService>
     {
         val eventBus = SingleThreadedEventBus()
+
         val studyRepo = InMemoryStudyRepository()
-        val studyService = StudyServiceHost( studyRepo, eventBus.createApplicationServiceAdapter( StudyService::class ) )
+        val studyService = StudyServiceHost(
+            studyRepo,
+            eventBus.createApplicationServiceAdapter( StudyService::class ) )
 
         val deploymentRepository = InMemoryDeploymentRepository()
-        val deploymentService = DeploymentServiceHost( deploymentRepository )
+        val deploymentService = DeploymentServiceHost(
+            deploymentRepository,
+            eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
         val participationRepository = InMemoryParticipationRepository()
         val participationService = ParticipationServiceHost(
             deploymentRepository,
             participationRepository,
-            InMemoryAccountService() )
+            InMemoryAccountService(),
+            eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 
         val participantService = ParticipantServiceHost(
             InMemoryParticipantRepository(),

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
@@ -83,15 +83,12 @@ class StudiesCodeSamples
             studyRepo,
             eventBus.createApplicationServiceAdapter( StudyService::class ) )
 
-        val deploymentRepository = InMemoryDeploymentRepository()
         val deploymentService = DeploymentServiceHost(
-            deploymentRepository,
+            InMemoryDeploymentRepository(),
             eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
-        val participationRepository = InMemoryParticipationRepository()
         val participationService = ParticipationServiceHost(
-            deploymentRepository,
-            participationRepository,
+            InMemoryParticipationRepository(),
             InMemoryAccountService(),
             eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
@@ -45,17 +45,14 @@ class HostsIntegrationTest
         studyService = StudyServiceHost( studyRepo, eventBus.createApplicationServiceAdapter( StudyService::class ) )
 
         // Create deployment service.
-        val deploymentRepo = InMemoryDeploymentRepository()
         deploymentService = DeploymentServiceHost(
-            deploymentRepo,
+            InMemoryDeploymentRepository(),
             eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
         // Create dependent participation service.
         val accountService = InMemoryAccountService()
-        val participationRepository = InMemoryParticipationRepository()
         participationService = ParticipationServiceHost(
-            deploymentRepo,
-            participationRepository,
+            InMemoryParticipationRepository(),
             accountService,
             eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
@@ -22,7 +22,8 @@ import kotlin.test.*
 
 
 /**
- * Tests whether different application service hosts are correctly integrated through integration events.
+ * Tests whether different application service hosts in the studies subsystem
+ * are correctly integrated through integration events.
  */
 class HostsIntegrationTest
 {

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
@@ -45,12 +45,18 @@ class HostsIntegrationTest
 
         // Create deployment service.
         val deploymentRepo = InMemoryDeploymentRepository()
-        deploymentService = DeploymentServiceHost( deploymentRepo )
+        deploymentService = DeploymentServiceHost(
+            deploymentRepo,
+            eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
         // Create dependent participation service.
         val accountService = InMemoryAccountService()
         val participationRepository = InMemoryParticipationRepository()
-        participationService = ParticipationServiceHost( deploymentRepo, participationRepository, accountService )
+        participationService = ParticipationServiceHost(
+            deploymentRepo,
+            participationRepository,
+            accountService,
+            eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 
         participantService = ParticipantServiceHost(
             InMemoryParticipantRepository(),

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/ParticipantServiceHostTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/ParticipantServiceHostTest.kt
@@ -2,7 +2,9 @@ package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.ddd.SingleThreadedEventBus
 import dk.cachet.carp.common.ddd.createApplicationServiceAdapter
+import dk.cachet.carp.deployment.application.DeploymentService
 import dk.cachet.carp.deployment.application.DeploymentServiceHost
+import dk.cachet.carp.deployment.application.ParticipationService
 import dk.cachet.carp.deployment.application.ParticipationServiceHost
 import dk.cachet.carp.deployment.infrastructure.InMemoryAccountService
 import dk.cachet.carp.deployment.infrastructure.InMemoryDeploymentRepository
@@ -22,16 +24,24 @@ class ParticipantServiceHostTest : ParticipantServiceTest
 
         // Create dependent study service.
         val studyRepo = InMemoryStudyRepository()
-        val studyService = StudyServiceHost( studyRepo, eventBus.createApplicationServiceAdapter( StudyService::class ) )
+        val studyService = StudyServiceHost(
+            studyRepo,
+            eventBus.createApplicationServiceAdapter( StudyService::class ) )
 
         // Create dependent deployment service.
         val deploymentRepo = InMemoryDeploymentRepository()
-        val deploymentService = DeploymentServiceHost( deploymentRepo )
+        val deploymentService = DeploymentServiceHost(
+            deploymentRepo,
+            eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
         // Create dependent participation service.
         val accountService = InMemoryAccountService()
         val participationRepository = InMemoryParticipationRepository()
-        val participationService = ParticipationServiceHost( deploymentRepo, participationRepository, accountService )
+        val participationService = ParticipationServiceHost(
+            deploymentRepo,
+            participationRepository,
+            accountService,
+            eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 
         val participantService = ParticipantServiceHost(
             InMemoryParticipantRepository(),

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/ParticipantServiceHostTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/ParticipantServiceHostTest.kt
@@ -29,17 +29,14 @@ class ParticipantServiceHostTest : ParticipantServiceTest
             eventBus.createApplicationServiceAdapter( StudyService::class ) )
 
         // Create dependent deployment service.
-        val deploymentRepo = InMemoryDeploymentRepository()
         val deploymentService = DeploymentServiceHost(
-            deploymentRepo,
+            InMemoryDeploymentRepository(),
             eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
         // Create dependent participation service.
         val accountService = InMemoryAccountService()
-        val participationRepository = InMemoryParticipationRepository()
         val participationService = ParticipationServiceHost(
-            deploymentRepo,
-            participationRepository,
+            InMemoryParticipationRepository(),
             accountService,
             eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
 


### PR DESCRIPTION
Similar to [a previous PR](https://github.com/cph-cachet/carp.core-kotlin/pull/221) which split repository dependencies between `StudyService` and `ParticipantService`, this PR removes dependencies between `DeploymentService` and `ParticipationService`. They now only have indirect dependencies via `EventBus`. This means that `Participation` is now stored in `ParticipantGroup` rather than in `StudyDeployment`.

Whenever a `StudyDeployment` is created, a matching `ParticipantGroup` gets created. `StudyDeployment` does device management (deployment and in the future status management), whereas `ParticipantGroup` manages everything related to participants, such as assigning devices to participants, consent, and storing participant data. This seems like a reasonable separation of concerns which at the very least makes the code easier to comprehend. Whether or not `DeploymentService` and `ParticipationService` need to evolve into separate microservices is to be determined later.

This separation might feel superfluous given that `ParticipationService` listens to a lot of changes of `DeploymentService` (register/unregister device, deployment stopped) to allow removing the dependency to `DeploymentRepository`, but we expect that later additions to the two respective services are less likely to impact one another. Furthermore, these are events which in practice won't be raised often.

There is one semi-unrelated commit: https://github.com/cph-cachet/carp.core-kotlin/pull/227/commits/0b48f2631e49bf69ff58074fc0418f9761fd06e2 I noticed the `InMemoryParticipationRepository` was not tested yet; only the test for the interface were written. Apparently, some of the tests were wrong, which are now fixed.

Potential improvements:

- [ ] Should we pass `DeviceDescriptor`s for `getActiveParticipationInvitations`? I see no real reason why only the role is passed.
- [ ] Now that `ParticipantGroup` contains assigned master devices, we could also consider storing which devices are assigned to participants within the same data structure. This would need to be updated as part of `addParticipation`.