### PR TITLE
Separate activating `EventBus` handlers from registering them.

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBus.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBus.kt
@@ -42,7 +42,7 @@ annotation class EventSubscriptionDsl
 @EventSubscriptionDsl
 class EventSubscriptionBuilder(
     @PublishedApi
-    internal val consumingService: Any,
+    internal val subscriber: Any,
     @PublishedApi
     internal val eventBus: EventBus
 )
@@ -54,7 +54,7 @@ class EventSubscriptionBuilder(
         reified TService : ApplicationService<TService, TEvent>,
         reified TEvent : IntegrationEvent<TService>> event(
         noinline handler: suspend (TEvent) -> Unit
-    ) = eventBus.registerHandler( TService::class, TEvent::class, consumingService, handler )
+    ) = eventBus.registerHandler( TEvent::class, subscriber, handler )
 }
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBus.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBus.kt
@@ -54,7 +54,7 @@ class EventSubscriptionBuilder(
         reified TService : ApplicationService<TService, TEvent>,
         reified TEvent : IntegrationEvent<TService>> event(
         noinline handler: suspend (TEvent) -> Unit
-    ) = eventBus.registerHandler( TEvent::class, subscriber, handler )
+    ) = eventBus.registerHandler( TService::class, TEvent::class, subscriber, handler )
 }
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ChannelConventionEventBus.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/ChannelConventionEventBus.kt
@@ -1,0 +1,52 @@
+package dk.cachet.carp.common.ddd
+
+import kotlin.reflect.KClass
+
+
+/**
+ * A base implementation of [EventBus] which sets up a subscription channel per application service
+ * from which events originate.
+ *
+ * The [EventBus] abstraction does not assume a one-to-one mapping between a message queue channel
+ * and application service. E.g., you could implement two channels per application service, or use one for two services.
+ * But, a one-to-one mapping is a reasonable convention. This base class implements that convention.
+ */
+abstract class ChannelConventionEventBus : EventBus()
+{
+    final override suspend fun <
+        TService : ApplicationService<TService, TEvent>,
+        TEvent : IntegrationEvent<TService>
+    > publish( publishingService: KClass<TService>, event: TEvent ) =
+        publishToChannel( publishingService, event )
+
+    override fun activateHandlers( subscriber: Any, handlers: List<Handler> )
+    {
+        handlers
+            .groupBy { it.eventSource }
+            .forEach { (source, handlers) -> subscribeToChannel( source, ::redirectEvent ) }
+    }
+
+    private suspend fun redirectEvent( event: IntegrationEvent<*> )
+    {
+        // Find all active handlers listening to the published event type.
+        val handlers = subscribers.values
+            .filter { it.isActivated }
+            .flatMap { it.eventHandlers.filter { handler -> handler.eventType.isInstance( event ) } }
+
+        // Publish.
+        handlers.forEach { it.handler( event ) }
+    }
+
+    /**
+     * Publish the specified [event] to the channel identified by [channelIdentifier].
+     */
+    abstract suspend fun <
+        TService : ApplicationService<TService, TEvent>,
+        TEvent : IntegrationEvent<TService>
+    > publishToChannel( channelIdentifier: KClass<TService>, event: TEvent )
+
+    /**
+     * Forward all events of the channel identified by [channelIdentifier] to [handler].
+     */
+    abstract fun subscribeToChannel( channelIdentifier: KClass<*>, handler: suspend (IntegrationEvent<*>) -> Unit )
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBus.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBus.kt
@@ -10,33 +10,71 @@ class SingleThreadedEventBus : EventBus
 {
     private class Handler( val eventType: KClass<*>, val handler: suspend (IntegrationEvent<*>) -> Unit )
 
+    private class EventConsumerState
+    {
+        val eventHandlers: MutableList<Handler> = mutableListOf()
+        var consumerActivated: Boolean = false
+    }
 
-    private val eventHandlers: MutableList<Handler> = mutableListOf()
+
+    private val eventConsumers: MutableMap<Any, EventConsumerState> = mutableMapOf()
 
     /**
-     * Publish the specified [event] belonging to [applicationServiceKlass]
+     * Publish the specified [event] belonging to [publishingService]
      * and instantly deliver it to all subscribers on the same thread as it is published on.
      */
     override suspend fun <
         TApplicationService : ApplicationService<TApplicationService, TEvent>,
-        TEvent : IntegrationEvent<TApplicationService>
-    > publish( applicationServiceKlass: KClass<TApplicationService>, event: TEvent )
+        TEvent : IntegrationEvent<TApplicationService>> publish(
+        publishingService: KClass<TApplicationService>,
+        event: TEvent
+    )
     {
-        val matchingTypes = eventHandlers.filter { it.eventType.isInstance( event ) }
-        matchingTypes.forEach { it.handler( event ) }
+        // Find all active handlers listening to the published event type.
+        val handlers = eventConsumers.values
+            .filter { it.consumerActivated }
+            .flatMap { it.eventHandlers.filter { handler -> handler.eventType.isInstance( event ) } }
+
+        // Publish.
+        handlers.forEach { it.handler( event ) }
     }
 
     /**
-     * Subscribe to events of [eventType] belonging to [applicationServiceKlass] and handle them using [handler].
+     * Register a [handler] for events of [eventType] belonging to [publishingServiceKlass],
+     * to be received by [consumingService].
+     *
+     * @throws IllegalStateException when trying to register a handler for a [consumingService]
+     *   for which [activateHandlers] has already been called.
      */
     override fun <
         TApplicationService : ApplicationService<TApplicationService, TEvent>,
-        TEvent : IntegrationEvent<TApplicationService>
-    > subscribe( applicationServiceKlass: KClass<TApplicationService>, eventType: KClass<TEvent>, handler: suspend (TEvent) -> Unit )
+        TEvent : IntegrationEvent<TApplicationService>> registerHandler(
+        publishingServiceKlass: KClass<TApplicationService>,
+        eventType: KClass<TEvent>,
+        consumingService: Any,
+        handler: suspend (TEvent) -> Unit
+    )
     {
+        val consumerState = eventConsumers.getOrPut( consumingService ) { EventConsumerState() }
+        check( !consumerState.consumerActivated )
+            { "Cannot register event handlers after handlers for consuming service have been activated." }
+
         @Suppress("UNCHECKED_CAST")
         val baseHandler = handler as suspend (IntegrationEvent<*>) -> Unit
 
-        eventHandlers.add( Handler( eventType, baseHandler ) )
+        consumerState.eventHandlers.add( Handler( eventType, baseHandler ) )
+    }
+
+    /**
+     * Start the event subscription for all registered handlers of [consumingService].
+     *
+     * @throws IllegalStateException when this is called more than once.
+     */
+    override fun activateHandlers( consumingService: Any )
+    {
+        val consumerState = eventConsumers.getOrPut( consumingService ) { EventConsumerState() }
+        check( !consumerState.consumerActivated ) { "Can only activate handlers for consuming service once." }
+
+        consumerState.consumerActivated = true
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBusTest.kt
@@ -42,19 +42,21 @@ class ApplicationServiceEventBusTest
         val serviceBus = bus.createApplicationServiceAdapter( TestService::class )
 
         var eventReceived = false
-        bus.subscribe { _: Event.SomeEvent -> eventReceived = true }
+        bus.registerHandler( this ) { _: Event.SomeEvent -> eventReceived = true }
+        bus.activateHandlers( this )
         serviceBus.publish( Event.SomeEvent )
 
         assertTrue( eventReceived )
     }
 
     @Test
-    fun subscribe_succeeds() = runSuspendTest {
+    fun registerHandler_succeeds() = runSuspendTest {
         val bus = SingleThreadedEventBus()
         val serviceBus = bus.createApplicationServiceAdapter( TestService::class )
 
         var eventReceived = false
-        serviceBus.subscribe { _: OtherEvent -> eventReceived = true }
+        serviceBus.registerHandler { _: OtherEvent -> eventReceived = true }
+        bus.activateHandlers( TestService::class )
         bus.publish( OtherEvent.SomeOtherEvent )
 
         assertTrue( eventReceived )

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/ApplicationServiceEventBusTest.kt
@@ -50,13 +50,14 @@ class ApplicationServiceEventBusTest
     }
 
     @Test
-    fun registerHandler_succeeds() = runSuspendTest {
+    fun subscribe_succeeds() = runSuspendTest {
         val bus = SingleThreadedEventBus()
         val serviceBus = bus.createApplicationServiceAdapter( TestService::class )
 
         var eventReceived = false
-        serviceBus.registerHandler { _: OtherEvent -> eventReceived = true }
-        bus.activateHandlers( TestService::class )
+        serviceBus.subscribe {
+            event { _: OtherEvent -> eventReceived = true }
+        }
         bus.publish( OtherEvent.SomeOtherEvent )
 
         assertTrue( eventReceived )

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/ChannelConventionEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/ChannelConventionEventBusTest.kt
@@ -1,0 +1,84 @@
+package dk.cachet.carp.common.ddd
+
+import dk.cachet.carp.test.runSuspendTest
+import kotlinx.serialization.Serializable
+import kotlin.reflect.KClass
+import kotlin.test.*
+
+
+/**
+ * Tests for [ChannelConventionEventBus].
+ */
+class ChannelConventionEventBusTest
+{
+    class StubChannelConventionEventBus : ChannelConventionEventBus()
+    {
+        val channelHandlers: MutableMap<KClass<*>, suspend (IntegrationEvent<*>) -> Unit> = mutableMapOf()
+
+        override suspend fun <TService : ApplicationService<TService, TEvent>, TEvent : IntegrationEvent<TService>> publishToChannel(
+            channelIdentifier: KClass<TService>,
+            event: TEvent
+        ) = channelHandlers[ channelIdentifier ]!!.invoke( event )
+
+        override fun subscribeToChannel( channelIdentifier: KClass<*>, handler: suspend (IntegrationEvent<*>) -> Unit )
+        {
+            channelHandlers[ channelIdentifier ] = handler
+        }
+    }
+
+    interface TestService1 : ApplicationService<TestService1, Service1Event>
+
+    @Serializable
+    sealed class Service1Event : IntegrationEvent<TestService1>()
+    {
+        @Serializable
+        data class SomeEvent( val data: String ) : Service1Event()
+
+        @Serializable
+        data class SomeOtherEvent( val data: String ) : Service1Event()
+    }
+
+    interface TestService2 : ApplicationService<TestService2, Service2Event>
+
+    @Serializable
+    sealed class Service2Event : IntegrationEvent<TestService2>()
+    {
+        @Serializable
+        data class SomeEvent( val data: String ) : Service2Event()
+    }
+
+
+    @Test
+    fun activeHandlers_redirects_to_subscribeToChannel()
+    {
+        val eventBus = StubChannelConventionEventBus()
+
+        // No channel subscriptions registered until activateHandlers is called.
+        eventBus.registerHandler( TestService1::class, Service1Event.SomeEvent::class, this ) { }
+        eventBus.registerHandler( TestService1::class, Service1Event.SomeOtherEvent::class, this ) { }
+        eventBus.registerHandler( TestService2::class, Service2Event.SomeEvent::class, this ) { }
+        assertTrue( eventBus.channelHandlers.isEmpty() )
+
+        // subscribeToChannel is grouped per application service.
+        eventBus.activateHandlers( this )
+        assertEquals( 2, eventBus.channelHandlers.size )
+        assertTrue( eventBus.channelHandlers.containsKey( TestService1::class ) )
+        assertTrue( eventBus.channelHandlers.containsKey( TestService2::class ) )
+    }
+
+    @Test
+    fun published_events_are_received_by_handlers() = runSuspendTest {
+        val eventBus = StubChannelConventionEventBus()
+
+        var eventReceived: String? = null
+        eventBus.registerHandler( TestService1::class, Service1Event.SomeEvent::class, this )
+        {
+            eventReceived = it.data
+        }
+        eventBus.activateHandlers( this )
+
+        val sentData = "Test"
+        eventBus.publish( Service1Event.SomeEvent( sentData ) )
+        assertEquals( sentData, eventReceived )
+    }
+}

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBusTest.kt
@@ -28,7 +28,7 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var receivedEventData: String? = null
-        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { event ->
+        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { event ->
             receivedEventData = event.data
         }
         bus.activateHandlers( this )
@@ -43,7 +43,7 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var receivedEventData: String? = null
-        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { event ->
+        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { event ->
             receivedEventData = event.data
         }
 
@@ -56,7 +56,7 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var eventReceived = false
-        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) {
+        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) {
             eventReceived = true
         }
         bus.activateHandlers( this )
@@ -71,9 +71,9 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var receivedBySubscriber1 = false
-        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { receivedBySubscriber1 = true }
+        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { receivedBySubscriber1 = true }
         var receivedBySubscriber2 = false
-        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { receivedBySubscriber2 = true }
+        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { receivedBySubscriber2 = true }
         bus.activateHandlers( this )
 
         bus.publish( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent( "Test" ) )
@@ -86,7 +86,7 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var receivedEvent = false
-        bus.registerHandler( TestService::class, BaseIntegrationEvent::class, this )
+        bus.registerHandler( BaseIntegrationEvent::class, this )
         {
             if ( it is BaseIntegrationEvent.SomeIntegrationEvent ) receivedEvent = true
         }
@@ -103,7 +103,7 @@ class SingleThreadedEventBusTest
         bus.activateHandlers( this )
 
         assertFailsWith<IllegalStateException> {
-            bus.registerHandler( TestService::class, BaseIntegrationEvent::class, this ) { }
+            bus.registerHandler( BaseIntegrationEvent::class, this ) { }
         }
     }
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/ddd/SingleThreadedEventBusTest.kt
@@ -28,14 +28,14 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var receivedEventData: String? = null
-        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { event ->
+        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { event ->
             receivedEventData = event.data
         }
         bus.activateHandlers( this )
         val sentData = "Data"
 
         bus.publish( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent( sentData ) )
-        assertEquals( "Data", receivedEventData )
+        assertEquals( sentData, receivedEventData )
     }
 
     @Test
@@ -43,7 +43,7 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var receivedEventData: String? = null
-        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { event ->
+        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { event ->
             receivedEventData = event.data
         }
 
@@ -56,7 +56,7 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var eventReceived = false
-        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) {
+        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) {
             eventReceived = true
         }
         bus.activateHandlers( this )
@@ -71,9 +71,9 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var receivedBySubscriber1 = false
-        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { receivedBySubscriber1 = true }
+        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { receivedBySubscriber1 = true }
         var receivedBySubscriber2 = false
-        bus.registerHandler( BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { receivedBySubscriber2 = true }
+        bus.registerHandler( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent::class, this ) { receivedBySubscriber2 = true }
         bus.activateHandlers( this )
 
         bus.publish( TestService::class, BaseIntegrationEvent.SomeIntegrationEvent( "Test" ) )
@@ -86,7 +86,7 @@ class SingleThreadedEventBusTest
         val bus = SingleThreadedEventBus()
 
         var receivedEvent = false
-        bus.registerHandler( BaseIntegrationEvent::class, this )
+        bus.registerHandler( TestService::class, BaseIntegrationEvent::class, this )
         {
             if ( it is BaseIntegrationEvent.SomeIntegrationEvent ) receivedEvent = true
         }
@@ -103,7 +103,7 @@ class SingleThreadedEventBusTest
         bus.activateHandlers( this )
 
         assertFailsWith<IllegalStateException> {
-            bus.registerHandler( BaseIntegrationEvent::class, this ) { }
+            bus.registerHandler( TestService::class, BaseIntegrationEvent::class, this ) { }
         }
     }
 

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
@@ -47,7 +47,7 @@ class HostsIntegrationTest
     @Test
     fun create_deployment_creates_participant_group() = runSuspendTest {
         var deploymentCreated: DeploymentService.Event.StudyDeploymentCreated? = null
-        eventBus.registerHandler( DeploymentService.Event.StudyDeploymentCreated::class, this )
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentCreated::class, this )
         {
             deploymentCreated = it
         }
@@ -64,7 +64,7 @@ class HostsIntegrationTest
     @Test
     fun removing_deployment_removes_participant_group() = runSuspendTest {
         var deploymentsRemoved: DeploymentService.Event.StudyDeploymentsRemoved? = null
-        eventBus.registerHandler( DeploymentService.Event.StudyDeploymentsRemoved::class, this )
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentsRemoved::class, this )
         {
             deploymentsRemoved = it
         }
@@ -84,7 +84,7 @@ class HostsIntegrationTest
     @Test
     fun stopping_deployment_stops_participant_group() = runSuspendTest {
         var studyDeploymentStopped: DeploymentService.Event.StudyDeploymentStopped? = null
-        eventBus.registerHandler( DeploymentService.Event.StudyDeploymentStopped::class, this )
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentStopped::class, this )
         {
             studyDeploymentStopped = it
         }
@@ -128,7 +128,7 @@ class HostsIntegrationTest
 
         // Subscribe to registration changes to test whether integration events are sent.
         var registrationChanged: DeploymentService.Event.DeviceRegistrationChanged? = null
-        eventBus.registerHandler( DeploymentService.Event.DeviceRegistrationChanged::class, this )
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.DeviceRegistrationChanged::class, this )
         {
             registrationChanged = it
         }

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
@@ -47,10 +47,11 @@ class HostsIntegrationTest
     @Test
     fun create_deployment_creates_participant_group() = runSuspendTest {
         var deploymentCreated: DeploymentService.Event.StudyDeploymentCreated? = null
-        eventBus.subscribe( DeploymentService::class, DeploymentService.Event.StudyDeploymentCreated::class )
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentCreated::class, this )
         {
             deploymentCreated = it
         }
+        eventBus.activateHandlers( this )
 
         val protocol = createComplexProtocol().getSnapshot()
         val deployment = deploymentService.createStudyDeployment( protocol )
@@ -63,10 +64,11 @@ class HostsIntegrationTest
     @Test
     fun removing_deployment_removes_participant_group() = runSuspendTest {
         var deploymentsRemoved: DeploymentService.Event.StudyDeploymentsRemoved? = null
-        eventBus.subscribe( DeploymentService::class, DeploymentService.Event.StudyDeploymentsRemoved::class )
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentsRemoved::class, this )
         {
             deploymentsRemoved = it
         }
+        eventBus.activateHandlers( this )
 
         val protocol = createComplexProtocol().getSnapshot()
         val deployment = deploymentService.createStudyDeployment( protocol )
@@ -82,10 +84,11 @@ class HostsIntegrationTest
     @Test
     fun stopping_deployment_stops_participant_group() = runSuspendTest {
         var studyDeploymentStopped: DeploymentService.Event.StudyDeploymentStopped? = null
-        eventBus.subscribe( DeploymentService::class, DeploymentService.Event.StudyDeploymentStopped::class )
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentStopped::class, this )
         {
             studyDeploymentStopped = it
         }
+        eventBus.activateHandlers( this )
 
         val protocol = createComplexProtocol().getSnapshot()
         val deployment = deploymentService.createStudyDeployment( protocol )
@@ -125,10 +128,11 @@ class HostsIntegrationTest
 
         // Subscribe to registration changes to test whether integration events are sent.
         var registrationChanged: DeploymentService.Event.DeviceRegistrationChanged? = null
-        eventBus.subscribe( DeploymentService::class, DeploymentService.Event.DeviceRegistrationChanged::class )
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.DeviceRegistrationChanged::class, this )
         {
             registrationChanged = it
         }
+        eventBus.activateHandlers( this )
 
         // Change registration for the assigned device.
         val registration = assignedDevice.createRegistration()

--- a/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
+++ b/carp.deployment.core/src/commonTest/kotlin/dk/cachet/carp/deployment/application/HostsIntegrationTest.kt
@@ -47,7 +47,7 @@ class HostsIntegrationTest
     @Test
     fun create_deployment_creates_participant_group() = runSuspendTest {
         var deploymentCreated: DeploymentService.Event.StudyDeploymentCreated? = null
-        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentCreated::class, this )
+        eventBus.registerHandler( DeploymentService.Event.StudyDeploymentCreated::class, this )
         {
             deploymentCreated = it
         }
@@ -64,7 +64,7 @@ class HostsIntegrationTest
     @Test
     fun removing_deployment_removes_participant_group() = runSuspendTest {
         var deploymentsRemoved: DeploymentService.Event.StudyDeploymentsRemoved? = null
-        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentsRemoved::class, this )
+        eventBus.registerHandler( DeploymentService.Event.StudyDeploymentsRemoved::class, this )
         {
             deploymentsRemoved = it
         }
@@ -84,7 +84,7 @@ class HostsIntegrationTest
     @Test
     fun stopping_deployment_stops_participant_group() = runSuspendTest {
         var studyDeploymentStopped: DeploymentService.Event.StudyDeploymentStopped? = null
-        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentStopped::class, this )
+        eventBus.registerHandler( DeploymentService.Event.StudyDeploymentStopped::class, this )
         {
             studyDeploymentStopped = it
         }
@@ -128,7 +128,7 @@ class HostsIntegrationTest
 
         // Subscribe to registration changes to test whether integration events are sent.
         var registrationChanged: DeploymentService.Event.DeviceRegistrationChanged? = null
-        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.DeviceRegistrationChanged::class, this )
+        eventBus.registerHandler( DeploymentService.Event.DeviceRegistrationChanged::class, this )
         {
             registrationChanged = it
         }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
@@ -66,7 +66,7 @@ class HostsIntegrationTest
     @Test
     fun create_study_creates_recruitment() = runSuspendTest {
         var studyCreated: StudyService.Event.StudyCreated? = null
-        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyCreated::class, this ) { studyCreated = it }
+        eventBus.registerHandler( StudyService.Event.StudyCreated::class, this ) { studyCreated = it }
         eventBus.activateHandlers( this )
 
         val study = studyService.createStudy( StudyOwner(), "Test" )
@@ -84,7 +84,7 @@ class HostsIntegrationTest
         studyService.setProtocol( studyId, protocol.getSnapshot() )
 
         var studyGoneLive: StudyService.Event.StudyGoneLive? = null
-        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyGoneLive::class, this ) { studyGoneLive = it }
+        eventBus.registerHandler( StudyService.Event.StudyGoneLive::class, this ) { studyGoneLive = it }
         eventBus.activateHandlers( this )
         studyService.goLive( studyId )
         val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
@@ -114,9 +114,9 @@ class HostsIntegrationTest
         val deploymentId = group.studyDeploymentStatus.studyDeploymentId
 
         var studyRemovedEvent: StudyService.Event.StudyRemoved? = null
-        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyRemoved::class, this ) { studyRemovedEvent = it }
+        eventBus.registerHandler( StudyService.Event.StudyRemoved::class, this ) { studyRemovedEvent = it }
         var deploymentsRemovedEvent: DeploymentService.Event.StudyDeploymentsRemoved? = null
