### PR TITLE
Add TS declarations for deployment subsystem requests.

### DIFF
--- a/typescript-declarations/@types/carp.core-kotlin-carp.deployment.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.deployment.core/index.d.ts
@@ -2,10 +2,18 @@ declare module 'carp.core-kotlin-carp.deployment.core'
 {
     import { kotlin } from 'kotlin'
     import ArrayList = kotlin.collections.ArrayList
+    import HashMap = kotlin.collections.HashMap
     import HashSet = kotlin.collections.HashSet
+    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
+    import Json = kotlinx.serialization.json.Json
     import { dk as cdk } from 'carp.core-kotlin-carp.common'
-    import UUID = cdk.cachet.carp.common.UUID
+    import AccountIdentity = cdk.cachet.carp.common.users.AccountIdentity
     import DateTime = cdk.cachet.carp.common.DateTime
+    import NamespacedId = cdk.cachet.carp.common.NamespacedId
+    import UUID = cdk.cachet.carp.common.UUID
+    import { dk as pdk } from 'carp.core-kotlin-carp.protocols.core'
+    import DeviceRegistration = pdk.cachet.carp.protocols.domain.devices.DeviceRegistration
+    import StudyProtocolSnapshot = pdk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 
 
     namespace dk.cachet.carp.deployment.domain
@@ -81,6 +89,30 @@ declare module 'carp.core-kotlin-carp.deployment.core'
         }
 
 
+        class MasterDeviceDeployment
+        {
+            constructor(
+                deviceDescriptor: any,
+                configuration: DeviceRegistration,
+                connectedDevices: HashSet<any>,
+                connectedDeviceConfigurations: HashMap<string, DeviceRegistration>,
+                tasks: HashSet<any>,
+                triggers: HashMap<number, any>,
+                triggeredTasks: HashSet<any> )
+
+                static get Companion(): MasterDeviceDeployment$Companion
+
+                readonly deviceDescriptor: any
+                readonly configuration: DeviceRegistration
+                readonly connectedDevices: HashSet<any>
+                readonly connectedDeviceConfigurations: HashMap<string, DeviceRegistration>
+                readonly tasks: HashSet<any>
+                readonly triggers: HashMap<number, any>
+                readonly triggeredTasks: HashSet<any>
+        }
+        interface MasterDeviceDeployment$Companion { serializer(): any }
+
+
         class StudyDeploymentStatus
         {
             static get Companion(): StudyDeploymentStatus$Companion
@@ -127,6 +159,29 @@ declare module 'carp.core-kotlin-carp.deployment.core'
 
     namespace dk.cachet.carp.deployment.domain.users
     {
+        class ActiveParticipationInvitation
+        {
+            constructor( participation: Participation, invitation: StudyInvitation, assignedDevices: HashSet<AssignedMasterDevice> )
+
+            static get Companion(): ActiveParticipationInvitation$Companion
+
+            readonly participation: Participation
+            readonly invitation: StudyInvitation
+            readonly assignedDevices: HashSet<AssignedMasterDevice>
+        }
+        interface ActiveParticipationInvitation$Companion { serializer(): any }
+
+        class AssignedMasterDevice
+        {
+            constructor( device: any, registration: DeviceRegistration | null )
+
+            static get Companion(): AssignedMasterDevice$Companion
+
+            readonly device: any
+            readonly registration: DeviceRegistration | null
+        }
+        interface AssignedMasterDevice$Companion { serializer(): any }
+
         class Participation
         {
             constructor( studyDeploymentId: UUID, id?: UUID )
@@ -138,6 +193,16 @@ declare module 'carp.core-kotlin-carp.deployment.core'
         }
         interface Participation$Companion { serializer(): any }
 
+        class ParticipantData
+        {
+            constructor( studyDeploymentId: UUID, data: HashMap<NamespacedId, any> )
+
+            static get Companion(): ParticipantData$Companion
+
+            readonly studyDeploymentId: UUID
+            readonly data: HashMap<NamespacedId, any>
+        }
+        interface ParticipantData$Companion { serializer(): any }
 
         class StudyInvitation
         {
@@ -154,5 +219,88 @@ declare module 'carp.core-kotlin-carp.deployment.core'
             serializer(): any;
             empty(): StudyInvitation;
         }
+    }
+
+
+    namespace dk.cachet.carp.deployment.infrastructure
+    {
+        import StudyInvitation = dk.cachet.carp.deployment.domain.users.StudyInvitation
+
+
+        abstract class DeploymentServiceRequest
+        {
+            static get Companion(): DeploymentServiceRequest$Companion
+        }
+        interface DeploymentServiceRequest$Companion { serializer(): any }
+
+        namespace DeploymentServiceRequest
+        {
+            class CreateStudyDeployment extends DeploymentServiceRequest
+            {
+                constructor( protocol: StudyProtocolSnapshot )
+            }
+            class GetStudyDeploymentStatus extends DeploymentServiceRequest
+            {
+                constructor( studyDeploymentId: UUID )
+            }
+            class GetStudyDeploymentStatusList extends DeploymentServiceRequest
+            {
+                constructor( studyDeploymentIds: HashSet<UUID> )
+            }
+            class RegisterDevice extends DeploymentServiceRequest
+            {
+                constructor( studyDeploymentId: UUID, deviceRoleName: string, registration: DeviceRegistration )
+            }
+            class UnregisterDevice extends DeploymentServiceRequest
+            {
+                constructor( studyDeploymentId: UUID, deviceRoleName: string )
+            }
+            class GetDeviceDeploymentFor extends DeploymentServiceRequest
+            {
+                constructor( studyDeploymentId: UUID, masterDeviceRoleName: string )
+            }
+            class DeploymentSuccessful extends DeploymentServiceRequest
+            {
+                constructor( studyDeploymentId: UUID, masterDeviceRoleName: string, deviceDeploymentLastUpdateDate: DateTime )
+            }
+            class Stop extends DeploymentServiceRequest
+            {
+                constructor( studyDeploymentId: UUID )
+            }
+        }
+
+
+        abstract class ParticipationServiceRequest
+        {
+            static get Companion(): ParticipationServiceRequest$Companion
+        }
+        interface ParticipationServiceRequest$Companion { serializer(): any }
+
+        namespace ParticipationServiceRequest
+        {
+            class AddParticipation extends ParticipationServiceRequest
+            {
+                constructor( studyDeploymentId: UUID, deviceRoleNames: HashSet<String>, identity: AccountIdentity, invitation: StudyInvitation )
+            }
+            class GetActiveParticipationInvitations extends ParticipationServiceRequest
+            {
+                constructor( accountId: UUID )
+            }
+            class GetParticipantData extends ParticipationServiceRequest
+            {
+                constructor( studyDeploymentId: UUID )
+            }
+            class GetParticipantDataList extends ParticipationServiceRequest
+            {
+                constructor( studyDeploymentIds: HashSet<UUID> )
+            }
+            class SetParticipantData extends ParticipationServiceRequest
+            {
+                constructor( studyDeploymentId: UUID, inputDataType: NamespacedId, data: any | null )
+            }
+        }
+
+        
+        function createDeploymentSerializer_18xi4u$(): Json
     }
 }

