### PR TITLE
Removing studies propagates to removal of data in deployment subsystem

### DIFF
--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentService.kt
@@ -25,6 +25,8 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
         @Serializable
         data class StudyDeploymentCreated( val deployment: StudyDeploymentSnapshot ) : Event()
         @Serializable
+        data class StudyDeploymentsRemoved( val deploymentIds: Set<UUID> ) : Event()
+        @Serializable
         data class StudyDeploymentStopped( val studyDeploymentId: UUID ) : Event()
         @Serializable
         data class DeviceRegistrationChanged(
@@ -42,6 +44,14 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
      * @return The [StudyDeploymentStatus] of the newly created study deployment.
      */
     suspend fun createStudyDeployment( protocol: StudyProtocolSnapshot ): StudyDeploymentStatus
+
+    /**
+     * Remove study deployments with the given [studyDeploymentIds].
+     * This also removes all data related to the study deployments managed by [ParticipationService].
+     *
+     * @return The IDs of study deployments which were removed. IDs for which no study deployment exists are ignored.
+     */
+    suspend fun removeStudyDeployments( studyDeploymentIds: Set<UUID> ): Set<UUID>
 
     /**
      * Get the status for a study deployment with the given [studyDeploymentId].

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceHost.kt
@@ -41,6 +41,19 @@ class DeploymentServiceHost(
     }
 
     /**
+     * Remove study deployments with the given [studyDeploymentIds].
+     * This also removes all data related to the study deployments managed by [ParticipationService].
+     *
+     * @return The IDs of study deployments which were removed. IDs for which no study deployment exists are ignored.
+     */
+    override suspend fun removeStudyDeployments( studyDeploymentIds: Set<UUID> ): Set<UUID>
+    {
+        val removedIds = repository.remove( studyDeploymentIds )
+        eventBus.publish( DeploymentService.Event.StudyDeploymentsRemoved( studyDeploymentIds ) )
+        return removedIds
+    }
+
+    /**
      * Get the status for a study deployment with the given [studyDeploymentId].
      *
      * @param studyDeploymentId The id of the [StudyDeployment] to return [StudyDeploymentStatus] for.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHost.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/application/ParticipationServiceHost.kt
@@ -35,10 +35,13 @@ class ParticipationServiceHost(
 {
     init
     {
-        // Create a ParticipantGroup per study deployment.
+        // Create a ParticipantGroup per study deployment (as long as it exists).
         eventBus.subscribe { created: DeploymentService.Event.StudyDeploymentCreated ->
             val group = ParticipantGroup.fromDeployment( created.deployment.toObject() )
             participationRepository.putParticipantGroup( group )
+        }
+        eventBus.subscribe { removed: DeploymentService.Event.StudyDeploymentsRemoved ->
+            participationRepository.removeParticipantGroups( removed.deploymentIds )
         }
 
         // Notify participant group that associated study deployment has stopped.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepository.kt
@@ -51,4 +51,11 @@ interface DeploymentRepository
      * @throws IllegalArgumentException when no previous version of this study deployment is stored in the repository.
      */
     suspend fun update( studyDeployment: StudyDeployment )
+
+    /**
+     * Remove the [StudyDeployment]s with the specified [studyDeploymentIds].
+     *
+     * @return The IDs of study deployments which were removed. IDs for which no study deployment exists are ignored.
+     */
+    suspend fun remove( studyDeploymentIds: Set<UUID> ): Set<UUID>
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepository.kt
@@ -49,4 +49,11 @@ interface ParticipationRepository
      * @return the previous [ParticipantGroup] stored in the repository, or null if it was not present before.
      */
     suspend fun putParticipantGroup( group: ParticipantGroup ): ParticipantGroup?
+
+    /**
+     * Remove the [ParticipantGroup]s matching the specified [studyDeploymentIds].
+     *
+     * @return The IDs of study deployments for which participant groups were removed. IDs for which no participant group exists are ignored.
+     */
+    suspend fun removeParticipantGroups( studyDeploymentIds: Set<UUID> ): Set<UUID>
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -28,6 +28,11 @@ sealed class DeploymentServiceRequest
         Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::createStudyDeployment, protocol )
 
     @Serializable
+    data class RemoveStudyDeployments( val studyDeploymentIds: Set<UUID> ) :
+        DeploymentServiceRequest(),
+        Invoker<Set<UUID>> by createServiceInvoker( Service::removeStudyDeployments, studyDeploymentIds )
+
+    @Serializable
     data class GetStudyDeploymentStatus( val studyDeploymentId: UUID ) :
         DeploymentServiceRequest(),
         Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::getStudyDeploymentStatus, studyDeploymentId )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryDeploymentRepository.kt
