### PR TITLE
Remove get/set participant data from `RecruitmentService`

### DIFF
--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroup.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroup.kt
@@ -184,15 +184,17 @@ class ParticipantGroup private constructor(
      * @throws IllegalArgumentException when:
      *   - [inputDataType] is not configured as expected participant data
      *   - [data] is invalid data for [inputDataType]
+     * @return True when data changed; false when data was already set.
      */
-    fun setData( registeredInputDataTypes: InputDataTypeList, inputDataType: InputDataType, data: Data? )
+    fun setData( registeredInputDataTypes: InputDataTypeList, inputDataType: InputDataType, data: Data? ): Boolean
     {
         require( expectedData.isValidParticipantData( registeredInputDataTypes, inputDataType, data ) )
             { "The input data type is not expected or invalid data is passed." }
 
         val prevData = _data.put( inputDataType, data )
 
-        if ( prevData != data ) event( Event.DataSet( inputDataType, data ) )
+        return ( prevData != data )
+            .eventIf( true ) { Event.DataSet( inputDataType, data ) }
     }
 
     /**

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroupTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/users/ParticipantGroupTest.kt
@@ -212,8 +212,31 @@ class ParticipantGroupTest
 
         val group = createParticipantGroup( protocol )
 
-        group.setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
+        val isSet = group.setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
+        assertTrue( isSet )
         assertEquals( Sex.Male, group.data[ CarpInputDataTypes.SEX ] )
+        assertEquals(
+            ParticipantGroup.Event.DataSet( CarpInputDataTypes.SEX, Sex.Male ),
+            group.consumeEvents().filterIsInstance<ParticipantGroup.Event.DataSet>().singleOrNull()
+        )
+    }
+
+    @Test
+    fun setData_returns_false_when_data_already_set()
+    {
+        val protocol: StudyProtocol = createSingleMasterDeviceProtocol()
+        protocol.addExpectedParticipantData( ParticipantAttribute.DefaultParticipantAttribute( CarpInputDataTypes.SEX ) )
+
+        val group = createParticipantGroup( protocol )
+        group.setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
+        group.consumeEvents()
+
+        val isSet = group.setData( CarpInputDataTypes, CarpInputDataTypes.SEX, Sex.Male )
+        assertFalse( isSet )
+        assertEquals(
+            0,
+            group.consumeEvents().filterIsInstance<ParticipantGroup.Event.DataSet>().count()
+        )
     }
 
     @Test

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
@@ -4,8 +4,6 @@ import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.common.application.data.Data
-import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.studies.application.users.AssignParticipantDevices
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
@@ -72,15 +70,4 @@ interface RecruitmentService : ApplicationService<RecruitmentService, Recruitmen
      * @throws IllegalArgumentException when a study with [studyId] or participant group with [groupId] does not exist.
      */
     suspend fun stopParticipantGroup( studyId: UUID, groupId: UUID ): ParticipantGroupStatus
-
-    /**
-     * Set participant [data] for the given [inputDataType],
-     * related to participants of the participant group with [groupId] in the study with the specified [studyId].
-     *
-     * @throws IllegalArgumentException when:
-     *   - a study with [studyId] or participant group with [groupId] does not exist.
-     *   - [inputDataType] is not configured as expected participant data in the study protocol
-     *   - [data] is invalid data for [inputDataType]
-     */
-    suspend fun setParticipantGroupData( studyId: UUID, groupId: UUID, inputDataType: InputDataType, data: Data? ): ParticipantGroupStatus
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/ParticipantGroupStatus.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/ParticipantGroupStatus.kt
@@ -1,8 +1,6 @@
 package dk.cachet.carp.studies.application.users
 
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.common.application.data.Data
-import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.deployments.domain.StudyDeployment
 import kotlinx.serialization.Serializable
@@ -20,12 +18,7 @@ data class ParticipantGroupStatus(
     /**
      * The participants that are part of this deployment.
      */
-    val participants: Set<Participant>,
-    /**
-     * Configurable data related to the participants in this participant group.
-     * Data which is not set equals null.
-     */
-    val data: Map<InputDataType, Data?>
+    val participants: Set<Participant>
 )
 {
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
@@ -2,15 +2,19 @@ package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.data.Data
+import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.users.EmailAccountIdentity
 import dk.cachet.carp.common.domain.AggregateRoot
 import dk.cachet.carp.common.domain.DomainEvent
+import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.deployments.application.users.ParticipantInvitation
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.deployments.application.throwIfInvalid
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.studies.application.users.AssignParticipantDevices
 import dk.cachet.carp.studies.application.users.Participant
+import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
 import dk.cachet.carp.studies.application.users.participantIds
 
 
@@ -146,7 +150,6 @@ class Recruitment( val studyId: UUID ) :
 
     /**
      * Per study deployment ID, the set of participants that participate in it.
-     * TODO: Maybe this should be kept private and be replaced with clearer helper functions (e.g., getStudyDeploymentIds).
      */
     val participations: Map<UUID, Set<Participant>>
         get() = _participations
@@ -171,16 +174,21 @@ class Recruitment( val studyId: UUID ) :
     }
 
     /**
-     * Get all [Participant]s for a specific [studyDeploymentId].
+     * Get the [ParticipantGroupStatus] of the study deployment identified by [studyDeploymentStatus].
      *
-     * @throws IllegalArgumentException when the given [studyDeploymentId] is not part of this recruitment.
+     * @throws IllegalArgumentException when the study deployment identified by [studyDeploymentStatus] is not part of this recruitment.
      */
-    fun getParticipations( studyDeploymentId: UUID ): Set<Participant>
+    fun getParticipantGroupStatus(
+        studyDeploymentStatus: StudyDeploymentStatus,
+        participantData: Map<InputDataType, Data?>
+    ): ParticipantGroupStatus
     {
-        val participations: Set<Participant> = _participations.getOrElse( studyDeploymentId ) { emptySet() }
-        require( participations.isNotEmpty() ) { "The specified study deployment ID is not part of this recruitment." }
+        val deploymentId = studyDeploymentStatus.studyDeploymentId
+        val participants: Set<Participant> = _participations.getOrElse( deploymentId ) { emptySet() }
+        require( participations.isNotEmpty() )
+            { "A study deployment with ID \"$deploymentId\" is not part of this recruitment." }
 
-        return participations
+        return ParticipantGroupStatus( studyDeploymentStatus, participants, participantData )
     }
 
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
@@ -2,8 +2,6 @@ package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.common.application.data.Data
-import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.users.EmailAccountIdentity
 import dk.cachet.carp.common.domain.AggregateRoot
 import dk.cachet.carp.common.domain.DomainEvent
@@ -178,17 +176,14 @@ class Recruitment( val studyId: UUID ) :
      *
      * @throws IllegalArgumentException when the study deployment identified by [studyDeploymentStatus] is not part of this recruitment.
      */
-    fun getParticipantGroupStatus(
-        studyDeploymentStatus: StudyDeploymentStatus,
-        participantData: Map<InputDataType, Data?>
-    ): ParticipantGroupStatus
+    fun getParticipantGroupStatus( studyDeploymentStatus: StudyDeploymentStatus ): ParticipantGroupStatus
     {
         val deploymentId = studyDeploymentStatus.studyDeploymentId
         val participants: Set<Participant> = _participations.getOrElse( deploymentId ) { emptySet() }
         require( participations.isNotEmpty() )
             { "A study deployment with ID \"$deploymentId\" is not part of this recruitment." }
 
-        return ParticipantGroupStatus( studyDeploymentStatus, participants, participantData )
+        return ParticipantGroupStatus( studyDeploymentStatus, participants )
     }
 
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequest.kt
@@ -2,8 +2,6 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.common.application.data.Data
-import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.infrastructure.services.ServiceInvoker
 import dk.cachet.carp.common.infrastructure.services.createServiceInvoker
 import dk.cachet.carp.studies.application.RecruitmentService
@@ -54,13 +52,4 @@ sealed class RecruitmentServiceRequest
     data class StopParticipantGroup( val studyId: UUID, val groupId: UUID ) :
         RecruitmentServiceRequest(),
         RecruitmentServiceInvoker<ParticipantGroupStatus> by createServiceInvoker( RecruitmentService::stopParticipantGroup, studyId, groupId )
-
-    @Serializable
-    data class SetParticipantGroupData(
-        val studyId: UUID,
-        val groupId: UUID,
-        val inputDataType: InputDataType,
-        val data: Data?
-    ) : RecruitmentServiceRequest(),
-        RecruitmentServiceInvoker<ParticipantGroupStatus> by createServiceInvoker( RecruitmentService::setParticipantGroupData, studyId, groupId, inputDataType, data )
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
@@ -8,13 +8,8 @@ import dk.cachet.carp.common.application.services.createApplicationServiceAdapte
 import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
 import dk.cachet.carp.deployments.application.DeploymentService
 import dk.cachet.carp.deployments.application.DeploymentServiceHost
-import dk.cachet.carp.deployments.application.ParticipationService
-import dk.cachet.carp.deployments.application.ParticipationServiceHost
 import dk.cachet.carp.deployments.application.StudyDeploymentStatus
-import dk.cachet.carp.deployments.domain.users.ParticipantGroupService
-import dk.cachet.carp.deployments.infrastructure.InMemoryAccountService
 import dk.cachet.carp.deployments.infrastructure.InMemoryDeploymentRepository
-import dk.cachet.carp.deployments.infrastructure.InMemoryParticipationRepository
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.ProtocolOwner
 import dk.cachet.carp.protocols.domain.StudyProtocol
@@ -88,16 +83,9 @@ class StudiesCodeSamples
             InMemoryDeploymentRepository(),
             eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
-        val accountService = InMemoryAccountService()
-        val participationService = ParticipationServiceHost(
-            InMemoryParticipationRepository(),
-            ParticipantGroupService( accountService ),
-            eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
-
         val recruitmentService = RecruitmentServiceHost(
             InMemoryParticipantRepository(),
             deploymentService,
-            participationService,
             eventBus.createApplicationServiceAdapter( RecruitmentService::class ) )
 
         return Pair( studyService, recruitmentService )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
@@ -59,7 +59,6 @@ class HostsIntegrationTest
         recruitmentService = RecruitmentServiceHost(
             InMemoryParticipantRepository(),
             deploymentService,
-            participationService,
             eventBus.createApplicationServiceAdapter( RecruitmentService::class ) )
     }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
@@ -4,12 +4,7 @@ import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
 import dk.cachet.carp.common.application.services.createApplicationServiceAdapter
 import dk.cachet.carp.deployments.application.DeploymentService
 import dk.cachet.carp.deployments.application.DeploymentServiceHost
-import dk.cachet.carp.deployments.application.ParticipationService
-import dk.cachet.carp.deployments.application.ParticipationServiceHost
-import dk.cachet.carp.deployments.domain.users.ParticipantGroupService
-import dk.cachet.carp.deployments.infrastructure.InMemoryAccountService
 import dk.cachet.carp.deployments.infrastructure.InMemoryDeploymentRepository
-import dk.cachet.carp.deployments.infrastructure.InMemoryParticipationRepository
 import dk.cachet.carp.studies.infrastructure.InMemoryParticipantRepository
 import dk.cachet.carp.studies.infrastructure.InMemoryStudyRepository
 
@@ -34,17 +29,9 @@ class RecruitmentServiceHostTest : RecruitmentServiceTest
             InMemoryDeploymentRepository(),
             eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
 
-        // Create dependent participation service.
-        val accountService = InMemoryAccountService()
-        val participationService = ParticipationServiceHost(
-            InMemoryParticipationRepository(),
-            ParticipantGroupService( accountService ),
-            eventBus.createApplicationServiceAdapter( ParticipationService::class ) )
-
         val participantService = RecruitmentServiceHost(
             InMemoryParticipantRepository(),
             deploymentService,
-            participationService,
             eventBus.createApplicationServiceAdapter( RecruitmentService::class ) )
 
         return Pair( participantService, studyService )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceMock.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceMock.kt
@@ -4,8 +4,6 @@ package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.common.application.data.Data
-import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.studies.application.users.AssignParticipantDevices
@@ -24,16 +22,14 @@ class RecruitmentServiceMock(
     private val getParticipantsResult: List<Participant> = emptyList(),
     private val deployParticipantResult: ParticipantGroupStatus = groupStatus,
     private val getParticipantGroupStatusListResult: List<ParticipantGroupStatus> = emptyList(),
-    private val stopParticipantGroupResult: ParticipantGroupStatus = groupStatus,
-    private val setParticipantGroupDataResult: ParticipantGroupStatus = groupStatus
+    private val stopParticipantGroupResult: ParticipantGroupStatus = groupStatus
 ) : Mock<RecruitmentService>(), RecruitmentService
 {
     companion object
     {
         private val groupStatus = ParticipantGroupStatus(
             StudyDeploymentStatus.Invited( UUID.randomUUID(), emptyList(), null ),
-            emptySet(),
-            emptyMap() )
+            emptySet() )
     }
 
 
@@ -60,8 +56,4 @@ class RecruitmentServiceMock(
     override suspend fun stopParticipantGroup( studyId: UUID, groupId: UUID ) =
         stopParticipantGroupResult
         .also { trackSuspendCall( RecruitmentService::stopParticipantGroup, studyId, groupId ) }
-
-    override suspend fun setParticipantGroupData( studyId: UUID, groupId: UUID, inputDataType: InputDataType, data: Data? ) =
-        setParticipantGroupDataResult
-        .also { trackSuspendCall( RecruitmentService::setParticipantGroupData, studyId, groupId, inputDataType, data ) }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
@@ -34,179 +34,179 @@ interface RecruitmentServiceTest
 
     @Test
     fun adding_and_retrieving_participant_succeeds() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val study = studyService.createStudy( StudyOwner(), "Test" )
         val studyId = study.studyId
 
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
         // Get single participant.
-        val studyParticipant = participantService.getParticipant( studyId, participant.id )
+        val studyParticipant = recruitmentService.getParticipant( studyId, participant.id )
         assertEquals( participant, studyParticipant )
 
         // Get all participants.
-        val studyParticipants = participantService.getParticipants( studyId )
+        val studyParticipants = recruitmentService.getParticipants( studyId )
         assertEquals( participant, studyParticipants.single() )
     }
 
     @Test
     fun addParticipant_fails_for_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
         val email = EmailAddress( "test@test.com" )
-        assertFailsWith<IllegalArgumentException> { participantService.addParticipant( unknownId, email ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.addParticipant( unknownId, email ) }
     }
 
     @Suppress( "ReplaceAssertBooleanWithAssertEquality" )
     @Test
     fun addParticipant_twice_returns_same_participant() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val study = studyService.createStudy( StudyOwner(), "Test" )
         val studyId = study.studyId
 
         val email = EmailAddress( "test@test.com" )
-        val p1 = participantService.addParticipant( studyId, email )
-        val p2 = participantService.addParticipant( studyId, email )
+        val p1 = recruitmentService.addParticipant( studyId, email )
+        val p2 = recruitmentService.addParticipant( studyId, email )
         assertTrue( p1 == p2 )
     }
 
     @Test
     fun getParticipant_fails_for_unknown_id() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val study = studyService.createStudy( StudyOwner(), "Test" )
 
         // Unknown study Id.