-        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentsRemoved::class, this ) { deploymentsRemovedEvent = it }
+        eventBus.registerHandler( DeploymentService.Event.StudyDeploymentsRemoved::class, this ) { deploymentsRemovedEvent = it }
         eventBus.activateHandlers( this )
         studyService.remove( studyId )
 
@@ -133,7 +133,7 @@ class HostsIntegrationTest
     @Test
     fun remove_study_does_not_trigger_event_when_study_does_not_exist() = runSuspendTest {
         var removedEvent: StudyService.Event.StudyRemoved? = null
-        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyRemoved::class, this ) { removedEvent = it }
+        eventBus.registerHandler( StudyService.Event.StudyRemoved::class, this ) { removedEvent = it }
         eventBus.activateHandlers( this )
         studyService.remove( UUID.randomUUID() )
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
@@ -66,7 +66,7 @@ class HostsIntegrationTest
     @Test
     fun create_study_creates_recruitment() = runSuspendTest {
         var studyCreated: StudyService.Event.StudyCreated? = null
-        eventBus.registerHandler( StudyService.Event.StudyCreated::class, this ) { studyCreated = it }
+        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyCreated::class, this ) { studyCreated = it }
         eventBus.activateHandlers( this )
 
         val study = studyService.createStudy( StudyOwner(), "Test" )
