### PR TITLE
Upgrade `detekt-verify-implementation` to 1.1.1; remove hacks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
 
             // DevOps versions.
             detektPlugin:'1.16.0-RC1',
-            detektVerifyImplementation:'1.0.0',
+            detektVerifyImplementation:'1.1.1',
             nexusReleasePlugin:'0.22.0'
         ]
     }
@@ -337,7 +337,8 @@ configure( rootProject )
         buildUponDefaultConfig = true
         ignoreFailures = false
         def classPaths = project.configurations.getByName("detekt")
-        coreModules.each { classPaths += it.configurations.getByName("jvmCompileClasspath") }
+        def multiplatformModules = coreModules + commonModule
+        multiplatformModules.each { classPaths += it.configurations.getByName("jvmCompileClasspath") }
         classpath.setFrom(classPaths)
     }
     tasks.detekt.jvmTarget = "1.8"

--- a/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
+++ b/carp.deployment.core/src/commonMain/kotlin/dk/cachet/carp/deployment/domain/StudyDeployment.kt
@@ -30,9 +30,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
         data class DeviceDeployed( val device: AnyMasterDeviceDescriptor ) : Event()
         data class Started( val startTime: DateTime ) : Event()
         data class DeploymentInvalidated( val device: AnyMasterDeviceDescriptor ) : Event()
-        // TODO: Immutable base class does not allow this to be defined as `object Stopped : Event()`.
-        //       It requires a data class, but that does not make sense since an object would still be immutable.
-        data class Stopped( private val ignored: Unit = Unit ) : Event()
+        object Stopped : Event()
     }
 
 
@@ -405,7 +403,7 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
         if ( !isStopped )
         {
             isStopped = true
-            event( Event.Stopped() )
+            event( Event.Stopped )
         }
     }
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/NoOptionsSamplingConfiguration.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/sampling/NoOptionsSamplingConfiguration.kt
@@ -1,21 +1,13 @@
 package dk.cachet.carp.protocols.domain.sampling
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
 
 
 /**
  * A sampling configuration which does not provide any configuration options.
  */
 @Serializable
-data class NoOptionsSamplingConfiguration(
-    /**
-     * HACK: This is only here because the Immutable base class of SamplingConfiguration currently does not allow this to be an object.
-     *       Remove once fixed: https://github.com/cph-cachet/carp.core-kotlin/issues/121
-     */
-    @Transient
-    private val ignored: String = ""
-) : SamplingConfiguration
+object NoOptionsSamplingConfiguration : SamplingConfiguration
 
 
 /**
@@ -23,5 +15,5 @@ data class NoOptionsSamplingConfiguration(
  */
 object NoOptionsSamplingConfigurationBuilder : SamplingConfigurationBuilder
 {
-    override fun build(): NoOptionsSamplingConfiguration = NoOptionsSamplingConfiguration()
+    override fun build(): NoOptionsSamplingConfiguration = NoOptionsSamplingConfiguration
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/Serialization.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/Serialization.kt
@@ -42,7 +42,7 @@ val PROTOCOLS_SERIAL_MODULE = SerializersModule {
     polymorphic( SamplingConfiguration::class )
     {
         subclass( IntervalSamplingConfiguration::class )
-        subclass( NoOptionsSamplingConfiguration::class )
+        subclass( NoOptionsSamplingConfiguration::class, NoOptionsSamplingConfiguration.serializer() )
     }
     polymorphic( DeviceRegistration::class )
     {

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/SerializationTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/SerializationTest.kt
@@ -24,7 +24,7 @@ private val protocolInstances = listOf(
 
     // Sampling configurations.
     IntervalSamplingConfiguration( TimeSpan.fromMilliseconds( 1000.0 ) ),
-    NoOptionsSamplingConfiguration(),
+    NoOptionsSamplingConfiguration,
 
     // Device registrations.
     AltBeaconDeviceRegistration( 0, UUID.randomUUID(), 0, 0 ),

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -20,13 +20,13 @@ interface StudyService : ApplicationService<StudyService, StudyService.Event>
     sealed class Event : IntegrationEvent<StudyService>()
     {
         @Serializable
-        class StudyCreated( val study: StudyDetails ) : Event()
+        data class StudyCreated( val study: StudyDetails ) : Event()
 
         @Serializable
-        class StudyGoneLive( val study: StudyDetails ) : Event()
+        data class StudyGoneLive( val study: StudyDetails ) : Event()
 
         @Serializable
-        class StudyRemoved( val studyId: UUID ) : Event()
+        data class StudyRemoved( val studyId: UUID ) : Event()
     }
 
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -64,14 +64,39 @@ style:
 verify-implementation:
   DataClass:
     active: true
+    # TODO: These need to be excluded because base class sources can't be analyzed. Can we include them in the classpath?
+    #   Alternatively, this new feature could help: https://github.com/cph-cachet/detekt-verify-implementation/issues/20
+    excludes: &verify-implementation-excludes
+        - '**/carp/detekt/**'
+        - '**/carp/common/*'
+        - '**/carp/common/data/CarpDataTypes.kt'
+        - '**/carp/common/data/input/CarpInputDataTypes.kt'
+        - '**/carp/common/data/input/CustomInput.kt'
+        - '**/carp/common/data/input/InputDataTypeList.kt'
+        - '**/carp/common/data/input/InputDataTypeListTest.kt'
+        - '**/carp/common/serialization/**'
+        - '**/carp/common/users/ParticipantAttributeTest.kt'
+        - '**/carp/protocols/domain/sampling/DataTypeSamplingScheme.kt'
+        - '**/carp/test/serialization/ConcreteTypesSerializationTest.kt'
+
+        # TODO: enums may be valid for `DataClass`. At least, the following comply with the expectations.
+        - '**/carp/common/data/input/Sex.kt'
+
+        # TODO: these are the exact classes we are trying to check! Only the inner classes and serializers should be ignored.
+        - '**/carp/protocols/domain/devices/BLEHeartRateSensor.kt'
+        - '**/carp/protocols/domain/devices/UnknownDeviceSerializers.kt'
+        - '**/carp/protocols/domain/sampling/UnknownSamplingConfigurationSerializers.kt'
+        - '**/carp/protocols/domain/tasks/UnknownTaskSerializers.kt'
+        - '**/carp/protocols/domain/triggers/UnknownTriggerSerializers.kt'
+        - '**/carp/protocols/domain/tasks/measures/PhoneSensorMeasure.kt'
     annotationClass: "dk.cachet.carp.common.ImplementAsDataClass"
-    includes: ['**/domain/**']
   Immutable:
     active: true
+    excludes: *verify-implementation-excludes
     annotationClass: "dk.cachet.carp.common.Immutable"
-    includes: ['**/domain/**']
     assumeImmutable: [
       'dk.cachet.carp.common.DateTime',
+      'dk.cachet.carp.common.data.input.CustomInput.T',
       'kotlinx.serialization.json.Json'
     ]
 


### PR DESCRIPTION
Fixes #121 
Fixes #173 

We still need to exclude a lot of sources for verification. Specifying certain classes _do not_ contain annotations would allow us to remove most of these: https://github.com/cph-cachet/detekt-verify-implementation/issues/20 This is thus a good candidate for a next `detekt-verify-implementation` release.