@@ -21,7 +21,8 @@ class InMemoryDeploymentRepository : DeploymentRepository
      */
     override suspend fun add( studyDeployment: StudyDeployment )
     {
-        require( !studyDeployments.contains( studyDeployment.id ) ) { "The repository already contains a study deployment with ID '${studyDeployment.id}'." }
+        require( !studyDeployments.contains( studyDeployment.id ) )
+            { "The repository already contains a study deployment with ID '${studyDeployment.id}'." }
 
         studyDeployments[ studyDeployment.id ] = studyDeployment.getSnapshot()
     }
@@ -44,8 +45,20 @@ class InMemoryDeploymentRepository : DeploymentRepository
      */
     override suspend fun update( studyDeployment: StudyDeployment )
     {
-        require( studyDeployments.contains( studyDeployment.id ) ) { "The repository does not contain an existing study deployment with ID '${studyDeployment.id}'." }
+        require( studyDeployments.contains( studyDeployment.id ) )
+            { "The repository does not contain an existing study deployment with ID '${studyDeployment.id}'." }
 
         studyDeployments[ studyDeployment.id ] = studyDeployment.getSnapshot()
     }
+
+    /**
+     * Remove the [StudyDeployment]s with the specified [studyDeploymentIds].
+     *
+     * @return The IDs of study deployments which were removed. IDs for which no study deployment exists are ignored.
+     */
+    override suspend fun remove( studyDeploymentIds: Set<UUID> ): Set<UUID> =
+        studyDeploymentIds
+            .mapNotNull { studyDeployments.remove( it ) }
+            .map { it.studyDeploymentId }
+            .toSet()
 }

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryParticipationRepository.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/InMemoryParticipationRepository.kt
@@ -47,4 +47,15 @@ class InMemoryParticipationRepository : ParticipationRepository
         participantGroups
             .put( group.studyDeploymentId, group.getSnapshot() )
             ?.let { ParticipantGroup.fromSnapshot( it ) }
+
+    /**
+     * Remove the [ParticipantGroup]s matching the specified [studyDeploymentIds].
+     *
+     * @return The IDs of study deployments for which participant groups were removed. IDs for which no participant group exists are ignored.
+     */
+    override suspend fun removeParticipantGroups( studyDeploymentIds: Set<UUID> ): Set<UUID> =
+        studyDeploymentIds
+            .mapNotNull { participantGroups.remove( it ) }
+            .map { it.studyDeploymentId }
+            .toSet()
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceMock.kt
@@ -15,6 +15,7 @@ private typealias Service = DeploymentService
 
 class DeploymentServiceMock(
     private val createStudyDeploymentResult: StudyDeploymentStatus = emptyStatus,
+    private val removeStudyDeploymentsResult: Set<UUID> = emptySet(),
     private val getStudyDeploymentStatusResult: StudyDeploymentStatus = emptyStatus,
     private val getStudyDeploymentStatusListResult: List<StudyDeploymentStatus> = emptyList(),
     private val registerDeviceResult: StudyDeploymentStatus = emptyStatus,
@@ -39,6 +40,10 @@ class DeploymentServiceMock(
     override suspend fun createStudyDeployment( protocol: StudyProtocolSnapshot ) =
         createStudyDeploymentResult
         .also { trackSuspendCall( Service::createStudyDeployment, protocol ) }
+
+    override suspend fun removeStudyDeployments( studyDeploymentIds: Set<UUID> ) =
+        removeStudyDeploymentsResult
+        .also { trackSuspendCall( Service::removeStudyDeployments, studyDeploymentIds ) }
 
     override suspend fun getStudyDeploymentStatus( studyDeploymentId: UUID ) =
         getStudyDeploymentStatusResult

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/DeploymentServiceTest.kt
@@ -22,6 +22,30 @@ abstract class DeploymentServiceTest
 
 
     @Test
+    fun removeStudyDeployments_succeeds() = runSuspendTest {
+        val deploymentService = createService()
+        val deploymentId1 = addTestDeployment( deploymentService, "Test device" )
+        val deploymentId2 = addTestDeployment( deploymentService, "Test device" )
+        val deploymentIds = setOf( deploymentId1, deploymentId2 )
+
+        val removedIds = deploymentService.removeStudyDeployments( deploymentIds )
+        assertEquals( deploymentIds, removedIds )
+        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatus( deploymentId1 ) }
+        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatus( deploymentId2 ) }
+    }
+
+    @Test
+    fun removeStudyDeployments_ignores_unknown_ids() = runSuspendTest {
+        val deploymentService = createService()
+        val deploymentId = addTestDeployment( deploymentService, "Test device" )
+        val unknownId = UUID.randomUUID()
+        val deploymentIds = setOf( deploymentId, unknownId )
+
+        val removedIds = deploymentService.removeStudyDeployments( deploymentIds )
+        assertEquals( setOf( deploymentId ), removedIds )
+    }
+
+    @Test
     fun getStudyDeploymentStatus_succeeds() = runSuspendTest {
         val deploymentService = createService()
         val studyDeploymentId = addTestDeployment( deploymentService, "Test device" )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
@@ -61,6 +61,25 @@ class HostsIntegrationTest
     }
 
     @Test