@@ -84,7 +84,7 @@ class HostsIntegrationTest
         studyService.setProtocol( studyId, protocol.getSnapshot() )
 
         var studyGoneLive: StudyService.Event.StudyGoneLive? = null
-        eventBus.registerHandler( StudyService.Event.StudyGoneLive::class, this ) { studyGoneLive = it }
+        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyGoneLive::class, this ) { studyGoneLive = it }
         eventBus.activateHandlers( this )
         studyService.goLive( studyId )
         val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
@@ -114,9 +114,9 @@ class HostsIntegrationTest
         val deploymentId = group.studyDeploymentStatus.studyDeploymentId
 
         var studyRemovedEvent: StudyService.Event.StudyRemoved? = null
-        eventBus.registerHandler( StudyService.Event.StudyRemoved::class, this ) { studyRemovedEvent = it }
+        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyRemoved::class, this ) { studyRemovedEvent = it }
         var deploymentsRemovedEvent: DeploymentService.Event.StudyDeploymentsRemoved? = null
-        eventBus.registerHandler( DeploymentService.Event.StudyDeploymentsRemoved::class, this ) { deploymentsRemovedEvent = it }
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentsRemoved::class, this ) { deploymentsRemovedEvent = it }
         eventBus.activateHandlers( this )
         studyService.remove( studyId )
 