-        assertFailsWith<IllegalArgumentException> { participantService.getParticipant( unknownId, unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipant( unknownId, unknownId ) }
 
         // Unknown participant Id.
-        assertFailsWith<IllegalArgumentException> { participantService.getParticipant( study.studyId, unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipant( study.studyId, unknownId ) }
     }
 
     @Test
     fun getParticipants_fails_for_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
-        assertFailsWith<IllegalArgumentException> { participantService.getParticipants( unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipants( unknownId ) }
     }
 
     @Test
     fun deployParticipantGroup_succeeds() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
-        val groupStatus = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         assertEquals( participant, groupStatus.participants.single() )
         assertNull( groupStatus.data[ CarpInputDataTypes.SEX ] ) // By default, the configured expected data is not set.
-        val participantGroups = participantService.getParticipantGroupStatusList( studyId )
+        val participantGroups = recruitmentService.getParticipantGroupStatusList( studyId )
         val participantInGroup = participantGroups.single().participants.single()
         assertEquals( participant, participantInGroup )
     }
 
     @Test
     fun deployParticipantGroup_fails_for_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
         val assignParticipant = AssignParticipantDevices( UUID.randomUUID(), setOf( "Test device" ) )
 
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.deployParticipantGroup( unknownId, setOf( assignParticipant ) )
+            recruitmentService.deployParticipantGroup( unknownId, setOf( assignParticipant ) )
         }
     }
 
     @Test
     fun deployParticipantGroup_fails_for_empty_group() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, _) = createLiveStudy( studyService )
 
