### PR TITLE
fix: DataTypeMetaData now gets added to the underlying list

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/DataTypeMetaDataList.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/DataTypeMetaDataList.kt
@@ -16,5 +16,5 @@ open class DataTypeMetaDataList : EnumObjectList<DataTypeMetaData>()
      * which can be displayed to the user using [displayName] and should be stored temporally as specified by [timeType].
      */
     fun add( fullyQualifiedName: String, displayName: String, timeType: DataTimeType ): DataTypeMetaData =
-        DataTypeMetaData( DataType.fromString( fullyQualifiedName ), displayName, timeType )
+        super.add( DataTypeMetaData( DataType.fromString( fullyQualifiedName ), displayName, timeType ) )
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/data/CarpDataTypesTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/data/CarpDataTypesTest.kt
@@ -10,6 +10,13 @@ import kotlin.test.*
  */
 class CarpDataTypesTest
 {
+    @Test
+    fun data_types_gets_added_to_underlying_list()
+    {
+        val size = CarpDataTypes.size
+        assertTrue( size > 0 )
+    }
+
     @ExperimentalSerializationApi
     @Test
     fun serializable_data_class_registered_for_each_data_type()


### PR DESCRIPTION
The `add` method in `DataTypeMetaDataList` shaded the `add` method in `EnumObjectList` and the former never ensured entries were actually added to the underlying list. Renamed method in `DataTypeMetaDataList` to `addMetaData` and make it call the parent `add` method.