@@ -133,7 +133,7 @@ class HostsIntegrationTest
     @Test
     fun remove_study_does_not_trigger_event_when_study_does_not_exist() = runSuspendTest {
         var removedEvent: StudyService.Event.StudyRemoved? = null
-        eventBus.registerHandler( StudyService.Event.StudyRemoved::class, this ) { removedEvent = it }
+        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyRemoved::class, this ) { removedEvent = it }
         eventBus.activateHandlers( this )
         studyService.remove( UUID.randomUUID() )
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
@@ -66,7 +66,8 @@ class HostsIntegrationTest
     @Test
     fun create_study_creates_recruitment() = runSuspendTest {
         var studyCreated: StudyService.Event.StudyCreated? = null
-        eventBus.subscribe( StudyService::class, StudyService.Event.StudyCreated::class ) { studyCreated = it }
+        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyCreated::class, this ) { studyCreated = it }
+        eventBus.activateHandlers( this )
 
         val study = studyService.createStudy( StudyOwner(), "Test" )
         val participants = participantService.getParticipants( study.studyId )
@@ -83,7 +84,8 @@ class HostsIntegrationTest
         studyService.setProtocol( studyId, protocol.getSnapshot() )
 
         var studyGoneLive: StudyService.Event.StudyGoneLive? = null