--- a/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
@@ -3,10 +3,13 @@ declare module 'carp.core-kotlin-carp.protocols.core'
     import { kotlin } from 'kotlin'
     import ArrayList = kotlin.collections.ArrayList
     import HashSet = kotlin.collections.HashSet
+    import HashMap = kotlin.collections.HashMap
+
     import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
     import Json = kotlinx.serialization.json.Json
     import { dk as cdk } from 'carp.core-kotlin-carp.common'
     import DateTime = cdk.cachet.carp.common.DateTime
+    import NamespacedId = cdk.cachet.carp.common.NamespacedId
     import UUID = cdk.cachet.carp.common.UUID
     import ParticipantAttribute = cdk.cachet.carp.common.users.ParticipantAttribute
 
@@ -62,6 +65,28 @@ declare module 'carp.core-kotlin-carp.protocols.core'
             readonly expectedParticipantData: ArrayList<ParticipantAttribute>
         }
         interface StudyProtocolSnapshot$Companion { serializer(): any }
+    }
+
+    namespace dk.cachet.carp.protocols.domain.devices
+    {
+        abstract class DeviceRegistration
+        {
+            static get Companion(): DeviceRegistration$Companion  
+            
+            readonly deviceId: string
+            readonly registrationCreationDate: DateTime
+        }
+        interface DeviceRegistration$Companion { serializer(): any }
+
+        class DefaultDeviceRegistration extends DeviceRegistration
+        {
+            constructor( deviceId: string )
+        }
+
+        class Smartphone
+        {
+            constructor( roleName: string, samplingConfiguration: HashMap<NamespacedId, any> )
+        }
     }
 
 

--- a/typescript-declarations/tests/carp.deployment.core.ts
+++ b/typescript-declarations/tests/carp.deployment.core.ts
@@ -3,18 +3,35 @@ import VerifyModule from './VerifyModule'
 import { kotlin } from 'kotlin'
 import ArrayList = kotlin.collections.ArrayList
 import toSet = kotlin.collections.toSet_us0mfu$
+import toMap = kotlin.collections.toMap_v2dak7$
 import { dk as dkc } from 'carp.core-kotlin-carp.common'
 import UUID = dkc.cachet.carp.common.UUID
+import { dk as dkp } from 'carp.core-kotlin-carp.protocols.core'
+import Smartphone = dkp.cachet.carp.protocols.domain.devices.Smartphone
+import DefaultDeviceRegistration = dkp.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
 import { dk } from 'carp.core-kotlin-carp.deployment.core'
+import ActiveParticipationInvitation = dk.cachet.carp.deployment.domain.users.ActiveParticipationInvitation
+import AssignedMasterDevice = dk.cachet.carp.deployment.domain.users.AssignedMasterDevice
+import ParticipantData = dk.cachet.carp.deployment.domain.users.ParticipantData
 import Participation = dk.cachet.carp.deployment.domain.users.Participation
 import StudyInvitation = dk.cachet.carp.deployment.domain.users.StudyInvitation
 import DeviceDeploymentStatus = dk.cachet.carp.deployment.domain.DeviceDeploymentStatus