-        assertFailsWith<IllegalArgumentException> { participantService.deployParticipantGroup( studyId, setOf() ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.deployParticipantGroup( studyId, setOf() ) }
     }
 
     @Test
     fun deployParticipantGroup_fails_for_unknown_participants() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
 
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( unknownId, deviceRoles )
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+            recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         }
     }
 
     @Test
     fun deployParticipantGroup_fails_for_unknown_device_roles() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, _) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
         val assignParticipant = AssignParticipantDevices( participant.id, setOf( "Unknown device" ) )
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+            recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         }
     }
 
     @Test
     fun deployParticipantGroup_fails_when_not_all_devices_assigned() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, _) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
         val assignParticipant = AssignParticipantDevices( participant.id, setOf() )
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+            recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         }
     }
 
     @Test
     fun deployParticipantGroup_multiple_times_returns_same_group() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
-        val groupStatus = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
 
         // Deploy the same group a second time.
-        val groupStatus2 = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus2 = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         assertEquals( groupStatus, groupStatus2 )
     }
 
     @Test
     fun deployParticipantGroup_for_previously_stopped_group_returns_new_group() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
-        val groupStatus = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
 
         // Stop previous group. A new deployment with the same participants should be a new participant group.
-        participantService.stopParticipantGroup( studyId, groupStatus.id )
-        val groupStatus2 = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        recruitmentService.stopParticipantGroup( studyId, groupStatus.id )
+        val groupStatus2 = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
         assertNotEquals( groupStatus, groupStatus2 )
     }
 
     @Test
     fun getParticipantGroupStatusList_returns_multiple_deployments() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
 