-        eventBus.subscribe( StudyService::class, StudyService.Event.StudyGoneLive::class ) { studyGoneLive = it }
+        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyGoneLive::class, this ) { studyGoneLive = it }
+        eventBus.activateHandlers( this )
         studyService.goLive( studyId )
         val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
@@ -112,9 +114,10 @@ class HostsIntegrationTest
         val deploymentId = group.studyDeploymentStatus.studyDeploymentId
 
         var studyRemovedEvent: StudyService.Event.StudyRemoved? = null
-        eventBus.subscribe( StudyService::class, StudyService.Event.StudyRemoved::class ) { studyRemovedEvent = it }
+        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyRemoved::class, this ) { studyRemovedEvent = it }
         var deploymentsRemovedEvent: DeploymentService.Event.StudyDeploymentsRemoved? = null
-        eventBus.subscribe( DeploymentService::class, DeploymentService.Event.StudyDeploymentsRemoved::class ) { deploymentsRemovedEvent = it }
+        eventBus.registerHandler( DeploymentService::class, DeploymentService.Event.StudyDeploymentsRemoved::class, this ) { deploymentsRemovedEvent = it }
+        eventBus.activateHandlers( this )
         studyService.remove( studyId )
 
         assertEquals( studyId, studyRemovedEvent?.studyId )
