### PR TITLE
Battery-aware sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ val phone = Smartphone( "Patient's phone" )
 {
     // Configure device-specific options, e.g., frequency to collect data at.
     defaultSamplingConfiguration {
-        geolocation { interval = TimeSpan.fromMinutes( 15.0 ) }
+        geolocation { granularity = Granularity.Normal }
     }
 }
 protocol.addMasterDevice( phone )

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ val phone = Smartphone( "Patient's phone" )
 {
     // Configure device-specific options, e.g., frequency to collect data at.
     defaultSamplingConfiguration {
-        geolocation { granularity = Granularity.Normal }
+        geolocation { batteryNormal { granularity = Granularity.Balanced } }
     }
 }
 protocol.addMasterDevice( phone )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
@@ -1,16 +1,12 @@
+@file:Suppress( "WildcardImport" )
+
 package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.application.Trilean
 import dk.cachet.carp.common.application.data.CarpDataTypes
 import dk.cachet.carp.common.application.data.DataType
-import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeList
-import dk.cachet.carp.common.application.sampling.Granularity
-import dk.cachet.carp.common.application.sampling.GranularitySamplingConfigurationBuilder
-import dk.cachet.carp.common.application.sampling.GranularitySamplingScheme
-import dk.cachet.carp.common.application.sampling.NoOptionsSamplingScheme
-import dk.cachet.carp.common.application.sampling.SamplingConfiguration
-import dk.cachet.carp.common.application.sampling.SamplingConfigurationMapBuilder
-import dk.cachet.carp.common.application.tasks.TaskDescriptorList
+import dk.cachet.carp.common.application.sampling.*
+import dk.cachet.carp.common.application.tasks.*
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 
@@ -39,7 +35,14 @@ data class Smartphone(
         /**
          *  Geographic location data, representing latitude and longitude within the World Geodetic System 1984.
          */
-        val GEOLOCATION = add( GranularitySamplingScheme( CarpDataTypes.GEOLOCATION, Granularity.Balanced ) )
+        val GEOLOCATION = add(
+            BatteryAwareSamplingScheme(
+                CarpDataTypes.GEOLOCATION,
+                builder = { GranularitySamplingConfigurationBuilder( Granularity.Balanced ) },
+                normal = GranularitySamplingConfiguration( Granularity.Balanced ),
+                low = GranularitySamplingConfiguration( Granularity.Coarse )
+            )
+        )
 
         /**
          * Steps within recorded time intervals as reported by a phone's dedicated hardware sensor.
@@ -87,6 +90,6 @@ class SmartphoneSamplingConfigurationMapBuilder : SamplingConfigurationMapBuilde
     /**
      * Configure sampling configuration for [CarpDataTypes.GEOLOCATION].
      */
-    fun geolocation( builder: GranularitySamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+    fun geolocation( builder: BatteryAwareSamplingConfigurationBuilder<GranularitySamplingConfiguration, GranularitySamplingConfigurationBuilder>.() -> Unit ): SamplingConfiguration =
         addConfiguration( Smartphone.Sensors.GEOLOCATION, builder )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
@@ -35,14 +35,7 @@ data class Smartphone(
         /**
          *  Geographic location data, representing latitude and longitude within the World Geodetic System 1984.
          */
-        val GEOLOCATION = add(
-            BatteryAwareSamplingScheme(
-                CarpDataTypes.GEOLOCATION,
-                builder = { GranularitySamplingConfigurationBuilder( Granularity.Balanced ) },
-                normal = GranularitySamplingConfiguration( Granularity.Balanced ),
-                low = GranularitySamplingConfiguration( Granularity.Coarse )
-            )
-        )
+        val GEOLOCATION = add( AdaptiveGranularitySamplingScheme( CarpDataTypes.GEOLOCATION ) )
 
         /**
          * Steps within recorded time intervals as reported by a phone's dedicated hardware sensor.
@@ -90,6 +83,6 @@ class SmartphoneSamplingConfigurationMapBuilder : SamplingConfigurationMapBuilde
     /**
      * Configure sampling configuration for [CarpDataTypes.GEOLOCATION].
      */
-    fun geolocation( builder: BatteryAwareSamplingConfigurationBuilder<GranularitySamplingConfiguration, GranularitySamplingConfigurationBuilder>.() -> Unit ): SamplingConfiguration =
+    fun geolocation( builder: AdaptiveGranularitySamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
         addConfiguration( Smartphone.Sensors.GEOLOCATION, builder )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
@@ -1,12 +1,12 @@
 package dk.cachet.carp.common.application.devices
 
-import dk.cachet.carp.common.application.TimeSpan
 import dk.cachet.carp.common.application.Trilean
 import dk.cachet.carp.common.application.data.CarpDataTypes
 import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeList
-import dk.cachet.carp.common.application.sampling.IntervalSamplingConfigurationBuilder
-import dk.cachet.carp.common.application.sampling.IntervalSamplingScheme
+import dk.cachet.carp.common.application.sampling.Granularity
+import dk.cachet.carp.common.application.sampling.GranularitySamplingConfigurationBuilder
+import dk.cachet.carp.common.application.sampling.GranularitySamplingScheme
 import dk.cachet.carp.common.application.sampling.NoOptionsSamplingScheme
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.application.sampling.SamplingConfigurationMapBuilder
@@ -39,9 +39,7 @@ data class Smartphone(
         /**
          *  Geographic location data, representing latitude and longitude within the World Geodetic System 1984.
          */
-        val GEOLOCATION = add(
-            IntervalSamplingScheme( CarpDataTypes.GEOLOCATION, TimeSpan.fromMinutes( 1.0 ) )
-        )
+        val GEOLOCATION = add( GranularitySamplingScheme( CarpDataTypes.GEOLOCATION, Granularity.Balanced ) )
 
         /**
          * Steps within recorded time intervals as reported by a phone's dedicated hardware sensor.
@@ -89,6 +87,6 @@ class SmartphoneSamplingConfigurationMapBuilder : SamplingConfigurationMapBuilde
     /**
      * Configure sampling configuration for [CarpDataTypes.GEOLOCATION].
      */
-    fun geolocation( builder: IntervalSamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+    fun geolocation( builder: GranularitySamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
         addConfiguration( Smartphone.Sensors.GEOLOCATION, builder )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/AdaptiveGranularitySampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/AdaptiveGranularitySampling.kt
@@ -1,0 +1,33 @@
+@file:Suppress( "MatchingDeclarationName" )
+
+package dk.cachet.carp.common.application.sampling
+
+import dk.cachet.carp.common.application.data.DataType
+import dk.cachet.carp.common.application.devices.DeviceDescriptor
+
+
+/**
+ * Sampling scheme which provides only indirect control over how data is sampled by specifying a desired level of [Granularity].
+ * The levels of granularity correspond to expected degrees of power consumption.
+ * By default, [Granularity.Balanced] is used; when the battery is low, [Granularity.Coarse]; when battery is critically low, sampling stops.
+ */
+class AdaptiveGranularitySamplingScheme( dataType: DataType ) :
+    BatteryAwareSamplingScheme<GranularitySamplingConfiguration, GranularitySamplingConfigurationBuilder>(
+        dataType,
+        { GranularitySamplingConfigurationBuilder( Granularity.Balanced ) },
+        normal = GranularitySamplingConfiguration( Granularity.Balanced ),
+        low = GranularitySamplingConfiguration( Granularity.Coarse )
+    )
+{
+    override fun isValidBatteryLevelConfiguration( configuration: GranularitySamplingConfiguration ): Boolean = true
+}
+
+/**
+ * A helper class to configure and construct immutable [BatteryAwareSamplingConfiguration] objects
+ * using [GranularitySamplingConfiguration] as part of setting up a [DeviceDescriptor].
+ */
+typealias AdaptiveGranularitySamplingConfigurationBuilder =
+    BatteryAwareSamplingConfigurationBuilder<
+        GranularitySamplingConfiguration,
+        GranularitySamplingConfigurationBuilder
+    >

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt
@@ -10,8 +10,8 @@ import kotlin.reflect.KClass
  * A sampling scheme which changes based on how much battery the device has left.
  */
 abstract class BatteryAwareSamplingScheme<
-    TConfiguration : SamplingConfiguration,
-    TBuilder : SamplingConfigurationBuilder<TConfiguration>
+    TConfig : SamplingConfiguration,
+    TBuilder : SamplingConfigurationBuilder<TConfig>
 >(
     dataType: DataType,
     /**
@@ -21,22 +21,22 @@ abstract class BatteryAwareSamplingScheme<
     /**
      * The default sampling configuration to use when there is plenty of battery left.
      */
-    private val normal: TConfiguration,
+    private val normal: TConfig,
     /**
      * The default sampling configuration to use when the battery is low.
      */
-    private val low: TConfiguration? = null,
+    private val low: TConfig? = null,
     /**
      * The default sampling configuration to use when the battery is critically low.
      * By default, sampling should be disabled at this point.
      */
-    private val critical: TConfiguration? = null
-) : DataTypeSamplingScheme<BatteryAwareSamplingConfigurationBuilder<TConfiguration, TBuilder>>( dataType )
+    private val critical: TConfig? = null
+) : DataTypeSamplingScheme<BatteryAwareSamplingConfigurationBuilder<TConfig, TBuilder>>( dataType )
 {
-    private val configurationKlass: KClass<out TConfiguration> = normal::class
+    private val configurationKlass: KClass<out TConfig> = normal::class
 
 
-    override fun createSamplingConfigurationBuilder(): BatteryAwareSamplingConfigurationBuilder<TConfiguration, TBuilder> =
+    override fun createSamplingConfigurationBuilder(): BatteryAwareSamplingConfigurationBuilder<TConfig, TBuilder> =
         BatteryAwareSamplingConfigurationBuilder( builder, normal, low, critical )
 
     override fun isValid( configuration: SamplingConfiguration ): Boolean
@@ -52,16 +52,16 @@ abstract class BatteryAwareSamplingScheme<
 
         // Verify whether constraints for the battery-level-specific configurations are met.
         @Suppress( "UNCHECKED_CAST" )
-        return isValidBatteryLevelConfiguration( configuration.normal as TConfiguration ) &&
-            ( configuration.low == null || isValidBatteryLevelConfiguration( configuration.low as TConfiguration ) ) &&
-            ( configuration.critical == null || isValidBatteryLevelConfiguration( configuration.critical as TConfiguration ) )
+        return isValidBatteryLevelConfiguration( configuration.normal as TConfig ) &&
+            ( configuration.low == null || isValidBatteryLevelConfiguration( configuration.low as TConfig ) ) &&
+            ( configuration.critical == null || isValidBatteryLevelConfiguration( configuration.critical as TConfig ) )
     }
 
     /**
      * Determines whether the [configuration] assigned to a specific battery level in a [BatteryAwareSamplingConfiguration]
      * is valid for the constraints defined in this sampling scheme.
      */
-    abstract fun isValidBatteryLevelConfiguration( configuration: TConfiguration ): Boolean
+    abstract fun isValidBatteryLevelConfiguration( configuration: TConfig ): Boolean
 }
 
 
@@ -69,19 +69,19 @@ abstract class BatteryAwareSamplingScheme<
  * A sampling configuration which changes based on how much battery the device has left.
  */
 @Serializable
-data class BatteryAwareSamplingConfiguration<TConfiguration : SamplingConfiguration>(
+data class BatteryAwareSamplingConfiguration<TConfig : SamplingConfiguration>(
     /**
      * The sampling configuration to use when there is plenty of battery left.
      */
-    val normal: TConfiguration,
+    val normal: TConfig,
     /**
      * The sampling configuration to use when the battery is low.
      */
-    val low: TConfiguration? = null,
+    val low: TConfig? = null,
     /**
      * The sampling configuration to use when the battery is critically low.
      */
-    val critical: TConfiguration? = null
+    val critical: TConfig? = null
 ) : SamplingConfiguration
 
 
@@ -90,14 +90,14 @@ data class BatteryAwareSamplingConfiguration<TConfiguration : SamplingConfigurat
  * as part of setting up a [DeviceDescriptor].
  */
 class BatteryAwareSamplingConfigurationBuilder<
-    TConfiguration : SamplingConfiguration,
-    TBuilder : SamplingConfigurationBuilder<TConfiguration>
+    TConfig : SamplingConfiguration,
+    TBuilder : SamplingConfigurationBuilder<TConfig>
 >(
     private val createBuilder: () -> TBuilder,
-    private var normal: TConfiguration,
-    private var low: TConfiguration?,
-    private var critical: TConfiguration?
-) : SamplingConfigurationBuilder<BatteryAwareSamplingConfiguration<TConfiguration>>
+    private var normal: TConfig,
+    private var low: TConfig?,
+    private var critical: TConfig?
+) : SamplingConfigurationBuilder<BatteryAwareSamplingConfiguration<TConfig>>
 {
     /**
      * The sampling configuration to use when there is plenty of battery left.
@@ -130,6 +130,6 @@ class BatteryAwareSamplingConfigurationBuilder<
     private fun createConfiguration( builder: TBuilder.() -> Unit ) =
         createBuilder().apply( builder ).build()
 
-    override fun build(): BatteryAwareSamplingConfiguration<TConfiguration> =
+    override fun build(): BatteryAwareSamplingConfiguration<TConfig> =
         BatteryAwareSamplingConfiguration( normal, low, critical )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt
@@ -1,0 +1,117 @@
+package dk.cachet.carp.common.application.sampling
+
+import dk.cachet.carp.common.application.data.DataType
+import dk.cachet.carp.common.application.devices.DeviceDescriptor
+import kotlinx.serialization.Serializable
+import kotlin.reflect.KClass
+
+
+/**
+ * A sampling scheme which changes based on how much battery the device has left.
+ */
+class BatteryAwareSamplingScheme<
+    TConfiguration : SamplingConfiguration,
+    TBuilder : SamplingConfigurationBuilder<TConfiguration>
+>(
+    dataType: DataType,
+    /**
+     * The builder to constructs [SamplingConfiguration]s when overriding configurations for different battery levels.
+     */
+    private val builder: () -> TBuilder,
+    /**
+     * The default sampling configuration to use when there is plenty of battery left.
+     */
+    private val normal: TConfiguration,
+    /**
+     * The default sampling configuration to use when the battery is low.
+     */
+    private val low: TConfiguration? = null,
+    /**
+     * The default sampling configuration to use when the battery is critically low.
+     * By default, sampling should be disabled at this point.
+     */
+    private val critical: TConfiguration? = null
+) : DataTypeSamplingScheme<BatteryAwareSamplingConfigurationBuilder<TConfiguration, TBuilder>>( dataType )
+{
+    private val configurationKlass: KClass<out TConfiguration> = normal::class
+
+
+    override fun createSamplingConfigurationBuilder(): BatteryAwareSamplingConfigurationBuilder<TConfiguration, TBuilder> =
+        BatteryAwareSamplingConfigurationBuilder( builder, normal, low, critical )
+
+    override fun isValid( configuration: SamplingConfiguration ): Boolean =
+        configuration is BatteryAwareSamplingConfiguration<*> &&
+        configurationKlass.isInstance( configuration.normal ) &&
+        ( configuration.low == null || configurationKlass.isInstance( configuration.low ) ) &&
+        ( configuration.critical == null || configurationKlass.isInstance( configuration.critical ) )
+}
+
+
+/**
+ * A sampling configuration which changes based on how much battery the device has left.
+ */
+@Serializable
+data class BatteryAwareSamplingConfiguration<TConfiguration : SamplingConfiguration>(
+    /**
+     * The sampling configuration to use when there is plenty of battery left.
+     */
+    val normal: TConfiguration,
+    /**
+     * The sampling configuration to use when the battery is low.
+     */
+    val low: TConfiguration? = null,
+    /**
+     * The sampling configuration to use when the battery is critically low.
+     */
+    val critical: TConfiguration? = null
+) : SamplingConfiguration
+
+
+/**
+ * A helper class to configure and construct immutable [BatteryAwareSamplingConfiguration] classes
+ * as part of setting up a [DeviceDescriptor].
+ */
+class BatteryAwareSamplingConfigurationBuilder<
+    TConfiguration : SamplingConfiguration,
+    TBuilder : SamplingConfigurationBuilder<TConfiguration>
+>(
+    private val createBuilder: () -> TBuilder,
+    private var normal: TConfiguration,
+    private var low: TConfiguration?,
+    private var critical: TConfiguration?
+) : SamplingConfigurationBuilder<BatteryAwareSamplingConfiguration<TConfiguration>>
+{
+    /**
+     * The sampling configuration to use when there is plenty of battery left.
+     */
+    fun batteryNormal( builder: TBuilder.() -> Unit ) =
+        createConfiguration( builder ).let { normal = it }
+
+    /**
+     * The sampling configuration to use when the battery is low.
+     */
+    fun batteryLow( builder: TBuilder.() -> Unit ) =
+        createConfiguration( builder ).let { low = it }
+
+    /**
+     * The sampling configuration to use when the battery is critically low.
+     */
+    fun batteryCritical( builder: TBuilder.() -> Unit ) =
+        createConfiguration( builder ).let { critical = it }
+
+    /**
+     * Apply the same sampling configuration for all battery levels: normal, low, and critical.
+     */
+    fun allBatteryLevels( builder: TBuilder.() -> Unit ) =
+        createConfiguration( builder ).let {
+            normal = it
+            low = it
+            critical = it
+        }
+
+    private fun createConfiguration( builder: TBuilder.() -> Unit ) =
+        createBuilder().apply( builder ).build()
+
+    override fun build(): BatteryAwareSamplingConfiguration<TConfiguration> =
+        BatteryAwareSamplingConfiguration( normal, low, critical )
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/DataTypeSamplingScheme.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/DataTypeSamplingScheme.kt
@@ -8,7 +8,7 @@ import dk.cachet.carp.common.application.tasks.Measure
 /**
  * Specifies the sampling scheme for a [DataType], including possible options, defaults, and constraints.
  */
-abstract class DataTypeSamplingScheme<TSamplingConfigurationBuilder : SamplingConfigurationBuilder<*>>(
+abstract class DataTypeSamplingScheme<TConfigBuilder : SamplingConfigurationBuilder<*>>(
     /**
      * The [DataType] this sampling scheme relates to.
      */
@@ -18,14 +18,14 @@ abstract class DataTypeSamplingScheme<TSamplingConfigurationBuilder : SamplingCo
     /**
      * Create a [SamplingConfigurationBuilder] to help construct a matching [SamplingConfiguration] for [type].
      */
-    protected abstract fun createSamplingConfigurationBuilder(): TSamplingConfigurationBuilder
+    protected abstract fun createSamplingConfigurationBuilder(): TConfigBuilder
 
     /**
      * Create a [SamplingConfiguration] which can be used to configure measures of [type].
      *
      * @throws IllegalArgumentException when a sampling configuration is built which breaks constraints specified in this sampling scheme.
      */
-    fun samplingConfiguration( builder: TSamplingConfigurationBuilder.() -> Unit ): SamplingConfiguration =
+    fun samplingConfiguration( builder: TConfigBuilder.() -> Unit ): SamplingConfiguration =
         createSamplingConfigurationBuilder().apply( builder ).build( this )
 
     /**
@@ -34,7 +34,7 @@ abstract class DataTypeSamplingScheme<TSamplingConfigurationBuilder : SamplingCo
      *
      * @throws IllegalArgumentException when a sampling configuration is built which breaks constraints specified in this sampling scheme.
      */
-    fun measure( samplingConfigurationBuilder: (TSamplingConfigurationBuilder.() -> Unit)? = null ): Measure =
+    fun measure( samplingConfigurationBuilder: (TConfigBuilder.() -> Unit)? = null ): Measure =
         Measure( type, samplingConfigurationBuilder?.let { samplingConfiguration( it ) } )
 
     /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt
@@ -1,0 +1,61 @@
+package dk.cachet.carp.common.application.sampling
+
+import dk.cachet.carp.common.application.data.DataType
+import dk.cachet.carp.common.application.devices.DeviceDescriptor
+import kotlinx.serialization.Serializable
+
+
+/**
+ * Sampling scheme which provides only indirect control over how data is sampled by specifying a desired level of [Granularity].
+ * The levels of granularity correspond to expected degrees of power consumption.
+ */
+class GranularitySamplingScheme( dataType: DataType, val defaultGranularity: Granularity ) :
+    DataTypeSamplingScheme<GranularitySamplingConfigurationBuilder>( dataType )
+{
+    override fun createSamplingConfigurationBuilder(): GranularitySamplingConfigurationBuilder =
+        GranularitySamplingConfigurationBuilder( defaultGranularity )
+
+    override fun isValid( configuration: SamplingConfiguration ) = configuration is GranularitySamplingConfiguration
+}
+
+
+/**
+ * The level of detail a data stream should be sampled at, corresponding to expected degrees of power consumption.
+ */
+@Serializable
+enum class Granularity
+{
+    /**
+     * Consumes a lot of power. Only use for short periods of time.
+     */
+    Detailed,
+
+    /**
+     * Balanced power consumption which aims not to require more than one recharge per day.
+     */
+    Balanced,
+
+    /**
+     * Minimal impact on power consumption, but only provides a very coarse level of detail.
+     */
+    Coarse
+}
+
+
+/**
+ * A [SamplingConfiguration] which allows specifying a desired level of [granularity],
+ * corresponding to expected degrees of power consumption.
+ */
+@Serializable
+data class GranularitySamplingConfiguration( val granularity: Granularity ) : SamplingConfiguration
+
+
+/**
+  * A helper class to configure and construct immutable [GranularitySamplingConfiguration] classes
+ * as part of setting up a [DeviceDescriptor].
+ */
+class GranularitySamplingConfigurationBuilder( var granularity: Granularity ) :
+    SamplingConfigurationBuilder<GranularitySamplingConfiguration>
+{
+    override fun build(): GranularitySamplingConfiguration = GranularitySamplingConfiguration( granularity )
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt
@@ -26,12 +26,12 @@ class GranularitySamplingScheme( dataType: DataType, val defaultGranularity: Gra
 enum class Granularity
 {
     /**
-     * Consumes a lot of power. Only use for short periods of time.
+     * Consumes a lot of power. Only use for short periods of time or when power consumption is not an issue.
      */
     Detailed,
 
     /**
-     * Balanced power consumption which aims not to require more than one recharge per day.
+     * Balanced power consumption. For battery-based devices this aims not to require more than one recharge per day.
      */
     Balanced,
 
@@ -51,7 +51,7 @@ data class GranularitySamplingConfiguration( val granularity: Granularity ) : Sa
 
 
 /**
-  * A helper class to configure and construct immutable [GranularitySamplingConfiguration] classes
+ * A helper class to configure and construct immutable [GranularitySamplingConfiguration] objects
  * as part of setting up a [DeviceDescriptor].
  */
 class GranularitySamplingConfigurationBuilder( var granularity: Granularity ) :

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt
@@ -27,7 +27,7 @@ data class IntervalSamplingConfiguration( val interval: TimeSpan ) : SamplingCon
 
 
 /**
- * A helper class to configure and construct immutable [IntervalSamplingConfiguration] classes
+ * A helper class to configure and construct immutable [IntervalSamplingConfiguration] objects
  * as part of setting up a [DeviceDescriptor].
  */
 class IntervalSamplingConfigurationBuilder( var interval: TimeSpan ) :

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/SamplingConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/SamplingConfiguration.kt
@@ -23,7 +23,7 @@ interface SamplingConfiguration
  * as part of setting up a [DeviceDescriptor].
 */
 @DeviceDescriptorBuilderDsl
-interface SamplingConfigurationBuilder<TSamplingConfiguration : SamplingConfiguration>
+interface SamplingConfigurationBuilder<TConfig : SamplingConfiguration>
 {
     /**
      * Build the immutable [SamplingConfiguration] using the current configuration of this [SamplingConfigurationBuilder]
@@ -31,7 +31,7 @@ interface SamplingConfigurationBuilder<TSamplingConfiguration : SamplingConfigur
      *
      * @throws IllegalArgumentException when the constructed sampling configuration breaks constraints specified in [samplingScheme].
      */
-    fun build( samplingScheme: DataTypeSamplingScheme<*> ): TSamplingConfiguration
+    fun build( samplingScheme: DataTypeSamplingScheme<*> ): TConfig
     {
         val configuration = build()
         require( samplingScheme.isValid( configuration ) )
@@ -43,7 +43,7 @@ interface SamplingConfigurationBuilder<TSamplingConfiguration : SamplingConfigur
     /**
      * Build the immutable [SamplingConfiguration] using the current configuration of this [SamplingConfigurationBuilder].
      */
-    fun build(): TSamplingConfiguration
+    fun build(): TConfig
 }
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
@@ -86,6 +86,7 @@ val COMMON_SERIAL_MODULE = SerializersModule {
     // `sampling` namespace.
     polymorphic( SamplingConfiguration::class )
     {
+        subclass( GranularitySamplingConfiguration::class )
         subclass( IntervalSamplingConfiguration::class )
         subclass( NoOptionsSamplingConfiguration::class, NoOptionsSamplingConfiguration.serializer() )
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
@@ -10,6 +10,8 @@ import dk.cachet.carp.common.application.sampling.*
 import dk.cachet.carp.common.application.tasks.*
 import dk.cachet.carp.common.application.triggers.*
 import dk.cachet.carp.common.application.users.*
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.*
 
@@ -86,6 +88,12 @@ val COMMON_SERIAL_MODULE = SerializersModule {
     // `sampling` namespace.
     polymorphic( SamplingConfiguration::class )
     {
+        @Suppress( "UNCHECKED_CAST" )
+        subclass(
+            BatteryAwareSamplingConfiguration::class,
+            BatteryAwareSamplingConfiguration.serializer( PolymorphicSerializer( SamplingConfiguration::class ) )
+                as KSerializer<BatteryAwareSamplingConfiguration<*>>
+        )
         subclass( GranularitySamplingConfiguration::class )
         subclass( IntervalSamplingConfiguration::class )
         subclass( NoOptionsSamplingConfiguration::class, NoOptionsSamplingConfiguration.serializer() )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubSamplingConfiguration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubSamplingConfiguration.kt
@@ -1,8 +1,16 @@
 package dk.cachet.carp.common.infrastructure.test
 
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
+import dk.cachet.carp.common.application.sampling.SamplingConfigurationBuilder
 import kotlinx.serialization.Serializable
 
 
 @Serializable
 data class StubSamplingConfiguration( val configuration: String ) : SamplingConfiguration
+
+
+class StubSamplingConfigurationBuilder( var configuration: String ) :
+    SamplingConfigurationBuilder<StubSamplingConfiguration>
+{
+    override fun build(): StubSamplingConfiguration = StubSamplingConfiguration( configuration )
+}

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/SmartphoneTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/SmartphoneTest.kt
@@ -14,20 +14,19 @@ class SmartphoneTest
     @Test
     fun builder_sets_sampling_configuration()
     {
-        val configuredGranularity = Granularity.Balanced
+        val expectedGranularity = Granularity.Balanced
 
         val phone = Smartphone( "Test" )
         {
             defaultSamplingConfiguration {
-                geolocation { allBatteryLevels { granularity = configuredGranularity } }
+                geolocation { allBatteryLevels { granularity = expectedGranularity } }
             }
         }
 
         val type = Smartphone.Sensors.GEOLOCATION.type
         val configuration = phone.defaultSamplingConfiguration[ type ] as? BatteryAwareSamplingConfiguration<*>
         assertNotNull( configuration )
-        val granularityConfiguration = configuration.normal as GranularitySamplingConfiguration
-        assertNotNull( granularityConfiguration )
-        assertEquals( configuredGranularity, granularityConfiguration.granularity )
+        val configuredGranularity = configuration.normal as GranularitySamplingConfiguration
+        assertEquals( expectedGranularity, configuredGranularity.granularity )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/SmartphoneTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/SmartphoneTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.application.devices
 
+import dk.cachet.carp.common.application.sampling.BatteryAwareSamplingConfiguration
 import dk.cachet.carp.common.application.sampling.Granularity
 import dk.cachet.carp.common.application.sampling.GranularitySamplingConfiguration
 import kotlin.test.*
@@ -18,12 +19,15 @@ class SmartphoneTest
         val phone = Smartphone( "Test" )
         {
             defaultSamplingConfiguration {
-                geolocation { granularity = configuredGranularity }
+                geolocation { allBatteryLevels { granularity = configuredGranularity } }
             }
         }
 
         val type = Smartphone.Sensors.GEOLOCATION.type
-        val configuration = phone.defaultSamplingConfiguration[ type ] as GranularitySamplingConfiguration
-        assertEquals( configuredGranularity, configuration.granularity )
+        val configuration = phone.defaultSamplingConfiguration[ type ] as? BatteryAwareSamplingConfiguration<*>
+        assertNotNull( configuration )
+        val granularityConfiguration = configuration.normal as GranularitySamplingConfiguration
+        assertNotNull( granularityConfiguration )
+        assertEquals( configuredGranularity, granularityConfiguration.granularity )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/SmartphoneTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/SmartphoneTest.kt
@@ -1,7 +1,7 @@
 package dk.cachet.carp.common.application.devices
 
-import dk.cachet.carp.common.application.TimeSpan
-import dk.cachet.carp.common.application.sampling.IntervalSamplingConfiguration
+import dk.cachet.carp.common.application.sampling.Granularity
+import dk.cachet.carp.common.application.sampling.GranularitySamplingConfiguration
 import kotlin.test.*
 
 
@@ -13,17 +13,17 @@ class SmartphoneTest
     @Test
     fun builder_sets_sampling_configuration()
     {
-        val measureInterval = TimeSpan.fromMinutes( 15.0 )
+        val configuredGranularity = Granularity.Balanced
 
         val phone = Smartphone( "Test" )
         {
             defaultSamplingConfiguration {
-                geolocation { interval = measureInterval }
+                geolocation { granularity = configuredGranularity }
             }
         }
 
         val type = Smartphone.Sensors.GEOLOCATION.type
-        val configuration = phone.defaultSamplingConfiguration[ type ] as IntervalSamplingConfiguration
-        assertEquals( measureInterval, configuration.interval )
+        val configuration = phone.defaultSamplingConfiguration[ type ] as GranularitySamplingConfiguration
+        assertEquals( configuredGranularity, configuration.granularity )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSamplingTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSamplingTest.kt
@@ -1,0 +1,118 @@
+@file:Suppress( "MatchingDeclarationName" )
+
+package dk.cachet.carp.common.application.sampling
+
+import dk.cachet.carp.common.application.TimeSpan
+import dk.cachet.carp.common.infrastructure.test.STUB_DATA_TYPE
+import kotlin.test.*
+
+
+/**
+ * Tests for [BatteryAwareSamplingScheme].
+ */
+class BatteryAwareSamplingSchemeTest
+{
+    @Test
+    fun isValid_true_for_correct_sampling_configuration_types()
+    {
+        val scheme = BatteryAwareSamplingScheme(
+            STUB_DATA_TYPE,
+            builder = { GranularitySamplingConfigurationBuilder( Granularity.Balanced ) },
+            normal = GranularitySamplingConfiguration( Granularity.Balanced )
+        )
+
+        val validConfiguration = BatteryAwareSamplingConfiguration(
+            normal = GranularitySamplingConfiguration( Granularity.Balanced ),
+            low = GranularitySamplingConfiguration( Granularity.Coarse ),
+            critical = GranularitySamplingConfiguration( Granularity.Coarse )
+        )
+        assertTrue( scheme.isValid( validConfiguration ) )
+    }
+
+    @Test
+    fun isValid_true_when_some_configurations_are_not_set()
+    {
+        val scheme = BatteryAwareSamplingScheme(
+            STUB_DATA_TYPE,
+            builder = { GranularitySamplingConfigurationBuilder( Granularity.Balanced ) },
+            normal = GranularitySamplingConfiguration( Granularity.Balanced )
+        )
+
+        val validConfiguration = BatteryAwareSamplingConfiguration(
+            normal = GranularitySamplingConfiguration( Granularity.Balanced )
+        )
+        assertTrue( scheme.isValid( validConfiguration ) )
+    }
+
+    @Test
+    fun isValid_false_when_incorrect_sampling_configuration_type_is_included()
+    {
+        val scheme = BatteryAwareSamplingScheme(
+            STUB_DATA_TYPE,
+            builder = { GranularitySamplingConfigurationBuilder( Granularity.Balanced ) },
+            normal = GranularitySamplingConfiguration( Granularity.Balanced )
+        )
+
+        val invalidConfiguration = BatteryAwareSamplingConfiguration(
+            normal = GranularitySamplingConfiguration( Granularity.Balanced ),
+            low = IntervalSamplingConfiguration( TimeSpan.fromMinutes( 1.0 ) ),
+            critical = GranularitySamplingConfiguration( Granularity.Coarse )
+        )
+        assertFalse( scheme.isValid( invalidConfiguration ) )
+    }
+
+    @Test
+    fun samplingConfiguration_succeeds()
+    {
+        val scheme = BatteryAwareSamplingScheme(
+            STUB_DATA_TYPE,
+            builder = { GranularitySamplingConfigurationBuilder( Granularity.Balanced ) },
+            normal = GranularitySamplingConfiguration( Granularity.Balanced )
+        )
+
+        val expectedGranularity = Granularity.Coarse
+        val expected = GranularitySamplingConfiguration( expectedGranularity )
+        assertBatteryAwareSamplingConfiguration( expected, expected, expected )
+        {
+            scheme.samplingConfiguration {
+                batteryNormal { granularity = expectedGranularity }
+                batteryLow { granularity = expectedGranularity }
+                batteryCritical { granularity = expectedGranularity }
+            }
+        }
+    }
+
+    @Test
+    fun samplingConfiguration_allBatteryLevels_succeeds()
+    {
+        val scheme = BatteryAwareSamplingScheme(
+            STUB_DATA_TYPE,
+            builder = { GranularitySamplingConfigurationBuilder( Granularity.Balanced ) },
+            normal = GranularitySamplingConfiguration( Granularity.Balanced )
+        )
+
+        val expectedGranularity = Granularity.Coarse
+        val expected = GranularitySamplingConfiguration( expectedGranularity )
+        assertBatteryAwareSamplingConfiguration( expected, expected, expected ) {
+            scheme.samplingConfiguration { allBatteryLevels { granularity = expectedGranularity } }
+        }
+    }
+
+    private fun assertBatteryAwareSamplingConfiguration(
+        expectedNormal: SamplingConfiguration,
+        expectedLow: SamplingConfiguration,
+        expectedCritical: SamplingConfiguration,
+        createActualConfiguration: () -> SamplingConfiguration
+    )
+    {
+        val actual = createActualConfiguration()
+
+        assertTrue( actual is BatteryAwareSamplingConfiguration<*> )
+        val normal = actual.normal
+        val low = actual.low
+        val critical = actual.critical
+        assertEquals( expectedNormal, normal )
+        assertEquals( expectedLow, low )
+        assertEquals( expectedCritical, critical )
+    }
+}

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
@@ -71,6 +71,7 @@ private val commonInstances = listOf(
     MACAddressDeviceRegistration( MACAddress( "00-00-00-00-00-00" ) ),
 
     // `sampling` namespace.
+    BatteryAwareSamplingConfiguration( GranularitySamplingConfiguration( Granularity.Balanced ) ),
     GranularitySamplingConfiguration( Granularity.Balanced ),
     IntervalSamplingConfiguration( TimeSpan.fromMilliseconds( 1000.0 ) ),
     NoOptionsSamplingConfiguration,
@@ -135,5 +136,17 @@ class SerializationTest : ConcreteTypesSerializationTest(
         val serialized = json.encodeToString( dataSerializer, data )
         val parsed = json.decodeFromString( dataSerializer, serialized )
         assertEquals( data, parsed )
+    }
+
+    @Test
+    fun can_serialize_polymorphic_BatteryAwareSamplingConfiguration()
+    {
+        val configuration: BatteryAwareSamplingConfiguration<GranularitySamplingConfiguration> =
+            BatteryAwareSamplingConfiguration( GranularitySamplingConfiguration( Granularity.Balanced ) )
+        val serializer = PolymorphicSerializer( SamplingConfiguration::class )
+
+        val serialized = json.encodeToString( serializer, configuration )
+        val parsed = json.decodeFromString( serializer, serialized )
+        assertEquals( configuration, parsed )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
@@ -7,13 +7,9 @@ import dk.cachet.carp.common.application.data.*
 import dk.cachet.carp.common.application.data.input.*
 import dk.cachet.carp.common.application.data.input.elements.*
 import dk.cachet.carp.common.application.devices.*
-import dk.cachet.carp.common.application.sampling.IntervalSamplingConfiguration
-import dk.cachet.carp.common.application.sampling.NoOptionsSamplingConfiguration
-import dk.cachet.carp.common.application.tasks.BackgroundTask
-import dk.cachet.carp.common.application.tasks.CustomProtocolTask
-import dk.cachet.carp.common.application.triggers.ElapsedTimeTrigger
-import dk.cachet.carp.common.application.triggers.ManualTrigger
-import dk.cachet.carp.common.application.triggers.ScheduledTrigger
+import dk.cachet.carp.common.application.sampling.*
+import dk.cachet.carp.common.application.tasks.*
+import dk.cachet.carp.common.application.triggers.*
 import dk.cachet.carp.common.application.users.*
 import dk.cachet.carp.common.infrastructure.test.*
 import dk.cachet.carp.test.serialization.ConcreteTypesSerializationTest
@@ -75,6 +71,7 @@ private val commonInstances = listOf(
     MACAddressDeviceRegistration( MACAddress( "00-00-00-00-00-00" ) ),
 
     // `sampling` namespace.
+    GranularitySamplingConfiguration( Granularity.Balanced ),
     IntervalSamplingConfiguration( TimeSpan.fromMilliseconds( 1000.0 ) ),
     NoOptionsSamplingConfiguration,
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
@@ -1,8 +1,8 @@
 package dk.cachet.carp.protocols
 
-import dk.cachet.carp.common.application.TimeSpan
 import dk.cachet.carp.common.application.devices.CustomProtocolDevice
 import dk.cachet.carp.common.application.devices.Smartphone
+import dk.cachet.carp.common.application.sampling.Granularity
 import dk.cachet.carp.common.application.tasks.CustomProtocolTask
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.protocols.domain.ProtocolOwner
@@ -27,7 +27,7 @@ class ProtocolsCodeSamples
         {
             // Configure device-specific options, e.g., frequency to collect data at.
             defaultSamplingConfiguration {
-                geolocation { interval = TimeSpan.fromMinutes( 15.0 ) }
+                geolocation { granularity = Granularity.Balanced }
             }
         }
         protocol.addMasterDevice( phone )

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
@@ -27,7 +27,7 @@ class ProtocolsCodeSamples
         {
             // Configure device-specific options, e.g., frequency to collect data at.
             defaultSamplingConfiguration {
-                geolocation { granularity = Granularity.Balanced }
+                geolocation { batteryNormal { granularity = Granularity.Balanced } }
             }
         }
         protocol.addMasterDevice( phone )

--- a/detekt.yml
+++ b/detekt.yml
@@ -85,6 +85,7 @@ verify-implementation:
     assumeImmutable: [
       'dk.cachet.carp.common.application.DateTime',
       'dk.cachet.carp.common.application.data.input.CustomInput.T',
+      'dk.cachet.carp.common.application.sampling.BatteryAwareSamplingConfiguration.TConfiguration',
       'kotlinx.serialization.json.Json'
     ]
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -85,7 +85,7 @@ verify-implementation:
     assumeImmutable: [
       'dk.cachet.carp.common.application.DateTime',
       'dk.cachet.carp.common.application.data.input.CustomInput.T',
-      'dk.cachet.carp.common.application.sampling.BatteryAwareSamplingConfiguration.TConfiguration',
+      'dk.cachet.carp.common.application.sampling.BatteryAwareSamplingConfiguration.TConfig',
       'kotlinx.serialization.json.Json'
     ]
 

--- a/docs/carp-common.md
+++ b/docs/carp-common.md
@@ -29,12 +29,18 @@ All of the built-in data types belong to the namespace: **dk.cachet.carp**.
 
 ### Sampling schemes
 
-| Class | Description |
-| --- | --- |
-| [BatteryAwareSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt) | Different sampling configuration depending on how much battery is left.|
-| [GranularitySampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt) | Specify a desired level of granularity, corresponding to expected degrees of power consumption.|
-| [IntervalSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt) | Specify a time interval in between subsequent measurements. |
-| [NoOptionsSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/NoOptionsSampling.kt) | Does not allow any sampling configuration. |
+Supports specifying the sampling scheme for a [`DataType`](#data-types), including possible options, defaults, and constraints.
+
+Some sampling schemes support specifying a different sampling configuration depending on how much battery is left,
+indicated by the "Battery-aware" column.
+These extend from [BatteryAwareSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt).
+
+| Class | Battery-aware | Description |
+| --- | :---: | --- |
+| [AdaptiveGranularitySampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/AdaptiveGranularitySampling.kt) | Yes | Specify a desired level of granularity at which to measure depending on the battery level. |
+| [GranularitySampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt) | | Specify a desired level of granularity, corresponding to expected degrees of power consumption. |
+| [IntervalSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt) | | Specify a time interval in between subsequent measurements. |
+| [NoOptionsSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/NoOptionsSampling.kt) | | Does not allow any sampling configuration. |
 
 ### Tasks
 

--- a/docs/carp-common.md
+++ b/docs/carp-common.md
@@ -31,6 +31,7 @@ All of the built-in data types belong to the namespace: **dk.cachet.carp**.
 
 | Class | Description |
 | --- | --- |
+| [BatteryAwareSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt) | Different sampling configuration depending on how much battery is left.|
 | [GranularitySampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt) | Specify a desired level of granularity, corresponding to expected degrees of power consumption.|
 | [IntervalSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt) | Specify a time interval in between subsequent measurements. |
 | [NoOptionsSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/NoOptionsSampling.kt) | Does not allow any sampling configuration. |

--- a/docs/carp-common.md
+++ b/docs/carp-common.md
@@ -31,6 +31,7 @@ All of the built-in data types belong to the namespace: **dk.cachet.carp**.
 
 | Class | Description |
 | --- | --- |
+| [GranularitySampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt) | Specify a desired level of granularity, corresponding to expected degrees of power consumption.|
 | [IntervalSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt) | Specify a time interval in between subsequent measurements. |
 | [NoOptionsSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/NoOptionsSampling.kt) | Does not allow any sampling configuration. |
 


### PR DESCRIPTION
I decided to implement battery-aware sampling configurations as a specialization of `DataTypeSamplingScheme` (it is thus its own 'type' of configuration), as opposed to specifying multiple default sampling configurations for all data types (for different battery levels) on a device as we originally considered.

The reasoning is:

- Not all data streams can be made meaningfully battery-aware. And, not all devices even care about optimizing battery life.
- It resolves the question which sampling configuration wins out when a custom configuration is passed for `Measure`. E.g., suppose the battery is low, thus a 'low' sampling configuration is used for geolocation. But, now a `Measure` is started which specifies a custom configuration; which configuration should be used, the 'low' one or the custom one? This choice is now delegated to the researcher configuring the protocol. Since the expected configuration in this case is battery-aware, so is the configuration which needs to be passed to `Measure`. The researcher can choose to only set one battery-level, or all in case a full override is desired.

After some consideration, I opted for adding both a non-battery-aware `GranularitySampling` and `AdaptiveGranularitySampling` which is battery-aware. The codebase is more consistent this way, and the API for developers is clearer.

Whether or not the intermediate `BatteryAwareSampling` abstraction will be reused in other specializations remains to be seen, but conceptually it seems to make sense. With minimal amount of code any sampling scheme can now be made 'battery-aware'.