### PR TITLE
Participant data race condition when deploying participant group

### DIFF
--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
@@ -18,6 +18,14 @@ interface ParticipationService : ApplicationService<ParticipationService, Partic
 {
     @Serializable
     sealed class Event : IntegrationEvent<ParticipationService>()
+    {
+        @Serializable
+        data class ParticipantDataSet(
+            val studyDeploymentId: UUID,
+            val inputDataType: InputDataType,
+            val data: Data?
+        ) : Event()
+    }
 
 
     /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHost.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHost.kt
@@ -112,8 +112,12 @@ class ParticipationServiceHost(
     override suspend fun setParticipantData( studyDeploymentId: UUID, inputDataType: InputDataType, data: Data? ): ParticipantData
     {
         val group = participationRepository.getParticipantGroupOrThrowBy( studyDeploymentId )
-        group.setData( participantDataInputTypes, inputDataType, data )
-        participationRepository.putParticipantGroup( group )
+        val isSet = group.setData( participantDataInputTypes, inputDataType, data )
+        if ( isSet )
+        {
+            participationRepository.putParticipantGroup( group )
+            eventBus.publish( ParticipationService.Event.ParticipantDataSet( studyDeploymentId, inputDataType, data ) )
+        }
 
         return ParticipantData( group.studyDeploymentId, group.data.toMap() )
     }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroup.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroup.kt
@@ -184,15 +184,17 @@ class ParticipantGroup private constructor(
      * @throws IllegalArgumentException when:
      *   - [inputDataType] is not configured as expected participant data
      *   - [data] is invalid data for [inputDataType]
+     * @return True when data changed; false when data was already set.
      */
-    fun setData( registeredInputDataTypes: InputDataTypeList, inputDataType: InputDataType, data: Data? )
+    fun setData( registeredInputDataTypes: InputDataTypeList, inputDataType: InputDataType, data: Data? ): Boolean
     {
         require( expectedData.isValidParticipantData( registeredInputDataTypes, inputDataType, data ) )
             { "The input data type is not expected or invalid data is passed." }
 
         val prevData = _data.put( inputDataType, data )
 
-        if ( prevData != data ) event( Event.DataSet( inputDataType, data ) )
+        return ( prevData != data )
+            .eventIf( true ) { Event.DataSet( inputDataType, data ) }
     }
 
     /**

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroupTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroupTest.kt
@@ -212,8 +212,31 @@ class ParticipantGroupTest
 
         val group = createParticipantGroup( protocol )
 
-        group.setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
+        val isSet = group.setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
+        assertTrue( isSet )
         assertEquals( Sex.Male, group.data[ CarpInputDataTypes.SEX ] )
+        assertEquals(
+            ParticipantGroup.Event.DataSet( CarpInputDataTypes.SEX, Sex.Male ),
+            group.consumeEvents().filterIsInstance<ParticipantGroup.Event.DataSet>().singleOrNull()
+        )
+    }
+
+    @Test
+    fun setData_returns_false_when_data_already_set()
+    {
+        val protocol: StudyProtocol = createSingleMasterDeviceProtocol()
+        protocol.addExpectedParticipantData( ParticipantAttribute.DefaultParticipantAttribute( CarpInputDataTypes.SEX ) )
+
+        val group = createParticipantGroup( protocol )
+        group.setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
+        group.consumeEvents()
+
+        val isSet = group.setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
+        assertFalse( isSet )
+        assertEquals(
+            0,
+            group.consumeEvents().filterIsInstance<ParticipantGroup.Event.DataSet>().count()
+        )
     }
 
     @Test

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/ParticipantRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/ParticipantRepository.kt
@@ -4,7 +4,7 @@ import dk.cachet.carp.common.application.UUID
 
 
 /**
- * Store [Participant] instances, linked to study IDs.
+ * Store participant recruitment and deloyment data, linked to study IDs.
  */
 interface ParticipantRepository
 {
@@ -19,6 +19,12 @@ interface ParticipantRepository
      * Returns the [Recruitment] for the specified [studyId], or null when no recruitment is found.
      */
     suspend fun getRecruitment( studyId: UUID ): Recruitment?
+
+    /**
+     * Returns the [Recruitment] which contains a participation with the specified [studyDeploymentId],
+     * or null when no such recruitment is found.
+     */
+    suspend fun getRecruitmentWithStudyDeploymentId( studyDeploymentId: UUID ): Recruitment?
 
     /**
      * Update a [Recruitment] which is already stored in this repository.

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
@@ -2,15 +2,19 @@ package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.data.Data
+import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.users.EmailAccountIdentity
 import dk.cachet.carp.common.domain.AggregateRoot
 import dk.cachet.carp.common.domain.DomainEvent
+import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.deployments.application.users.ParticipantInvitation
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.deployments.application.throwIfInvalid
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.studies.application.users.AssignParticipantDevices
 import dk.cachet.carp.studies.application.users.Participant
+import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
 import dk.cachet.carp.studies.application.users.participantIds
 
 
@@ -146,7 +150,6 @@ class Recruitment( val studyId: UUID ) :
 
     /**
      * Per study deployment ID, the set of participants that participate in it.
-     * TODO: Maybe this should be kept private and be replaced with clearer helper functions (e.g., getStudyDeploymentIds).
      */
     val participations: Map<UUID, Set<Participant>>
         get() = _participations
@@ -171,16 +174,21 @@ class Recruitment( val studyId: UUID ) :
     }
 
     /**
-     * Get all [Participant]s for a specific [studyDeploymentId].
+     * Get the [ParticipantGroupStatus] of the study deployment identified by [studyDeploymentStatus].
      *
-     * @throws IllegalArgumentException when the given [studyDeploymentId] is not part of this recruitment.
+     * @throws IllegalArgumentException when the study deployment identified by [studyDeploymentStatus] is not part of this recruitment.
      */
-    fun getParticipations( studyDeploymentId: UUID ): Set<Participant>
+    fun getParticipantGroupStatus(
+        studyDeploymentStatus: StudyDeploymentStatus,
+        participantData: Map<InputDataType, Data?>
+    ): ParticipantGroupStatus
     {
-        val participations: Set<Participant> = _participations.getOrElse( studyDeploymentId ) { emptySet() }
-        require( participations.isNotEmpty() ) { "The specified study deployment ID is not part of this recruitment." }
+        val deploymentId = studyDeploymentStatus.studyDeploymentId
+        val participants: Set<Participant> = _participations.getOrElse( deploymentId ) { emptySet() }
+        require( participations.isNotEmpty() )
+            { "A study deployment with ID \"$deploymentId\" is not part of this recruitment." }
 
-        return participations
+        return ParticipantGroupStatus( studyDeploymentStatus, participants, participantData )
     }
 
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentSnapshot.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentSnapshot.kt
@@ -2,6 +2,8 @@ package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.DateTime
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.data.Data
+import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.domain.Snapshot
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
@@ -19,7 +21,11 @@ data class RecruitmentSnapshot(
     /**
      * Per study deployment ID, the IDs of the participants participating in it.
      */
-    val participations: Map<UUID, Set<UUID>>
+    val participations: Map<UUID, Set<UUID>>,
+    /**
+     * Per study deployment ID, input data related to the participant group.
+     */
+    val participantGroupData: Map<UUID, Map<InputDataType, Data?>>
 ) : Snapshot<Recruitment>
 {
     companion object
@@ -47,7 +53,9 @@ data class RecruitmentSnapshot(
                 studyProtocol,
                 invitation,
                 recruitment.participants,
-                participations )
+                participations,
+                recruitment.participantGroupData.toMap()
+            )
         }
     }
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryParticipantRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryParticipantRepository.kt
@@ -29,6 +29,15 @@ class InMemoryParticipantRepository : ParticipantRepository
         recruitments[ studyId ]?.let { Recruitment.fromSnapshot( it ) }
 
     /**
+     * Returns the [Recruitment] which contains a participation with the specified [studyDeploymentId],
+     * or null when no such recruitment is found.
+     */
+    override suspend fun getRecruitmentWithStudyDeploymentId( studyDeploymentId: UUID ): Recruitment? =
+        recruitments.values
+            .singleOrNull { studyDeploymentId in it.participations }
+            ?.let { Recruitment.fromSnapshot( it ) }
+
+    /**
      * Update a [Recruitment] which is already stored in this repository.
      *
      * @throws IllegalArgumentException when no previous version of this recruitment is stored in the repository.

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
@@ -139,7 +139,7 @@ class HostsIntegrationTest
     }
 
     @Test
-    fun set_participant_data_in_deployment_is_sent_as_event() = runSuspendTest {
+    fun set_participant_data_in_deployment_is_also_set_in_recruitment() = runSuspendTest {
         val (studyId, deviceRole) = createLiveStudy()
         {
             addExpectedParticipantData( ParticipantAttribute.DefaultParticipantAttribute( CarpInputDataTypes.SEX ) )
@@ -155,9 +155,13 @@ class HostsIntegrationTest
         eventBus.registerHandler( ParticipationService::class, ParticipationService.Event.ParticipantDataSet::class, this )
             { participantDataSet = it }
         eventBus.activateHandlers( this )
-        participationService.setParticipantData( deploymentId, CarpInputDataTypes.SEX, Sex.Male )
+        val dataToSet = CarpInputDataTypes.SEX to Sex.Male
+        participationService.setParticipantData( deploymentId, dataToSet.first, dataToSet.second )
 
         assertEquals( deploymentId, participantDataSet?.studyDeploymentId )
+        val groupStatus = recruitmentService.getParticipantGroupStatusList( studyId ).singleOrNull()
+        assertNotNull( groupStatus )
+        assertEquals( mapOf( dataToSet ), groupStatus.data )
     }
 
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
@@ -34,179 +34,179 @@ interface RecruitmentServiceTest
 
     @Test
     fun adding_and_retrieving_participant_succeeds() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val study = studyService.createStudy( StudyOwner(), "Test" )
         val studyId = study.studyId
 
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
         // Get single participant.
-        val studyParticipant = participantService.getParticipant( studyId, participant.id )
+        val studyParticipant = recruitmentService.getParticipant( studyId, participant.id )
         assertEquals( participant, studyParticipant )
 
         // Get all participants.
-        val studyParticipants = participantService.getParticipants( studyId )
+        val studyParticipants = recruitmentService.getParticipants( studyId )
         assertEquals( participant, studyParticipants.single() )
     }
 
     @Test
     fun addParticipant_fails_for_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
         val email = EmailAddress( "test@test.com" )
-        assertFailsWith<IllegalArgumentException> { participantService.addParticipant( unknownId, email ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.addParticipant( unknownId, email ) }
     }
 
     @Suppress( "ReplaceAssertBooleanWithAssertEquality" )
     @Test
     fun addParticipant_twice_returns_same_participant() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val study = studyService.createStudy( StudyOwner(), "Test" )
         val studyId = study.studyId
 
         val email = EmailAddress( "test@test.com" )
-        val p1 = participantService.addParticipant( studyId, email )
-        val p2 = participantService.addParticipant( studyId, email )
+        val p1 = recruitmentService.addParticipant( studyId, email )
+        val p2 = recruitmentService.addParticipant( studyId, email )
         assertTrue( p1 == p2 )
     }
 
     @Test
     fun getParticipant_fails_for_unknown_id() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val study = studyService.createStudy( StudyOwner(), "Test" )
 
         // Unknown study Id.
-        assertFailsWith<IllegalArgumentException> { participantService.getParticipant( unknownId, unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipant( unknownId, unknownId ) }
 
         // Unknown participant Id.
-        assertFailsWith<IllegalArgumentException> { participantService.getParticipant( study.studyId, unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipant( study.studyId, unknownId ) }
     }
 
     @Test
     fun getParticipants_fails_for_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
-        assertFailsWith<IllegalArgumentException> { participantService.getParticipants( unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipants( unknownId ) }
     }
 
     @Test
     fun deployParticipantGroup_succeeds() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
-        val groupStatus = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         assertEquals( participant, groupStatus.participants.single() )
         assertNull( groupStatus.data[ CarpInputDataTypes.SEX ] ) // By default, the configured expected data is not set.
-        val participantGroups = participantService.getParticipantGroupStatusList( studyId )
+        val participantGroups = recruitmentService.getParticipantGroupStatusList( studyId )
         val participantInGroup = participantGroups.single().participants.single()
         assertEquals( participant, participantInGroup )
     }
 
     @Test
     fun deployParticipantGroup_fails_for_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
         val assignParticipant = AssignParticipantDevices( UUID.randomUUID(), setOf( "Test device" ) )
 
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.deployParticipantGroup( unknownId, setOf( assignParticipant ) )
+            recruitmentService.deployParticipantGroup( unknownId, setOf( assignParticipant ) )
         }
     }
 
     @Test
     fun deployParticipantGroup_fails_for_empty_group() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, _) = createLiveStudy( studyService )
 
-        assertFailsWith<IllegalArgumentException> { participantService.deployParticipantGroup( studyId, setOf() ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.deployParticipantGroup( studyId, setOf() ) }
     }
 
     @Test
     fun deployParticipantGroup_fails_for_unknown_participants() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
 
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( unknownId, deviceRoles )
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+            recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         }
     }
 
     @Test
     fun deployParticipantGroup_fails_for_unknown_device_roles() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, _) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
         val assignParticipant = AssignParticipantDevices( participant.id, setOf( "Unknown device" ) )
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+            recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         }
     }
 
     @Test
     fun deployParticipantGroup_fails_when_not_all_devices_assigned() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, _) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
         val assignParticipant = AssignParticipantDevices( participant.id, setOf() )
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+            recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         }
     }
 
     @Test
     fun deployParticipantGroup_multiple_times_returns_same_group() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
-        val groupStatus = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
 
         // Deploy the same group a second time.
-        val groupStatus2 = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus2 = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         assertEquals( groupStatus, groupStatus2 )
     }
 
     @Test
     fun deployParticipantGroup_for_previously_stopped_group_returns_new_group() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
-        val groupStatus = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
 
         // Stop previous group. A new deployment with the same participants should be a new participant group.
-        participantService.stopParticipantGroup( studyId, groupStatus.id )
-        val groupStatus2 = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        recruitmentService.stopParticipantGroup( studyId, groupStatus.id )
+        val groupStatus2 = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         assertNotEquals( groupStatus, groupStatus2 )
     }
 
     @Test
     fun getParticipantGroupStatusList_returns_multiple_deployments() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
 
-        val p1 = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val p1 = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val assignedP1 = AssignParticipantDevices( p1.id, deviceRoles )
-        participantService.deployParticipantGroup( studyId, setOf( assignedP1 ) )
+        recruitmentService.deployParticipantGroup( studyId, setOf( assignedP1 ) )
 
-        val p2 = participantService.addParticipant( studyId, EmailAddress( "test2@test.com" ) )
+        val p2 = recruitmentService.addParticipant( studyId, EmailAddress( "test2@test.com" ) )
         val assignedP2 = AssignParticipantDevices( p2.id, deviceRoles )
-        participantService.deployParticipantGroup( studyId, setOf( assignedP2 ) )
+        recruitmentService.deployParticipantGroup( studyId, setOf( assignedP2 ) )
 
-        val participantGroups = participantService.getParticipantGroupStatusList( studyId )
+        val participantGroups = recruitmentService.getParticipantGroupStatusList( studyId )
         assertEquals( 2, participantGroups.size )
         val deployedParticipants = participantGroups.flatMap { it.participants }.toSet()
         assertEquals( setOf( p1, p2 ), deployedParticipants )
@@ -214,54 +214,54 @@ interface RecruitmentServiceTest
 
     @Test
     fun getParticipantGroupStatusLists_fails_for_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
-        assertFailsWith<IllegalArgumentException> { participantService.getParticipantGroupStatusList( unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipantGroupStatusList( unknownId ) }
     }
 
     @Test
     fun stopParticipantGroup_succeeds() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
-        val groupStatus = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
 
-        val stoppedGroupStatus = participantService.stopParticipantGroup( studyId, groupStatus.id )
+        val stoppedGroupStatus = recruitmentService.stopParticipantGroup( studyId, groupStatus.id )
         assertTrue( stoppedGroupStatus.studyDeploymentStatus is StudyDeploymentStatus.Stopped )
     }
 
     @Test
     fun stopParticipantGroup_fails_with_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.stopParticipantGroup( unknownId, UUID.randomUUID() )
+            recruitmentService.stopParticipantGroup( unknownId, UUID.randomUUID() )
         }
     }
 
     @Test
     fun stopParticipantGroup_fails_with_unknown_groupId() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, _) = createLiveStudy( studyService )
 
-        assertFailsWith<IllegalArgumentException> { participantService.stopParticipantGroup( studyId, unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.stopParticipantGroup( studyId, unknownId ) }
     }
 
     @Test
     fun setParticipantGroupData_succeeds() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, snapshot) = createLiveStudy( studyService )
-        val group = createLiveGroup( participantService, studyId, snapshot )
+        val group = createLiveGroup( recruitmentService, studyId, snapshot )
 
         val expectedData = CarpInputDataTypes.SEX
-        val groupAfterSet = participantService.setParticipantGroupData( studyId, group.id, expectedData, Sex.Male )
+        val groupAfterSet = recruitmentService.setParticipantGroupData( studyId, group.id, expectedData, Sex.Male )
         assertEquals( 1, groupAfterSet.data.size )
         assertEquals( Sex.Male, groupAfterSet.data[ expectedData ] )
 
-        val retrievedGroups = participantService.getParticipantGroupStatusList( studyId )
+        val retrievedGroups = recruitmentService.getParticipantGroupStatusList( studyId )
         val retrievedGroup = retrievedGroups.firstOrNull { it.id == group.id }
         assertNotNull( retrievedGroup )
         assertEquals( groupAfterSet.data, retrievedGroup.data )
@@ -269,23 +269,23 @@ interface RecruitmentServiceTest
 
     @Test
     fun setParticipantGroupData_fails_with_unknown_id() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.setParticipantGroupData( unknownId, unknownId, CarpInputDataTypes.SEX, Sex.Male )
+            recruitmentService.setParticipantGroupData( unknownId, unknownId, CarpInputDataTypes.SEX, Sex.Male )
         }
     }
 
     @Test
     fun setParticipantGroupData_fails_for_unexpected_data() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, snapshot) = createLiveStudy( studyService )
-        val group = createLiveGroup( participantService, studyId, snapshot )
+        val group = createLiveGroup( recruitmentService, studyId, snapshot )
 
         val unexpectedData = InputDataType( "namespace", "type" )
         assertFailsWith<IllegalArgumentException> {
-            participantService.setParticipantGroupData( studyId, group.id, unexpectedData, null )
+            recruitmentService.setParticipantGroupData( studyId, group.id, unexpectedData, null )
         }
     }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.studies.domain.users
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.EmailAccountIdentity
+import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSingleMasterDeviceProtocol
@@ -105,7 +106,7 @@ class RecruitmentTest
 
         recruitment.addParticipation( participant, studyDeploymentId )
         assertEquals( Recruitment.Event.ParticipationAdded( participant, studyDeploymentId ), recruitment.consumeEvents().last() )
-        assertEquals( participant, recruitment.getParticipations( studyDeploymentId ).single() )
+        assertEquals( participant, recruitment.participations[ studyDeploymentId ]?.singleOrNull() )
     }
 
     @Test
@@ -122,11 +123,30 @@ class RecruitmentTest
     }
 
     @Test
-    fun getParticipations_fails_for_unknown_studyDeploymentId()
+    fun getParticipantGroupStatus_succeeds()
+    {
+        val recruitment = Recruitment( studyId )
+        val participant = recruitment.addParticipant( participantEmail )
+        val protocol = createEmptyProtocol()
+        recruitment.lockInStudy( protocol.getSnapshot(), StudyInvitation.empty() )
+        recruitment.addParticipation( participant, studyDeploymentId )
+
+        val stubDeploymentStatus = StudyDeploymentStatus.DeployingDevices( studyDeploymentId, emptyList(), null )
+        val groupStatus = recruitment.getParticipantGroupStatus( stubDeploymentStatus, emptyMap() )
+
+        assertEquals( studyDeploymentId, groupStatus.id )
+        assertEquals( setOf( participant ), groupStatus.participants )
+    }
+
+    @Test
+    fun getParticipantGroupStatus_fails_for_unknown_studyDeploymentId()
     {
         val recruitment = Recruitment( studyId )
 
         val unknownId = UUID.randomUUID()
-        assertFailsWith<IllegalArgumentException> { recruitment.getParticipations( unknownId ) }
+        val stubDeploymentStatus = StudyDeploymentStatus.DeployingDevices( unknownId, emptyList(), null )
+        assertFailsWith<IllegalArgumentException> {
+            recruitment.getParticipantGroupStatus( stubDeploymentStatus, emptyMap() )
+        }
     }
 }


### PR DESCRIPTION
This solves #269 by replicating any participant data that gets added through `ParticipationService` in the corresponding backing repo of `RecruitmentService` (in `Recruitment`). This prevent `RecruitmentService` from having to look up participant data in `ParticipationService` whenever it needs to return `ParticipantGroupStatus`. Instead, this data is now _eventually consistent_.

**But,** although this PR might work and is almost complete, give or take a few missing unit tests, I am not all that certain anymore this is the way to go. This seems a whole lot of trouble, simply for the sake of returning, and being able to set, participant data from the studies subsystem endpoints. Why not simply let the studies frontend call the participation service directly? If the studies frontend wants to show participant data, it could do so by doing an additional request to the deployment service. The race condition will remain, but now it can simply be solved by using a delay in the request on the frontend. The data will still be _eventually consistent_.

Furthermore, this raises a couple of open questions on how this implementation should evolve. E.g., [should `Recruitment` do its  own input data validation](https://github.com/cph-cachet/carp.core-kotlin/pull/270/files#diff-b4994e4e7333c2246a5c0abc0fc7335f81eaca36ebdb444d915e1d96dfaee202R197)? What would then happen if the studies subsystem has different registered input types than the deployments subsystem?

Therefore, I think I'll open a second PR tomorrow which instead simply tries to _remove_ participant data from `RecruitmentService`. We are not yet using it either way. However, it would change the client API and thus updating TypeScript declarations, etc.