@@ -130,7 +133,8 @@ class HostsIntegrationTest
     @Test
     fun remove_study_does_not_trigger_event_when_study_does_not_exist() = runSuspendTest {
         var removedEvent: StudyService.Event.StudyRemoved? = null
-        eventBus.subscribe( StudyService::class, StudyService.Event.StudyRemoved::class ) { removedEvent = it }
+        eventBus.registerHandler( StudyService::class, StudyService.Event.StudyRemoved::class, this ) { removedEvent = it }
+        eventBus.activateHandlers( this )
         studyService.remove( UUID.randomUUID() )
 
         assertNull( removedEvent )


### PR DESCRIPTION
This decoupling is needed for concrete `EventBus` implementations which need to specify all subscriptions at once, before any events are received. Otherwise, the only way to implement this using the previous abstraction is to keep track of state (all previous `subscribe` calls), and renew a previous subscription each time `subscribe` is called, all the while handling incoming events.

This is messy and undesirable; a better abstraction was needed.

The new `EventBus` abstraction does not assume a one-to-one mapping between a message queue channel and application service. E.g., you could implement two channels per application service, or use one for two services. The consumer API abstracts this 'wiring' away and simply takes any list of event handlers types to the concrete or polymorphic events ([see example in `ParticipationServiceHost`](https://github.com/cph-cachet/carp.core-kotlin/pull/238/files#diff-8809601ca3720c6beb434ab9bafbec21a3608d272911c3fdda51cea0eceea946R37)).

But, a one-to-one mapping is a reasonable convention for a concrete implementation. Therefore, [`ChannelConventionEventBus` implements that convention](https://github.com/cph-cachet/carp.core-kotlin/pull/238/files#diff-b7332627eb310560731ee61196c47bcf66ff4f29844eec86aa66c69411ea1b4b). Extending from it only requires overriding:
- `publishToChannel( channelIdentifier: KClass<TService>, event: TEvent )`
- `subscribeToChannel( channelIdentifier: KClass<*>, handler: suspend (IntegrationEvent<*>) -> Unit )`