-        val p1 = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val p1 = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val assignedP1 = AssignParticipantDevices( p1.id, deviceRoles )
-        participantService.deployParticipantGroup( studyId, setOf( assignedP1 ) )
+        recruitmentService.deployParticipantGroup( studyId, setOf( assignedP1 ) )
 
-        val p2 = participantService.addParticipant( studyId, EmailAddress( "test2@test.com" ) )
+        val p2 = recruitmentService.addParticipant( studyId, EmailAddress( "test2@test.com" ) )
         val assignedP2 = AssignParticipantDevices( p2.id, deviceRoles )
-        participantService.deployParticipantGroup( studyId, setOf( assignedP2 ) )
+        recruitmentService.deployParticipantGroup( studyId, setOf( assignedP2 ) )
 
-        val participantGroups = participantService.getParticipantGroupStatusList( studyId )
+        val participantGroups = recruitmentService.getParticipantGroupStatusList( studyId )
         assertEquals( 2, participantGroups.size )
         val deployedParticipants = participantGroups.flatMap { it.participants }.toSet()
         assertEquals( setOf( p1, p2 ), deployedParticipants )
@@ -214,54 +214,54 @@ interface RecruitmentServiceTest
 
     @Test
     fun getParticipantGroupStatusLists_fails_for_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