+    fun removing_deployment_removes_participant_group() = runSuspendTest {
+        var deploymentsRemoved: DeploymentService.Event.StudyDeploymentsRemoved? = null
+        eventBus.subscribe( DeploymentService::class, DeploymentService.Event.StudyDeploymentsRemoved::class )
+        {
+            deploymentsRemoved = it
+        }
+
+        val protocol = createComplexProtocol().getSnapshot()
+        val deployment = deploymentService.createStudyDeployment( protocol )
+
+        deploymentService.removeStudyDeployments( setOf( deployment.studyDeploymentId ) )
+        assertEquals( setOf( deployment.studyDeploymentId ), deploymentsRemoved?.deploymentIds )
+        assertFailsWith<IllegalArgumentException>
+        {
+            participationService.getParticipantData( deployment.studyDeploymentId )
+        }
+    }
+
+    @Test
     fun stopping_deployment_stops_participant_group() = runSuspendTest {
         var studyDeploymentStopped: DeploymentService.Event.StudyDeploymentStopped? = null
         eventBus.subscribe( DeploymentService::class, DeploymentService.Event.StudyDeploymentStopped::class )

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/DeploymentRepositoryTest.kt
@@ -132,4 +132,35 @@ interface DeploymentRepositoryTest
             repo.update( deployment )
         }
     }
+
+    @Test
+    fun remove_succeeds() = runSuspendTest {
+        val repo = createRepository()
+        val protocol = createSingleMasterWithConnectedDeviceProtocol()
+        val deployment1 = studyDeploymentFor( protocol )
+        val deployment2 = studyDeploymentFor( protocol )
+        repo.add( deployment1 )
+        repo.add( deployment2 )
+
+        val deploymentIds = setOf( deployment1.id, deployment2.id )
+        val removed = repo.remove( deploymentIds )
+        assertEquals( deploymentIds, removed )
+        val retrievedDeployment1 = repo.getStudyDeploymentBy( deployment1.id )
+        val retrievedDeployment2 = repo.getStudyDeploymentBy( deployment2.id )
+        assertNull( retrievedDeployment1 )
+        assertNull( retrievedDeployment2 )
+    }
+
+    @Test
+    fun remove_igores_unknown_ids() = runSuspendTest {
+        val repo = createRepository()
+        val protocol = createSingleMasterWithConnectedDeviceProtocol()
+        val deployment = studyDeploymentFor( protocol )
+        repo.add( deployment )
+
+        val unknownId = UUID.randomUUID()
+        val deploymentIds = setOf( deployment.id, unknownId )
+        val removed = repo.remove( deploymentIds )
+        assertEquals( setOf( deployment.id ), removed )
+    }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepositoryTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/domain/users/ParticipationRepositoryTest.kt
@@ -118,4 +118,30 @@ interface ParticipationRepositoryTest
         assertNotNull( previous )
         assertEquals( group.creationDate, previous.creationDate )
     }