+import MasterDeviceDeployment = dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import StudyDeploymentStatus = dk.cachet.carp.deployment.domain.StudyDeploymentStatus
+import DeploymentServiceRequest = dk.cachet.carp.deployment.infrastructure.DeploymentServiceRequest
+import ParticipationServiceRequest = dk.cachet.carp.deployment.infrastructure.ParticipationServiceRequest
 
 
 describe( "carp.deployment.core", () => {
     it( "verify module declarations", async () => {
+        const exampleDevice = new Smartphone( "test", toMap( [] ) )
         const instances = [
+            new ActiveParticipationInvitation( new Participation( UUID.Companion.randomUUID() ), StudyInvitation.Companion.empty(), toSet( [] ) ),
+            ActiveParticipationInvitation.Companion,
+            new AssignedMasterDevice( exampleDevice, null ),
+            AssignedMasterDevice.Companion,
+            new ParticipantData( UUID.Companion.randomUUID(), toMap( [] ) ),
+            ParticipantData.Companion,
             new Participation( UUID.Companion.randomUUID() ),
             Participation.Companion,
             StudyInvitation.Companion.empty(),
@@ -26,10 +43,17 @@ describe( "carp.deployment.core", () => {
             new DeviceDeploymentStatus.NeedsRedeployment( null, toSet( [] ), toSet( [] ) ),
             [ "NotDeployed", new DeviceDeploymentStatus.Unregistered( null, true, toSet( [] ), toSet( [] ) ) ],
             StudyDeploymentStatus.Companion,
+            new MasterDeviceDeployment(
+                exampleDevice,
+                new DefaultDeviceRegistration( "some role" ),
+                toSet( [] ), toMap( [] ), toSet( [] ), toMap( [] ), toSet( [] ) ),
+            MasterDeviceDeployment.Companion,
             new StudyDeploymentStatus.Invited( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ), null ),
             new StudyDeploymentStatus.DeployingDevices( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ), null ),
             new StudyDeploymentStatus.DeploymentReady( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ), null ),
-            new StudyDeploymentStatus.Stopped( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ), null )
+            new StudyDeploymentStatus.Stopped( UUID.Companion.randomUUID(), new ArrayList<DeviceDeploymentStatus>( [] ), null ),
+            DeploymentServiceRequest.Companion,
+            ParticipationServiceRequest.Companion
         ]
 
         const moduleVerifier = new VerifyModule( 'carp.core-kotlin-carp.deployment.core', instances )

--- a/typescript-declarations/tests/carp.protocols.core.ts
+++ b/typescript-declarations/tests/carp.protocols.core.ts
@@ -6,6 +6,8 @@ import Json = kotlinx.serialization.json.Json
 import { dk as dkc } from 'carp.core-kotlin-carp.common'
 import UUID = dkc.cachet.carp.common.UUID
 import { dk } from 'carp.core-kotlin-carp.protocols.core'
+import DeviceRegistration = dk.cachet.carp.protocols.domain.devices.DeviceRegistration
+import DefaultDeviceRegistration = dk.cachet.carp.protocols.domain.devices.DefaultDeviceRegistration
 import ProtocolId = dk.cachet.carp.protocols.domain.StudyProtocol.Id
 import ProtocolOwner = dk.cachet.carp.protocols.domain.ProtocolOwner
 import ProtocolVersion = dk.cachet.carp.protocols.domain.ProtocolVersion
@@ -29,6 +31,8 @@ describe( "carp.protocols.core", () => {
             [ "Id$Companion", ProtocolId.Companion ],
             studyProtocolSnapshot,
             StudyProtocolSnapshot.Companion,
+            [ "DeviceRegistration", new DefaultDeviceRegistration( "some device id" ) ],
+            DeviceRegistration.Companion,
             new ProtocolVersion( "Version" ),
             ProtocolVersion.Companion,
             ProtocolServiceRequest.Companion,


### PR DESCRIPTION
This includes all TS declarations needed to initialize `DeploymentService` and `ParticipationService` requests, serialize them, and deserialize the responses of those requests.

Look at the `carp.core` codebase to see which types are returned by which requests. You can find TS declarations in the corresponding namespaces. To serialize/deserialize, look at the examples of the other requests. But, now use the `createDeploymentSerializer`. When you need a `Map` or `Set` of the objects to be serialized, use the List/Map/Set serializer constructor (see [example in existing unit tests](https://github.com/cph-cachet/carp.core-kotlin/blob/develop/typescript-declarations/tests/carp.studies.core.ts#L130)).

I did use `any` here and there in type declarations where I did not think you would need to access the elements within it. `any` means you can still access them dynamically just like you would in Javascript. If we ever need type safety for those, I can add more type declarations. But, this should get you going!

Note that these are the declarations for the current `develop` branch, which is not backwards compatible with alpha 28. Next, I will create a hotfix for alpha 28 and modify these declarations where needed (not too much discrepancy).