-        assertFailsWith<IllegalArgumentException> { participantService.getParticipantGroupStatusList( unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipantGroupStatusList( unknownId ) }
     }
 
     @Test
     fun stopParticipantGroup_succeeds() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, protocolSnapshot) = createLiveStudy( studyService )
-        val participant = participantService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val deviceRoles = protocolSnapshot.masterDevices.map { it.roleName }.toSet()
         val assignParticipant = AssignParticipantDevices( participant.id, deviceRoles )
-        val groupStatus = participantService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
+        val groupStatus = recruitmentService.deployParticipantGroup( studyId, setOf( assignParticipant ) )
 
-        val stoppedGroupStatus = participantService.stopParticipantGroup( studyId, groupStatus.id )
+        val stoppedGroupStatus = recruitmentService.stopParticipantGroup( studyId, groupStatus.id )
         assertTrue( stoppedGroupStatus.studyDeploymentStatus is StudyDeploymentStatus.Stopped )
     }
 
     @Test
     fun stopParticipantGroup_fails_with_unknown_studyId() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.stopParticipantGroup( unknownId, UUID.randomUUID() )
+            recruitmentService.stopParticipantGroup( unknownId, UUID.randomUUID() )
         }
     }
 
     @Test
     fun stopParticipantGroup_fails_with_unknown_groupId() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, _) = createLiveStudy( studyService )
 
