### PR TITLE
Register `UnknownPolymorphicSerializer`s as `default` in `SerializersModule`.

### DIFF
--- a/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntimeSnapshot.kt
+++ b/carp.client.core/src/commonMain/kotlin/dk/cachet/carp/client/domain/StudyRuntimeSnapshot.kt
@@ -6,7 +6,6 @@ import dk.cachet.carp.common.ddd.Snapshot
 import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
-import dk.cachet.carp.protocols.domain.devices.DeviceDescriptorSerializer
 import kotlinx.serialization.Serializable
 
 
@@ -14,7 +13,6 @@ import kotlinx.serialization.Serializable
 data class StudyRuntimeSnapshot(
     val studyDeploymentId: UUID,
     override val creationDate: DateTime,
-    @Serializable( DeviceDescriptorSerializer::class )
     val device: AnyMasterDeviceDescriptor,
     val isDeployed: Boolean,
     val deploymentInformation: MasterDeviceDeployment?,

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/reflect/AccessInternals.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/reflect/AccessInternals.kt
@@ -1,0 +1,14 @@
+package dk.cachet.carp.common.reflect
+
+
+/**
+ * Provide access to runtime internals which cannot be accessed at compile time.
+ */
+internal expect object AccessInternals
+{
+    /**
+     * Set the value of the field with the given [fieldName] on a given object ([onObject]) to [value].
+     */
+    @Suppress( "UnusedPrivateMember" ) // TODO: Remove once detekt bug is fixed: https://github.com/detekt/detekt/issues/3415
+    fun setField( onObject: Any, fieldName: String, value: Any )
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/UnknownPolymorphicSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/serialization/UnknownPolymorphicSerializer.kt
@@ -1,16 +1,22 @@
 package dk.cachet.carp.common.serialization
 
 import dk.cachet.carp.common.reflect.reflectIfAvailable
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.reflect.KClass
@@ -25,6 +31,7 @@ import kotlin.reflect.KClass
  *  In case it is impossible for a base return type to implement this interface you can disable the runtime verification by setting this to false.
  *  However, ensure that all deriving classes of this base type implement [UnknownPolymorphicWrapper], otherwise serialization will not output the original JSON found upon deserializing.
  */
+@OptIn( ExperimentalSerializationApi::class )
 abstract class UnknownPolymorphicSerializer<P : Any, W : P>(
     baseClass: KClass<P>,
     wrapperClass: KClass<W>,
@@ -33,11 +40,10 @@ abstract class UnknownPolymorphicSerializer<P : Any, W : P>(
 {
     companion object
     {
-        private fun unsupportedException( cause: Throwable? = null ) =
+        private val unsupportedException =
             SerializationException(
-                "${UnknownPolymorphicSerializer::class.simpleName} only supports JSON serialization" +
-                " with a class discriminator configured (no array polymorphism) when serializing unknown types.",
-                cause
+                "${UnknownPolymorphicSerializer::class.simpleName} only supports JSON serialization, " +
+                "configured to use a class discriminator for polymorphism."
             )
     }
 
@@ -56,74 +62,66 @@ abstract class UnknownPolymorphicSerializer<P : Any, W : P>(
         }
     }
 
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor(
+        "dk.cachet.carp.common.serialization.UnknownPolymorphicSerializer<${baseClass.simpleName}>"
+    )
 
-    private val polymorphicSerializer: PolymorphicSerializer<P> = PolymorphicSerializer( baseClass )
-    override val descriptor: SerialDescriptor = polymorphicSerializer.descriptor
 
+    @InternalSerializationApi
     override fun serialize( encoder: Encoder, value: P )
     {
-        // An encoder-agnostic fallback allows serialization only if the type is known.
+        // This serializer assumes JSON serialization with class discriminator configured for polymorphism.
+        // TODO: It should also be possible to support array polymorphism, but that is not a priority now.
         if ( encoder !is JsonEncoder )
         {
-            try
-            {
-                encoder.encodeSerializableValue( polymorphicSerializer, value )
-                return
-            }
-            catch ( ex: SerializationException )
-            {
-                // Serialization likely failed because the type is not registered for polymorphic serialization.
-                throw unsupportedException( ex )
-            }
+            throw unsupportedException
         }
+        val classDiscriminator = getClassDiscriminator( encoder.json )
 
-        // For JSON with class discriminators, we can verify whether the type is known and handle unknown types.
-        // TODO: It should also be possible to support array polymorphism, but that is not a priority now.
-        getClassDiscriminator( encoder.json ) // Throws on incorrect Json configuration.
-        if ( value is UnknownPolymorphicWrapper )
+        // Get the unknown JSON object.
+        check( value is UnknownPolymorphicWrapper )
+        val unknown = Json.parseToJsonElement( value.jsonSource ) as JsonObject
+
+        // Output all elements in the JSON object.
+        // HACK: This abuses kotlinx.serialization internals and only works when this serializer is used during polymorphic serialization.
+        //  The `serialName` of `mapDescriptor` is used as the class discriminator when calling `beginStructure`.
+        //  Therefore, wrappers can't be serialized as top-level objects (the first object to be serialized).
+        val mapDescriptor = buildSerialDescriptor( value.className, StructureKind.MAP )
         {
-            // Output raw JSON as originally wrapped for unknown types.
-            val jsonElement = Json.parseToJsonElement( value.jsonSource )
-            encoder.encodeJsonElement( jsonElement )
+            element( "key", String.serializer().descriptor )
+            element( "value", JsonElement.serializer().descriptor )
         }
-        else
+        val mapEncoder = encoder.beginStructure( mapDescriptor )
+        var index = 0
+        for ( (key, value) in unknown.filter { it.key != classDiscriminator } )
         {
-            // Normal polymorphic serialization for known types.
-            encoder.encodeSerializableValue( polymorphicSerializer, value )
+            mapEncoder.encodeSerializableElement( mapDescriptor, index++, String.serializer(), key )
+            mapEncoder.encodeSerializableElement( mapDescriptor, index++, JsonElement.serializer(), value )
         }
+        mapEncoder.endStructure( mapDescriptor )
     }
 
     @InternalSerializationApi
     override fun deserialize( decoder: Decoder ): P
     {
-        // An encoder-agnostic fallback allows deserialization only if the type is known.
+        // This serializer assumes JSON serialization with class discriminator configured for polymorphism.
+        // TODO: It should also be possible to support array polymorphism, but that is not a priority now.
         if ( decoder !is JsonDecoder )
         {
-            try
-            {
-                return decoder.decodeSerializableValue( polymorphicSerializer )
-            }
-            catch ( ex: SerializationException )
-            {
-                // Deserialization likely failed because the type is not registered for polymorphic serialization.
-                throw unsupportedException( ex )
-            }
+            throw unsupportedException
         }
-
-        // For JSON with class discriminators, we can verify whether the type is known and handle unknown types.
-        // TODO: It should also be possible to support array polymorphism, but that is not a priority now.
         val classDiscriminator = getClassDiscriminator( decoder.json )
 
-        // Determine class to be loaded and whether it is available at runtime.
+        // Get raw JSON for the unknown type.
         val jsonElement = decoder.decodeJsonElement()
-        val className = jsonElement.jsonObject[ classDiscriminator ]!!.jsonPrimitive.content
-        val registeredSerializer = polymorphicSerializer.findPolymorphicSerializerOrNull( decoder, className )
-        val canLoadClass = registeredSerializer != null
-
-        // Deserialize object when serializer is available, or wrap in case type is unknown.
         val jsonSource = jsonElement.toString()
-        return if ( canLoadClass ) decoder.json.decodeFromString( polymorphicSerializer, jsonSource )
-        else createWrapper( className, jsonSource, decoder.json )
+
+        // TODO: `className` is already inferred by kotlinx.serialization at this point,
+        //  which is why this serializer, which should be registered as `default`, is triggered.
+        //  We might be able to intercept the className there (in the `default` lambda), rather than parsing it here.
+        val className = jsonElement.jsonObject[ classDiscriminator ]!!.jsonPrimitive.content
+
+        return createWrapper( className, jsonSource, decoder.json )
     }
 
     // HACK: Since `Json.configuration` is internal, this is a workaround to find the configured class discriminator.
@@ -133,7 +131,7 @@ abstract class UnknownPolymorphicSerializer<P : Any, W : P>(
         var extractedDiscriminator: String? = null
         Json( json )
         {
-            if ( useArrayPolymorphism ) throw unsupportedException()
+            if ( useArrayPolymorphism ) throw unsupportedException
             extractedDiscriminator = classDiscriminator
         }
         return extractedDiscriminator!!

--- a/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/reflect/AccessInternals.kt
+++ b/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/reflect/AccessInternals.kt
@@ -1,0 +1,16 @@
+package dk.cachet.carp.common.reflect
+
+
+internal actual object AccessInternals
+{
+    actual fun setField( onObject: Any, fieldName: String, value: Any )
+    {
+        // Find the corresponding field name for the JavaScript runtime, which often attaches mangled suffixes.
+        val fields = js( "Object.keys( onObject )" ) as Array<String>
+        val mangledField = fields.singleOrNull { it.startsWith( fieldName ) }
+        checkNotNull( mangledField ) { "Could not find a matching field for \"$fieldName\" on the JavaScript runtime." }
+
+        val toModify = onObject.asDynamic()
+        toModify[ mangledField ] = value
+    }
+}

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/reflect/AccessInternals.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/reflect/AccessInternals.kt
@@ -1,0 +1,15 @@
+package dk.cachet.carp.common.reflect
+
+
+internal actual object AccessInternals
+{
+    actual fun setField( onObject: Any, fieldName: String, value: Any )
+    {
+        // Get field.
+        val klass = onObject::class.java
+        val field = klass.getDeclaredField( fieldName )
+        field.isAccessible = true
+
+        field.set( onObject, value )
+    }
+}

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/DeviceDeploymentStatus.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.deployment.domain
 
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
-import dk.cachet.carp.protocols.domain.devices.DeviceDescriptorSerializer
 import kotlinx.serialization.Serializable
 
 
@@ -14,7 +13,6 @@ sealed class DeviceDeploymentStatus
     /**
      * The description of the device.
      */
-    @Serializable( DeviceDescriptorSerializer::class )
     abstract val device: AnyDeviceDescriptor
 
     /**
@@ -62,7 +60,6 @@ sealed class DeviceDeploymentStatus
      */
     @Serializable
     data class Unregistered(
-        @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor,
         override val requiresDeployment: Boolean,
         override val remainingDevicesToRegisterToObtainDeployment: Set<String>,
@@ -74,7 +71,6 @@ sealed class DeviceDeploymentStatus
      */
     @Serializable
     data class Registered(
-        @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor,
         override val requiresDeployment: Boolean,
         override val remainingDevicesToRegisterToObtainDeployment: Set<String>,
@@ -86,7 +82,6 @@ sealed class DeviceDeploymentStatus
      */
     @Serializable
     data class Deployed(
-        @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor
     ) : DeviceDeploymentStatus()
     {
@@ -99,7 +94,6 @@ sealed class DeviceDeploymentStatus
      */
     @Serializable
     data class NeedsRedeployment(
-        @Serializable( DeviceDescriptorSerializer::class )
         override val device: AnyDeviceDescriptor,
         override val remainingDevicesToRegisterToObtainDeployment: Set<String>,
         override val remainingDevicesToRegisterBeforeDeployment: Set<String>

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/MasterDeviceDeployment.kt
@@ -3,13 +3,9 @@ package dk.cachet.carp.deployment.domain
 import dk.cachet.carp.common.DateTime
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
-import dk.cachet.carp.protocols.domain.devices.DeviceDescriptorSerializer
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
-import dk.cachet.carp.protocols.domain.devices.DeviceRegistrationSerializer
 import dk.cachet.carp.protocols.domain.tasks.TaskDescriptor
-import dk.cachet.carp.protocols.domain.tasks.TaskDescriptorSerializer
 import dk.cachet.carp.protocols.domain.triggers.Trigger
-import dk.cachet.carp.protocols.domain.triggers.TriggerSerializer
 import kotlinx.serialization.Serializable
 
 
@@ -25,24 +21,23 @@ data class MasterDeviceDeployment(
     /**
      * Configuration for this master device.
      */
-    @Serializable( DeviceRegistrationSerializer::class )
     val configuration: DeviceRegistration,
     /**
      * The devices this device needs to connect to.
      */
-    val connectedDevices: Set<@Serializable( DeviceDescriptorSerializer::class ) AnyDeviceDescriptor>,
+    val connectedDevices: Set<AnyDeviceDescriptor>,
     /**
      * Preregistration of connected devices, including configuration such as connection properties, stored per role name.
      */
-    val connectedDeviceConfigurations: Map<String, @Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>,
+    val connectedDeviceConfigurations: Map<String, DeviceRegistration>,
     /**
      * All tasks which should be able to be executed on this or connected devices.
      */
-    val tasks: Set<@Serializable( TaskDescriptorSerializer::class ) TaskDescriptor>,
+    val tasks: Set<TaskDescriptor>,
     /**
      * All triggers originating from this device and connected devices, stored per assigned id unique within the study protocol.
      */
-    val triggers: Map<Int, @Serializable( TriggerSerializer::class ) Trigger>,
+    val triggers: Map<Int, Trigger>,
     /**
      * The specification of tasks triggered and the devices they are sent to.
      */

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/RegistrableDevice.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/RegistrableDevice.kt
@@ -1,7 +1,6 @@
 package dk.cachet.carp.deployment.domain
 
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
-import dk.cachet.carp.protocols.domain.devices.DeviceDescriptorSerializer
 import kotlinx.serialization.Serializable
 
 
@@ -13,7 +12,6 @@ data class RegistrableDevice(
     /**
      * The description of the device.
      */
-    @Serializable( DeviceDescriptorSerializer::class )
     val device: AnyDeviceDescriptor,
     /**
      * Determines whether this device requires deployment after it has been registered.

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeploymentSnapshot.kt
@@ -5,7 +5,6 @@ import dk.cachet.carp.common.UUID
 import dk.cachet.carp.common.ddd.Snapshot
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
-import dk.cachet.carp.protocols.domain.devices.DeviceRegistrationSerializer
 import kotlinx.serialization.Serializable
 
 
@@ -18,7 +17,7 @@ data class StudyDeploymentSnapshot(
     override val creationDate: DateTime,
     val studyProtocolSnapshot: StudyProtocolSnapshot,
     val registeredDevices: Set<String>,
-    val deviceRegistrationHistory: Map<String, List<@Serializable( DeviceRegistrationSerializer::class ) DeviceRegistration>>,
+    val deviceRegistrationHistory: Map<String, List<DeviceRegistration>>,
     val deployedDevices: Set<String>,
     val invalidatedDeployedDevices: Set<String>,
     val startTime: DateTime?,

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/AssignedMasterDevice.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/users/AssignedMasterDevice.kt
@@ -2,8 +2,6 @@ package dk.cachet.carp.deployment.domain.users
 
 import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
-import dk.cachet.carp.protocols.domain.devices.DeviceRegistrationSerializer
-import dk.cachet.carp.protocols.domain.devices.MasterDeviceDescriptorSerializer
 import kotlinx.serialization.Serializable
 
 
@@ -11,9 +9,4 @@ import kotlinx.serialization.Serializable
  * Master [device] and its current [registration] assigned to participants as part of a [ParticipantGroup].
  */
 @Serializable
-data class AssignedMasterDevice(
-    @Serializable( MasterDeviceDescriptorSerializer::class )
-    val device: AnyMasterDeviceDescriptor,
-    @Serializable( DeviceRegistrationSerializer::class )
-    val registration: DeviceRegistration?
-)
+data class AssignedMasterDevice( val device: AnyMasterDeviceDescriptor, val registration: DeviceRegistration? )

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/infrastructure/DeploymentServiceRequest.kt
@@ -9,7 +9,6 @@ import dk.cachet.carp.deployment.domain.MasterDeviceDeployment
 import dk.cachet.carp.deployment.domain.StudyDeploymentStatus
 import dk.cachet.carp.protocols.domain.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.devices.DeviceRegistration
-import dk.cachet.carp.protocols.domain.devices.DeviceRegistrationSerializer
 import kotlinx.serialization.Serializable
 
 private typealias Service = DeploymentService
@@ -46,7 +45,6 @@ sealed class DeploymentServiceRequest
     data class RegisterDevice(
         val studyDeploymentId: UUID,
         val deviceRoleName: String,
-        @Serializable( DeviceRegistrationSerializer::class )
         val registration: DeviceRegistration
     ) : DeploymentServiceRequest(),
         Invoker<StudyDeploymentStatus> by createServiceInvoker( Service::registerDevice, studyDeploymentId, deviceRoleName, registration )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolSnapshot.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolSnapshot.kt
@@ -6,12 +6,8 @@ import dk.cachet.carp.common.ddd.Snapshot
 import dk.cachet.carp.common.users.ParticipantAttribute
 import dk.cachet.carp.protocols.domain.devices.AnyDeviceDescriptor
 import dk.cachet.carp.protocols.domain.devices.AnyMasterDeviceDescriptor
-import dk.cachet.carp.protocols.domain.devices.DeviceDescriptorSerializer
-import dk.cachet.carp.protocols.domain.devices.MasterDeviceDescriptorSerializer
 import dk.cachet.carp.protocols.domain.tasks.TaskDescriptor
-import dk.cachet.carp.protocols.domain.tasks.TaskDescriptorSerializer
 import dk.cachet.carp.protocols.domain.triggers.Trigger
-import dk.cachet.carp.protocols.domain.triggers.TriggerSerializer
 import kotlinx.serialization.Serializable
 
 
@@ -24,11 +20,11 @@ data class StudyProtocolSnapshot(
     val name: String,
     val description: String,
     override val creationDate: DateTime,
-    val masterDevices: List<@Serializable( MasterDeviceDescriptorSerializer::class ) AnyMasterDeviceDescriptor>,
-    val connectedDevices: List<@Serializable( DeviceDescriptorSerializer::class ) AnyDeviceDescriptor>,
+    val masterDevices: List<AnyMasterDeviceDescriptor>,
+    val connectedDevices: List<AnyDeviceDescriptor>,
     val connections: List<DeviceConnection>,
-    val tasks: List<@Serializable( TaskDescriptorSerializer::class ) TaskDescriptor>,
-    val triggers: Map<Int, @Serializable( TriggerSerializer::class ) Trigger>,
+    val tasks: List<TaskDescriptor>,
+    val triggers: Map<Int, Trigger>,
     val triggeredTasks: List<TriggeredTask>,
     val expectedParticipantData: List<ParticipantAttribute>
 ) : Snapshot<StudyProtocol>

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/UnknownDeviceSerializers.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/devices/UnknownDeviceSerializers.kt
@@ -6,7 +6,6 @@ import dk.cachet.carp.common.serialization.createUnknownPolymorphicSerializer
 import dk.cachet.carp.common.serialization.UnknownPolymorphicSerializer
 import dk.cachet.carp.common.serialization.UnknownPolymorphicWrapper
 import dk.cachet.carp.protocols.domain.sampling.SamplingConfiguration
-import dk.cachet.carp.protocols.domain.sampling.SamplingConfigurationSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -17,6 +16,7 @@ import kotlin.reflect.KClass
 /**
  * A wrapper used to load extending types from [DeviceDescriptor] serialized as JSON which are unknown at runtime.
  */
+@Serializable( DeviceDescriptorSerializer::class )
 data class CustomDeviceDescriptor( override val className: String, override val jsonSource: String, val serializer: Json ) :
     DeviceDescriptor<DeviceRegistration, DeviceRegistrationBuilder<DeviceRegistration>>(), UnknownPolymorphicWrapper
 {
@@ -48,6 +48,7 @@ data class CustomDeviceDescriptor( override val className: String, override val 
 /**
  * A wrapper used to load extending types from [MasterDeviceDescriptor] serialized as JSON which are unknown at runtime.
  */
+@Serializable( MasterDeviceDescriptorSerializer::class )
 data class CustomMasterDeviceDescriptor( override val className: String, override val jsonSource: String, val serializer: Json ) :
     MasterDeviceDescriptor<DeviceRegistration, DeviceRegistrationBuilder<DeviceRegistration>>(), UnknownPolymorphicWrapper
 {
@@ -80,7 +81,7 @@ data class CustomMasterDeviceDescriptor( override val className: String, overrid
 private data class BaseMembers(
     override val roleName: String,
     override val supportedDataTypes: Set<DataType>,
-    override val samplingConfiguration: Map<DataType, @Serializable( SamplingConfigurationSerializer::class ) SamplingConfiguration>
+    override val samplingConfiguration: Map<DataType, SamplingConfiguration>
 ) : DeviceDescriptor<DeviceRegistration, DeviceRegistrationBuilder<DeviceRegistration>>()
 {
     override fun createDeviceRegistrationBuilder(): DeviceRegistrationBuilder<DeviceRegistration> =
@@ -123,6 +124,7 @@ object MasterDeviceDescriptorSerializer : KSerializer<AnyMasterDeviceDescriptor>
 /**
  * A wrapper used to load extending types from [DeviceRegistration] serialized as JSON which are unknown at runtime.
  */
+@Serializable( DeviceRegistrationSerializer::class )
 data class CustomDeviceRegistration( override val className: String, override val jsonSource: String, val serializer: Json ) :
     DeviceRegistration(), UnknownPolymorphicWrapper
 {

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/UnknownSamplingConfigurationSerializers.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/UnknownSamplingConfigurationSerializers.kt
@@ -3,12 +3,14 @@ package dk.cachet.carp.protocols.domain.sampling
 import dk.cachet.carp.common.serialization.UnknownPolymorphicWrapper
 import dk.cachet.carp.common.serialization.createUnknownPolymorphicSerializer
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 
 /**
  * A wrapper used to load extending types from [SamplingConfiguration] serialized as JSON which are unknown at runtime.
  */
+@Serializable( SamplingConfigurationSerializer::class )
 data class CustomSamplingConfiguration( override val className: String, override val jsonSource: String, val serializer: Json ) :
     SamplingConfiguration, UnknownPolymorphicWrapper
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/ConcurrentTask.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/ConcurrentTask.kt
@@ -11,6 +11,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ConcurrentTask(
     override val name: String,
-    @Serializable( MeasuresSerializer::class )
     override val measures: List<Measure>
 ) : TaskDescriptor

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/CustomProtocolTask.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/CustomProtocolTask.kt
@@ -19,6 +19,5 @@ data class CustomProtocolTask(
     /**
      * This list is empty, since measures are defined in [studyProtocol] in a different format.
      */
-    @Serializable( MeasuresSerializer::class )
     override val measures: List<Measure> = emptyList()
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/UnknownTaskSerializers.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/tasks/UnknownTaskSerializers.kt
@@ -6,21 +6,18 @@ import dk.cachet.carp.common.serialization.UnknownPolymorphicWrapper
 import dk.cachet.carp.protocols.domain.tasks.measures.Measure
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 
 
 /**
  * A wrapper used to load extending types from [TaskDescriptor] serialized as JSON which are unknown at runtime.
  */
+@Serializable( TaskDescriptorSerializer::class )
 data class CustomTaskDescriptor( override val className: String, override val jsonSource: String, val serializer: Json ) :
     TaskDescriptor, UnknownPolymorphicWrapper
 {
     @Serializable
-    private class BaseMembers(
-        override val name: String,
-        override val measures: List<@Serializable( MeasureSerializer::class ) Measure>
-    ) : TaskDescriptor
+    private class BaseMembers( override val name: String, override val measures: List<Measure> ) : TaskDescriptor
 
     override val name: String
     override val measures: List<Measure>
@@ -44,6 +41,7 @@ object TaskDescriptorSerializer : KSerializer<TaskDescriptor>
 /**
  * A wrapper used to load extending types from [Measure] serialized as JSON which are unknown at runtime.
  */
+@Serializable( MeasureSerializer::class )
 data class CustomMeasure( override val className: String, override val jsonSource: String, val serializer: Json ) :
     Measure, UnknownPolymorphicWrapper
 {
@@ -65,8 +63,3 @@ data class CustomMeasure( override val className: String, override val jsonSourc
  */
 object MeasureSerializer : KSerializer<Measure>
     by createUnknownPolymorphicSerializer( { className, json, serializer -> CustomMeasure( className, json, serializer ) } )
-
-/**
- * Custom serializer for a list of [Measure]s which enables deserializing types that are unknown at runtime, yet extend from [Measure].
- */
-object MeasuresSerializer : KSerializer<List<Measure>> by ListSerializer( MeasureSerializer )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/triggers/UnknownTriggerSerializers.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/triggers/UnknownTriggerSerializers.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 /**
  * A wrapper used to load extending types from [Trigger] serialized as JSON which are unknown at runtime.
  */
+@Serializable( TriggerSerializer::class )
 data class CustomTrigger( override val className: String, override val jsonSource: String, val serializer: Json ) :
     Trigger(), UnknownPolymorphicWrapper
 {

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/Serialization.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/Serialization.kt
@@ -27,6 +27,8 @@ val PROTOCOLS_SERIAL_MODULE = SerializersModule {
     {
         subclass( CustomProtocolDevice::class )
         subclass( Smartphone::class )
+
+        subclass( CustomMasterDeviceDescriptor::class )
     }
 
     polymorphic( DeviceDescriptor::class )
@@ -34,15 +36,23 @@ val PROTOCOLS_SERIAL_MODULE = SerializersModule {
         subclass( AltBeacon::class )
         subclass( BLEHeartRateSensor::class )
         registerMasterDeviceDescriptorSubclasses()
+
+        subclass( CustomDeviceDescriptor::class )
+        default { DeviceDescriptorSerializer }
     }
     polymorphic( MasterDeviceDescriptor::class )
     {
         registerMasterDeviceDescriptorSubclasses()
+
+        default { MasterDeviceDescriptorSerializer }
     }
     polymorphic( SamplingConfiguration::class )
     {
         subclass( IntervalSamplingConfiguration::class )
         subclass( NoOptionsSamplingConfiguration::class )
+
+        subclass( CustomSamplingConfiguration::class )
+        default { SamplingConfigurationSerializer }
     }
     polymorphic( DeviceRegistration::class )
     {
@@ -50,22 +60,34 @@ val PROTOCOLS_SERIAL_MODULE = SerializersModule {
         subclass( BLESerialNumberDeviceRegistration::class )
         subclass( DefaultDeviceRegistration::class )
         subclass( MACAddressDeviceRegistration::class )
+
+        subclass( CustomDeviceRegistration::class )
+        default { DeviceRegistrationSerializer }
     }
     polymorphic( TaskDescriptor::class )
     {
         subclass( ConcurrentTask::class )
         subclass( CustomProtocolTask::class )
+
+        subclass( CustomTaskDescriptor::class )
+        default { TaskDescriptorSerializer }
     }
     polymorphic( Measure::class )
     {
         subclass( DataTypeMeasure::class )
         subclass( PhoneSensorMeasure::class )
+
+        subclass( CustomMeasure::class )
+        default { MeasureSerializer }
     }
     polymorphic( Trigger::class )
     {
         subclass( ElapsedTimeTrigger::class )
         subclass( ManualTrigger::class )
         subclass( ScheduledTrigger::class )
+
+        subclass( CustomTrigger::class )
+        default { TriggerSerializer }
     }
 }
 
@@ -131,10 +153,10 @@ fun StudyProtocolSnapshot.toJson(): String =
  * Create a [DeviceRegistration] from JSON, serialized using the globally set infrastructure serializer ([JSON]).
  */
 fun DeviceRegistration.Companion.fromJson( json: String ): DeviceRegistration =
-    JSON.decodeFromString( DeviceRegistrationSerializer, json )
+    JSON.decodeFromString( serializer(), json )
 
 /**
  * Serialize to JSON, using the globally set infrastructure serializer ([JSON]).
  */
 fun DeviceRegistration.toJson(): String =
-    JSON.encodeToString( DeviceRegistrationSerializer, this )
+    JSON.encodeToString( DeviceRegistration.serializer(), this )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/StubTaskDescriptor.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/test/StubTaskDescriptor.kt
@@ -1,6 +1,5 @@
 package dk.cachet.carp.protocols.infrastructure.test
 
-import dk.cachet.carp.protocols.domain.tasks.MeasuresSerializer
 import dk.cachet.carp.protocols.domain.tasks.TaskDescriptor
 import dk.cachet.carp.protocols.domain.tasks.measures.Measure
 import kotlinx.serialization.Serializable
@@ -9,6 +8,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class StubTaskDescriptor(
     override val name: String = "Stub task",
-    @Serializable( MeasuresSerializer::class )
     override val measures: List<Measure> = listOf()
 ) : TaskDescriptor

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/SerializationTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/SerializationTest.kt
@@ -7,13 +7,29 @@ import dk.cachet.carp.common.RecurrenceRule
 import dk.cachet.carp.common.TimeOfDay
 import dk.cachet.carp.common.TimeSpan
 import dk.cachet.carp.common.UUID
+import dk.cachet.carp.common.serialization.UnknownPolymorphicWrapper
 import dk.cachet.carp.protocols.domain.sampling.*
 import dk.cachet.carp.protocols.domain.devices.*
 import dk.cachet.carp.protocols.domain.tasks.*
 import dk.cachet.carp.protocols.domain.tasks.measures.*
 import dk.cachet.carp.protocols.domain.triggers.*
+import dk.cachet.carp.protocols.infrastructure.test.STUBS_SERIAL_MODULE
+import dk.cachet.carp.protocols.infrastructure.test.StubDeviceDescriptor
+import dk.cachet.carp.protocols.infrastructure.test.StubMasterDeviceDescriptor
+import dk.cachet.carp.protocols.infrastructure.test.StubMeasure
+import dk.cachet.carp.protocols.infrastructure.test.StubSamplingConfiguration
+import dk.cachet.carp.protocols.infrastructure.test.StubTaskDescriptor
+import dk.cachet.carp.protocols.infrastructure.test.StubTrigger
 import dk.cachet.carp.test.serialization.ConcreteTypesSerializationTest
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 
+
+const val testClassDiscriminator = "_type"
+val testJson = Json( createProtocolsSerializer( STUBS_SERIAL_MODULE ) ) { classDiscriminator = testClassDiscriminator }
 
 private val protocolInstances = listOf(
     // Devices.
@@ -21,16 +37,20 @@ private val protocolInstances = listOf(
     BLEHeartRateSensor( "Polar" ),
     CustomProtocolDevice( "User's phone" ),
     Smartphone( "User's phone" ),
+    unknown( StubDeviceDescriptor() ) { CustomDeviceDescriptor( it.first, it.second, it.third ) },
+    unknown( StubMasterDeviceDescriptor() ) { CustomMasterDeviceDescriptor( it.first, it.second, it.third ) },
 
     // Sampling configurations.
     IntervalSamplingConfiguration( TimeSpan.fromMilliseconds( 1000.0 ) ),
     NoOptionsSamplingConfiguration(),
+    unknown( StubSamplingConfiguration( "" ) ) { CustomSamplingConfiguration( it.first, it.second, it.third ) },
 
     // Device registrations.
     AltBeaconDeviceRegistration( 0, UUID.randomUUID(), 0, 0 ),
     BLESerialNumberDeviceRegistration( "123456789" ),
     DefaultDeviceRegistration( "Some device" ),
     MACAddressDeviceRegistration( MACAddress( "00-00-00-00-00-00" ) ),
+    unknown( DefaultDeviceRegistration( "id" ) ) { CustomDeviceRegistration( it.first, it.second, it.third ) },
 
     // Tasks.
     ConcurrentTask( "Start measures", listOf() ),
@@ -38,10 +58,12 @@ private val protocolInstances = listOf(
         "Custom study runtime",
         "{ \"\$type\": \"Study\", \"custom\": \"protocol\" }"
     ),
+    unknown( StubTaskDescriptor() ) { CustomTaskDescriptor( it.first, it.second, it.third ) },
 
     // Measures.
     DataTypeMeasure( "dk.cachet.carp", "SomeType" ),
     PhoneSensorMeasure.geolocation(),
+    unknown( StubMeasure() ) { CustomMeasure( it.first, it.second, it.third ) },
 
     // Triggers.
     ElapsedTimeTrigger( Smartphone( "User's phone" ), TimeSpan( 0 ) ),
@@ -53,13 +75,30 @@ private val protocolInstances = listOf(
     ScheduledTrigger(
         Smartphone( "User's phone"),
         TimeOfDay( 12 ), RecurrenceRule( RecurrenceRule.Frequency.DAILY )
-    )
+    ),
+    unknown( StubTrigger( "source" ) ) { CustomTrigger( it.first, it.second, it.third ) }
 )
+
+/**
+ * Convert the specified [stub] to the corresponding [UnknownPolymorphicWrapper] as if it were unknown at runtime.
+ */
+inline fun <reified Base : Any> unknown( stub: Base, constructor: (Triple<String, String, Json>) -> Base ): Base
+{
+    val originalObject = testJson.encodeToJsonElement( PolymorphicSerializer( Base::class ), stub ) as JsonObject
+
+    // Mimic the passed stub as an unknown object.
+    val unknownName = "Unknown"
+    val unknownObject = originalObject.toMutableMap()
+    unknownObject[ testClassDiscriminator ] = JsonPrimitive( unknownName )
+    val jsonSource = testJson.encodeToString( unknownObject )
+
+    return constructor( Triple( unknownName, jsonSource, testJson ) )
+}
 
 /**
  * Serialization tests for all extending types from base classes in [dk.cachet.carp.protocols].
  */
 class SerializationTest : ConcreteTypesSerializationTest(
-    createProtocolsSerializer(),
+    testJson,
     PROTOCOLS_SERIAL_MODULE,
     protocolInstances )

--- a/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/serialization/ConcreteTypesSerializationTest.kt
+++ b/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/serialization/ConcreteTypesSerializationTest.kt
@@ -90,7 +90,10 @@ fun getPolymorphicSerializers( serialModule: SerializersModule ): Map<KClass<*>,
             override fun <Base : Any> polymorphicDefault(
                 baseClass: KClass<Base>,
                 defaultSerializerProvider: (className: String?) -> DeserializationStrategy<out Base>?
-            ) = throw UnsupportedOperationException()
+            )
+            {
+                // The default serializer is not returned by this method.
+            }
         }
 
     serialModule.dumpTo( collector )


### PR DESCRIPTION
By relying on the `default` fallback mechanism of polymorphic serialization to register the `UnknownPolymorphicSerializer`, it is no longer needed to specify the unknown serializers anywhere unknown types can be encountered in the codebase.

To make this work, the wrapper objects used to store unknown types at runtime also need to be registered as `subclass` for the polymorphic types. I updated the documentation accordingly.

In addition, this means that by registering a different `default` serializer (and `subclass` for the wrapper), unknown polymorphic serialization can now also be supported for different serialization formats than Json.

Making this work was a bit of a hack which required accessing `kotlinx.serialization` internals. An `Encoder` maintains state that the current object is being encoded as polymorphic or not. Depending on this state, `beginStructure` outputs type information or not. But, given that the wrapped object already contains type information, we never want to output this. But whether or not the `Encoder` is currently writing something as polymorphic is handled outside of the serializer. I wrote a tiny multiplatform accessor to modify this internal boolean state prior to encoding the wrapped json object. I will contact the Jetbrains folks to see whether or not they could consider this as a valid use case to open up their APIs a bit.

This fixes the following issues:

- [Make use of the new `default` feature of polymorphic `kotlinx.serialization`](https://github.com/cph-cachet/carp.core-kotlin/issues/161)
- [Prevent deriving types from types which allow unknown extending classes having to specify custom serializers wherever they are used](https://github.com/cph-cachet/carp.core-kotlin/issues/9) (e.g., `Measure`, and `AnyDeviceDescriptor`).