+
+    @Test
+    fun removeParticipantGroups_succeeds() = runSuspendTest {
+        val repo = createRepository()
+        val group1 = createComplexParticipantGroup()
+        val group2 = createComplexParticipantGroup()
+        repo.putParticipantGroup( group1 )
+        repo.putParticipantGroup( group2 )
+
+        val groupIds = setOf( group1.studyDeploymentId, group2.studyDeploymentId )
+        val removedIds = repo.removeParticipantGroups( groupIds )
+        assertEquals( groupIds, removedIds )
+        assertNull( repo.getParticipantGroup( group1.studyDeploymentId ) )
+        assertNull( repo.getParticipantGroup( group2.studyDeploymentId ) )
+    }
+
+    @Test
+    fun removeParticipantGroups_ignores_unknown_ids() = runSuspendTest {
+        val repo = createRepository()
+        val group = createComplexParticipantGroup()
+        repo.putParticipantGroup( group )
+
+        val deploymentIds = setOf( group.studyDeploymentId, unknownId )
+        val removed = repo.removeParticipantGroups( deploymentIds )
+        assertEquals( setOf( group.studyDeploymentId ), removed )
+    }
 }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequestsTest.kt
@@ -20,6 +20,7 @@ class DeploymentServiceRequestsTest
     {
         val requests: List<DeploymentServiceRequest> = listOf(
             DeploymentServiceRequest.CreateStudyDeployment( createEmptyProtocol().getSnapshot() ),
+            DeploymentServiceRequest.RemoveStudyDeployments( emptySet() ),
             DeploymentServiceRequest.GetStudyDeploymentStatus( UUID.randomUUID() ),
             DeploymentServiceRequest.GetStudyDeploymentStatusList( setOf( UUID.randomUUID() ) ),
             DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration( "Device ID" ) ),

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/ParticipantServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/ParticipantServiceHost.kt
@@ -45,6 +45,12 @@ class ParticipantServiceHost(
 
         // Propagate removal of all data related to a study.
         eventBus.subscribe { removed: StudyService.Event.StudyRemoved ->
+            // Remove deployments in the deployment subsystem.
+            val recruitment = participantRepository.getRecruitment( removed.studyId )
+            checkNotNull( recruitment )
+            val idsToRemove = recruitment.participations.keys
+            deploymentService.removeStudyDeployments( idsToRemove )
+
             participantRepository.removeStudy( removed.studyId )
         }
     }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -108,7 +108,7 @@ interface StudyService : ApplicationService<StudyService, StudyService.Event>
     suspend fun goLive( studyId: UUID ): StudyStatus
 
     /**
-     * Remove the study with the specified [studyId].
+     * Remove the study with the specified [studyId] and all related data.
      *
      * @return True when the study has been deleted, or false when there is no study to delete.
      */

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
@@ -162,7 +162,7 @@ class StudyServiceHost(
     }
 
     /**
-     * Remove the study with the specified [studyId].
+     * Remove the study with the specified [studyId] and all related data.
      *
      * @return True when the study has been deleted, or false when there is no study to delete.
      */

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,6 +1,8 @@
 complexity:
   LongParameterList:
     excludes: ['**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/test/**']
+  TooManyFunctions:
+    ignorePrivate: true
 
 formatting:
   Filename:

--- a/docs/carp-deployment.md
+++ b/docs/carp-deployment.md
@@ -36,6 +36,7 @@ Allows deploying study protocols and retrieving master device deployments for pa
 | Endpoint | Description | Require | Grant |
 | --- | --- | --- | --- |
 | `createStudyDeployment` | Instantiate a study deployment for a given protocol. | | manage deployment: `studyDeploymentId`, in deployment: `studyDeploymentId` |
+| `removeStudyDeployments` | Remove study deployments and all related data to it. | manage deployment: `studyDeploymentId`| |
 | `getStudyDeploymentStatus` | Get the status for a study deployment. | in deployment: `studyDeploymentId` | |
 | `getStudyDeploymentStatusList` | Get the statuses for a set of deployments. | in deployment: (all) `studyDeploymentIds` | |
 | `registerDevice` | Register a device for a study deployment. | in deployment: `studyDeploymentId` | |

--- a/docs/carp-studies.md
+++ b/docs/carp-studies.md
@@ -23,6 +23,7 @@ Allows creating and managing studies.
 | `setInvitation` | Specify an invitation, shared with participants once they are invited to a study. | manage study: `studyId` | |
 | `setProtocol` | Specify the study protocol to use for a study. | manage study: `studyId` | |
 | `goLive` | Lock in the current study protocol so that a study may be deployed to participants. | manage study: `studyId` | |
+| `remove` | Remove a study and all related data. | manage study: `studyId` | |
 
 ### [`ParticipantService`](../carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/ParticipantService.kt)
 


### PR DESCRIPTION
Fairly trivial now with all the plumbing of last PR is in place.

The individual commits speak for themselves what this PR entails.