-        assertFailsWith<IllegalArgumentException> { participantService.stopParticipantGroup( studyId, unknownId ) }
+        assertFailsWith<IllegalArgumentException> { recruitmentService.stopParticipantGroup( studyId, unknownId ) }
     }
 
     @Test
     fun setParticipantGroupData_succeeds() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, snapshot) = createLiveStudy( studyService )
-        val group = createLiveGroup( participantService, studyId, snapshot )
+        val group = createLiveGroup( recruitmentService, studyId, snapshot )
 
         val expectedData = CarpInputDataTypes.SEX
-        val groupAfterSet = participantService.setParticipantGroupData( studyId, group.id, expectedData, Sex.Male )
+        val groupAfterSet = recruitmentService.setParticipantGroupData( studyId, group.id, expectedData, Sex.Male )
         assertEquals( 1, groupAfterSet.data.size )
         assertEquals( Sex.Male, groupAfterSet.data[ expectedData ] )
 
-        val retrievedGroups = participantService.getParticipantGroupStatusList( studyId )
+        val retrievedGroups = recruitmentService.getParticipantGroupStatusList( studyId )
         val retrievedGroup = retrievedGroups.firstOrNull { it.id == group.id }
         assertNotNull( retrievedGroup )
         assertEquals( groupAfterSet.data, retrievedGroup.data )
@@ -269,23 +269,23 @@ interface RecruitmentServiceTest
 
     @Test
     fun setParticipantGroupData_fails_with_unknown_id() = runSuspendTest {
-        val (participantService, _) = createService()
+        val (recruitmentService, _) = createService()
 
         assertFailsWith<IllegalArgumentException>
         {
-            participantService.setParticipantGroupData( unknownId, unknownId, CarpInputDataTypes.SEX, Sex.Male )
+            recruitmentService.setParticipantGroupData( unknownId, unknownId, CarpInputDataTypes.SEX, Sex.Male )
         }
     }
 
     @Test
     fun setParticipantGroupData_fails_for_unexpected_data() = runSuspendTest {
-        val (participantService, studyService) = createService()
+        val (recruitmentService, studyService) = createService()
         val (studyId, snapshot) = createLiveStudy( studyService )
-        val group = createLiveGroup( participantService, studyId, snapshot )
+        val group = createLiveGroup( recruitmentService, studyId, snapshot )
 
         val unexpectedData = InputDataType( "namespace", "type" )
         assertFailsWith<IllegalArgumentException> {
-            participantService.setParticipantGroupData( studyId, group.id, unexpectedData, null )
+            recruitmentService.setParticipantGroupData( studyId, group.id, unexpectedData, null )
         }
     }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
@@ -132,7 +132,7 @@ class RecruitmentTest
         recruitment.addParticipation( participant, studyDeploymentId )
 
         val stubDeploymentStatus = StudyDeploymentStatus.DeployingDevices( studyDeploymentId, emptyList(), null )
-        val groupStatus = recruitment.getParticipantGroupStatus( stubDeploymentStatus, emptyMap() )
+        val groupStatus = recruitment.getParticipantGroupStatus( stubDeploymentStatus )
 
         assertEquals( studyDeploymentId, groupStatus.id )
         assertEquals( setOf( participant ), groupStatus.participants )
@@ -146,7 +146,7 @@ class RecruitmentTest
         val unknownId = UUID.randomUUID()
         val stubDeploymentStatus = StudyDeploymentStatus.DeployingDevices( unknownId, emptyList(), null )
         assertFailsWith<IllegalArgumentException> {
-            recruitment.getParticipantGroupStatus( stubDeploymentStatus, emptyMap() )
+            recruitment.getParticipantGroupStatus( stubDeploymentStatus )
         }
     }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.studies.domain.users
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.EmailAccountIdentity
+import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSingleMasterDeviceProtocol
@@ -105,7 +106,7 @@ class RecruitmentTest
 
         recruitment.addParticipation( participant, studyDeploymentId )
         assertEquals( Recruitment.Event.ParticipationAdded( participant, studyDeploymentId ), recruitment.consumeEvents().last() )
-        assertEquals( participant, recruitment.getParticipations( studyDeploymentId ).single() )
+        assertEquals( participant, recruitment.participations[ studyDeploymentId ]?.singleOrNull() )
     }
 
     @Test
@@ -122,11 +123,30 @@ class RecruitmentTest
     }
 
     @Test
-    fun getParticipations_fails_for_unknown_studyDeploymentId()
+    fun getParticipantGroupStatus_succeeds()
+    {
+        val recruitment = Recruitment( studyId )
+        val participant = recruitment.addParticipant( participantEmail )
+        val protocol = createEmptyProtocol()
+        recruitment.lockInStudy( protocol.getSnapshot(), StudyInvitation.empty() )
+        recruitment.addParticipation( participant, studyDeploymentId )
+
+        val stubDeploymentStatus = StudyDeploymentStatus.DeployingDevices( studyDeploymentId, emptyList(), null )
+        val groupStatus = recruitment.getParticipantGroupStatus( stubDeploymentStatus, emptyMap() )
+
+        assertEquals( studyDeploymentId, groupStatus.id )
+        assertEquals( setOf( participant ), groupStatus.participants )
+    }
+
+    @Test
+    fun getParticipantGroupStatus_fails_for_unknown_studyDeploymentId()
     {
         val recruitment = Recruitment( studyId )
 
         val unknownId = UUID.randomUUID()
-        assertFailsWith<IllegalArgumentException> { recruitment.getParticipations( unknownId ) }
+        val stubDeploymentStatus = StudyDeploymentStatus.DeployingDevices( unknownId, emptyList(), null )
+        assertFailsWith<IllegalArgumentException> {
+            recruitment.getParticipantGroupStatus( stubDeploymentStatus, emptyMap() )
+        }
     }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
@@ -1,8 +1,6 @@
 package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.common.application.data.input.CarpInputDataTypes
-import dk.cachet.carp.common.application.data.input.Sex
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.deployments.application.StudyDeploymentStatus
@@ -22,8 +20,7 @@ class ParticipantGroupStatusTest
         val studyDeploymentId = UUID.randomUUID()
         val deploymentStatus = StudyDeploymentStatus.Invited( studyDeploymentId, listOf(), null )
         val participants = setOf( Participant( AccountIdentity.fromEmailAddress( "test@test.com" ) ) )
-        val someData = mapOf( CarpInputDataTypes.SEX to Sex.Female )
-        val groupStatus = ParticipantGroupStatus( deploymentStatus, participants, someData )
+        val groupStatus = ParticipantGroupStatus( deploymentStatus, participants )
 
         val serialized: String = JSON.encodeToString( ParticipantGroupStatus.serializer(), groupStatus )
         val parsed: ParticipantGroupStatus = JSON.decodeFromString( ParticipantGroupStatus.serializer(), serialized )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequestsTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequestsTest.kt
@@ -2,8 +2,6 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.common.application.data.input.CustomInput
-import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.test.infrastructure.ApplicationServiceRequestsTest
 import dk.cachet.carp.studies.application.RecruitmentService
 import dk.cachet.carp.studies.application.RecruitmentServiceMock
@@ -29,8 +27,7 @@ class RecruitmentServiceRequestsTest : ApplicationServiceRequestsTest<Recruitmen
             RecruitmentServiceRequest.GetParticipants( studyId ),
             RecruitmentServiceRequest.DeployParticipantGroup( studyId, setOf() ),
             RecruitmentServiceRequest.GetParticipantGroupStatusList( studyId ),
-            RecruitmentServiceRequest.StopParticipantGroup( studyId, UUID.randomUUID() ),
-            RecruitmentServiceRequest.SetParticipantGroupData( studyId, UUID.randomUUID(), InputDataType( "some", "type" ), CustomInput( "Test" ) )
+            RecruitmentServiceRequest.StopParticipantGroup( studyId, UUID.randomUUID() )
         )
     }
 }

--- a/docs/carp-studies.md
+++ b/docs/carp-studies.md
@@ -32,6 +32,7 @@ Allows setting recruitment goals, adding participants to studies, and creating d
 | Endpoint | Description | Require | Grant |
 | --- | --- | --- | --- |
 | `addParticipant` | Add a participant identified by a specified email address to a study. | manage study: `studyId` | |
+| `getParticipant` | Returns the participant with a specified ID for a study. | manage study: `studyId` | |
 | `getParticipants` | Get all participants for a study. | manage study: `studyId` | |
 | `deployParticipantGroup` | Deploy a study to a group of previously added participants. | manage study: `studyId` | |
 | `getParticipantGroupStatusList` | Get the status of all deployed participant groups in a study. | manage study: `studyId` | |

--- a/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
@@ -123,13 +123,12 @@ declare module 'carp.core-kotlin-carp.studies.core'
 
         class ParticipantGroupStatus
         {
-            constructor( studyDeploymentStatus: StudyDeploymentStatus, participants: HashSet<Participant>, data: HashMap<NamespacedId, any> )
+            constructor( studyDeploymentStatus: StudyDeploymentStatus, participants: HashSet<Participant> )
 
             static get Companion(): ParticipantGroupStatus$Companion
 
             readonly studyDeploymentStatus: StudyDeploymentStatus
             readonly participants: HashSet<Participant>
-            readonly data: any
         }
         interface ParticipantGroupStatus$Companion { serializer(): any }
 
@@ -230,10 +229,6 @@ declare module 'carp.core-kotlin-carp.studies.core'
             class StopParticipantGroup extends RecruitmentServiceRequest
             {
                 constructor( studyId: UUID, groupId: UUID )
-            }
-            class SetParticipantGroupData extends RecruitmentServiceRequest
-            {
-                constructor( studyId: UUID, groupId: UUID, inputDataType: NamespacedId, data?: any )
             }
         }
     }

--- a/typescript-declarations/tests/carp.studies.core.ts
+++ b/typescript-declarations/tests/carp.studies.core.ts
@@ -53,7 +53,7 @@ describe( "carp.studies.core", () => {
             AssignParticipantDevices.Companion,
             new Participant( new UsernameAccountIdentity( new Username( "Test" ) ) ),
             Participant.Companion,
-            new ParticipantGroupStatus( new StudyDeploymentStatus(), new HashSet<Participant>(), toMap( [] ) ),
+            new ParticipantGroupStatus( new StudyDeploymentStatus(), new HashSet<Participant>() ),
             ParticipantGroupStatus.Companion,
             new StudyOwner(),
             StudyOwner.Companion,
@@ -164,13 +164,7 @@ describe( "carp.studies.core", () => {
         it( "can serialize ParticipantGroupStatus", () => {
             const deploymentStatus = new StudyDeploymentStatus.DeploymentReady( UUID.Companion.randomUUID(), new ArrayList( [] ), DateTime.Companion.now() )
             const participants = toSet( [ new Participant( new UsernameAccountIdentity( new Username( "Test" ) ) ) ] )
-
-            // Initialize data through a participant attribute. TypeScript does not have to initialize data objects directly.
-            const attribute = new ParticipantAttribute.CustomParticipantAttribute( new Text( "Name" ) )
-            const inputData = attribute.inputToData_etkzhw$( CarpInputDataTypes, "Steven" )
-            const data = toMap( [ new Pair( new NamespacedId( "namespace", "type" ), inputData ) ] )
-
-            const group = new ParticipantGroupStatus( deploymentStatus, participants, data )
+            const group = new ParticipantGroupStatus( deploymentStatus, participants )
 
             const json: Json = createDefaultJSON()
             const serializer = ParticipantGroupStatus.Companion.serializer()


### PR DESCRIPTION
This closes #269 since the race condition arose from calling `getParticipantData` which no longer occurs. It is a competing solution to #270 

Rather than simply redirecting get/set participant data from `RecruitmentService` to `ParticipationService`, the frontend can call `ParticipationService` directly. Or, we can later provide a common API gateway.

This moves the race condition to the frontend as part of a separate _transaction_, which is a better way of modeling this. If the frontend wants get `getParticipantData` it will either need to be notified once the participant group is available, and thus data can be retrieved, or, it can add a delay in requesting the participant data.