### PR TITLE
Upgrade all the things

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -30,4 +30,4 @@ jobs:
 
       - name: Deploy snapshot
         if: success()
-        run: ./gradlew jsPackageJson publishSnapshot
+        run: ./gradlew setSnapshotVersion publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,6 @@ jobs:
         if: success()
         run: ./gradlew verifyTsDeclarations
 
-      - name: Publish to staging repo
+      - name: Publish to staging repo and release
         if: success()
-        run: ./gradlew jsPackageJson publishSigned
-      
-      - name: Release staged repo
-        if: success()
-        run: ./gradlew closeAndReleaseRepository
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ In case you want to contribute, please follow our [contribution guidelines](http
 We recommend using IntelliJ IDEA 2020, as this is the development environment we use and is therefore fully tested.
 
 - Open the project folder in IntelliJ 2020.
-- Install the Kotlin plugin for IntelliJ IDEA (203-1.4.31-release-IJ*): `Tools->Kotlin->Configure Kotlin Plugin Updates`
+- Install the Kotlin plugin for IntelliJ IDEA (211-1.5.21-release-*): `Tools->Kotlin->Configure Kotlin Plugin Updates`
 - To build/test/publish, click "Edit Configurations" to add configurations for [the included Gradle tasks](#gradle-tasks), or run them from the Gradle tool window.
 
 ### Gradle tasks

--- a/README.md
+++ b/README.md
@@ -313,5 +313,8 @@ For `carp.core-kotlin`:
 - **jsTest**: Test the full project on a JavaScript runtime using a headless Chrome browser.
 - **verifyTsDeclarations**: Verify whether the TypeScript declarations of all modules, defined in `typescript-declarations`, match the compiled JS sources and work at runtime.
 - **detektPasses**: Run code analysis. Output will list failure in case code smells are detected.
-- **jsPackageJson publishSigned**: Publish all projects to Maven using the version number specified in `ext.globalVersion`. This includes documentation, sources, and signing. For this to work you need to configure a `publish.properties` file with a signing signature and repository user in the project root folder. See main `build.gradle` for details.
-- **jsPackageJson publishSnapshot**: Publish a snapshot build for all projects to Maven, substituting the suffix of the version specified in `ext.globalVersion` with `-SNAPSHOT`.
+- **publishToSonatype closeAndReleaseSonatypeStagingRepository**: Publish all projects to Maven using the version number specified in `ext.globalVersion`.
+  This includes documentation, sources, and signing.
+  For this to work you need to configure a `publish.properties` file with a signing signature and repository user in the project root folder.
+  Preface with `setSnapshotVersion` task to publish to the snapshot repository, substituting the suffix of the version specified in `ext.globalVersion` with `-SNAPSHOT`.
+  See main `build.gradle` for details.

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ buildscript {
 
         versions = [
             // Kotlin multiplatform versions.
-            kotlin:'1.5.10',
-            serialization:'1.2.1',
-            coroutines:'1.5.0',
+            kotlin:'1.5.21',
+            serialization:'1.2.2',
+            coroutines:'1.5.1',
 
             // JVM versions.
             jvmTarget:'1.8',
@@ -236,7 +236,7 @@ task setupTsProject(type: NpmTask) {
 task copyTestJsSources(type: Copy, dependsOn: setupTsProject) {
     // Make sure no old imported packages are left behind.
     def importedPackages = file("$rootDir/build/js/packages_imported")
-    importedPackages.eachFile { it.delete() }
+    if (importedPackages.exists()) importedPackages.eachFile { it.delete() }
 
     // Compile all subprojects for which TypeScript declarations are defined.
     def projects = coreModules + commonModule

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
     ext {
         // Version used for all submodule artifacts.
         // Snapshot publishing changes (or adds) the suffix after '-' with 'SNAPSHOT' prior to publishing.
-        // The 'publishSigned' task publishes to SonaType's staging repo and 'publishSnapshot' instantly uploads to the snapshots repo.
         globalVersion = '1.0.0-alpha.34'
 
         versions = [
@@ -29,7 +28,7 @@ buildscript {
             // DevOps versions.
             detektPlugin:'1.17.0',
             detektVerifyImplementation:'1.2.2',
-            nexusReleasePlugin:'0.22.0' // TODO: Migrate to `gradle-nexus-publish-plugin`.
+            nexusPublishPlugin:'1.1.0'
         ]
     }
 
@@ -46,7 +45,7 @@ buildscript {
 
         // DevOps plugins.
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detektPlugin}"
-        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:${versions.nexusReleasePlugin}"
+        classpath "io.github.gradle-nexus:publish-plugin:${versions.nexusPublishPlugin}"
     }
 
     repositories {
@@ -127,6 +126,7 @@ configure( subprojects - detektModule ) {
     // > repository.username=<SONATYPE USERNAME>
     // > repository.password=<SONATYPE PASSWORD>
     apply plugin: 'maven-publish'
+    apply plugin: 'signing'
     apply plugin: 'org.jetbrains.dokka'
     task dokkaJvmJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
         dokkaSourceSets {
@@ -178,52 +178,41 @@ configure( subprojects - detektModule ) {
                 name "local"
                 url "$buildDir/repository"
             }
-            maven {
-                name = "sonatype"
-                url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2' // Staging repo.
-                credentials {
-                    username = publishProperties['repository.username']
-                    password = publishProperties['repository.password']
-                }
-            }
         }
     }
-    // Configure the 'sign' task to sign all files part of the maven package.
-    apply plugin: 'signing'
     signing {
-        sign publishing.publications
-    }
-    task publishSigned {
-        doFirst {
-            def signingKey = new File(publishProperties['signing.keyFile']).text
+        def signingKeyFile = publishProperties['signing.keyFile']
+        if (signingKeyFile != null) {
+            def signingKey = new File(signingKeyFile).text
             def signingPassword = publishProperties['signing.password']
-            signing.useInMemoryPgpKeys(signingKey, signingPassword)
+            useInMemoryPgpKeys(signingKey, signingPassword)
+            sign publishing.publications
         }
     }
-    publishSigned.finalizedBy publish
-    task publishSnapshot {
-        doFirst {
-            // Since project dependencies trigger publications of other projects, immediately modify versions of all subprojects.
-            (rootProject.subprojects - detektModule).each { project ->
-                def versionSplit = project.version.split('-')
-                def snapshotVersion = "${versionSplit[0]}-SNAPSHOT"
-                project.version = snapshotVersion
-
-                // Override 'maven-publish' publication versions and change staging repo URL to snapshot repo.
-                project.publishing.publications.all { version = version }
-                project.publishing.repositories.sonatype.url = 'https://oss.sonatype.org/content/repositories/snapshots'
-            }
-        }
-    }
-    publishSnapshot.finalizedBy publishSigned
 }
-// Add 'closeAndReleaseRepository' task to close and release uploads to Sonatype Nexus Repository after 'publishSigned'.
-apply plugin: 'io.codearte.nexus-staging'
-nexusStaging {
-    packageGroup = 'dk.cachet.carp'
-    numberOfRetries = 30
-    username = publishProperties['repository.username']
-    password = publishProperties['repository.password']
+
+// Sonatype Nexus publication.
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
+group = "dk.cachet.carp"
+version = globalVersion
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = publishProperties['repository.username']
+            password = publishProperties['repository.password']
+        }
+    }
+}
+task setSnapshotVersion {
+    doFirst {
+        def versionSplit = globalVersion.split('-')
+        def snapshotVersion = "${versionSplit[0]}-SNAPSHOT"
+        version = snapshotVersion
+
+        (rootProject.subprojects - detektModule).each { project ->
+            project.version = snapshotVersion
+        }
+    }
 }
 
 // TypeScript ambient declaration verification.

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
             // JVM versions.
             jvmTarget:'1.8',
             jUnit5:'5.7.2',
-            dokkaPlugin:'0.9.18',
+            dokkaPlugin:'1.5.0',
             reflections:'0.9.12',
 
             // JS versions.
@@ -128,15 +128,19 @@ configure( subprojects - detektModule ) {
     // > repository.password=<SONATYPE PASSWORD>
     apply plugin: 'maven-publish'
     apply plugin: 'org.jetbrains.dokka'
-    dokka {
-        outputFormat = 'html'
-        outputDirectory = "$buildDir/javadoc"
+    task dokkaJvmJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
+        dokkaSourceSets {
+            register("jvm") {
+                platform.set(org.jetbrains.dokka.Platform.jvm)
+                sourceRoots.from(kotlin.sourceSets.getByName("jvmMain").kotlin.srcDirs)
+            }
+        }
     }
     task javadocJar(type: Jar) {
         group JavaBasePlugin.DOCUMENTATION_GROUP
         description 'Create javadoc jar using Dokka'
         archiveClassifier = "javadoc"
-        from dokka
+        from dokkaJvmJavadoc
     }
     publishing {
         publications {
@@ -355,36 +359,4 @@ configure( rootProject )
     }
     tasks.detekt.jvmTarget = "1.8"
     tasks.detekt.dependsOn ":carp.detekt:assemble" // Ensure 'carp.detekt' is built prior to running code analysis.
-}
-
-
-// HACK: Dokka currently does not work for multiplatform projects.
-// The following configuration is a workaround to configure Dokka for JVM solely:
-// https://discuss.kotlinlang.org/t/how-to-configure-dokka-for-kotlin-multiplatform/9834
-configure( subprojects - detektModule ) {
-    dokka {
-        kotlinTasks { [] }
-        // Dokka fails to retrieve sources from multiplatform tasks. Setting this as empty avoids exceptions.
-        sourceRoot {
-            path = kotlin.sourceSets.commonMain.kotlin.srcDirs[0] // There is only one source dir.
-            platforms = ["Common"]
-        }
-        sourceRoot {
-            path = kotlin.sourceSets.jvmMain.kotlin.srcDirs[0] // There is only one source dir.
-            platforms = ["JVM"]
-        }
-    }
-}
-// HACK: Manually add source dependencies of core modules to 'common' so that Dokka can resolve them.
-configure( coreModules ) {
-    dokka {
-        sourceRoot {
-            path = project(':carp.common').kotlin.sourceSets.commonMain.kotlin.srcDirs[0] // There is only one source dir.
-            platforms = ["Common"]
-        }
-        sourceRoot {
-            path = project(':carp.common').kotlin.sourceSets.jvmMain.kotlin.srcDirs[0] // There is only one source dir.
-            platforms = ["JVM"]
-        }
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
             nodePlugin:'3.1.0',
 
             // DevOps versions.
-            detektPlugin:'1.17.0',
+            detektPlugin:'1.18.0-RC1',
             detektVerifyImplementation:'1.2.2',
             nexusPublishPlugin:'1.1.0'
         ]

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,12 @@ buildscript {
 
         versions = [
             // Kotlin multiplatform versions.
-            kotlin:'1.5.20',
+            kotlin:'1.5.10',
             serialization:'1.2.1',
             coroutines:'1.5.0',
 
             // JVM versions.
-            jvmTarget:'1.6',
+            jvmTarget:'1.8',
             jUnit5:'5.7.2',
             dokkaPlugin:'0.9.18',
             reflections:'0.9.12',
@@ -230,17 +230,26 @@ task setupTsProject(type: NpmTask) {
     args = ['install']
 }
 task copyTestJsSources(type: Copy, dependsOn: setupTsProject) {
-    // First compile all subprojects for which TypeScript declarations are defined.
+    // Make sure no old imported packages are left behind.
+    def importedPackages = file("$rootDir/build/js/packages_imported")
+    importedPackages.eachFile { it.delete() }
+
+    // Compile all subprojects for which TypeScript declarations are defined.
     def projects = coreModules + commonModule
     projects.each { dependsOn("${it.name}:jsBrowserDistribution") }
 
-    projects.each {
-        // Copy JS packages into ...
-        from "${it.rootDir}/build/js/node_modules"
+    // Copy compiled sources and dependencies to test project node_modules.
+    from "$rootDir/build/js/packages"
+    from(importedPackages) {
+        eachFile {
+            def path = it.path
+            if (path == ".visited") return // We don't need this file.
 
-        // ... 'node_modules' so that test can retrieve dependencies.
-        into "./${typescriptFolder}/node_modules"
+            // Remove intermediate version directory: e.g. "kotlin/1.5.10/kotlin.js"
+            it.path = path.replaceFirst(/\d+\.\d+.\d+\//, "")
+        }
     }
+    into "./$typescriptFolder/node_modules"
 }
 task compileTs(type: NpmTask, dependsOn: copyTestJsSources) {
     workingDir = file(typescriptFolder)

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ buildscript {
 
         versions = [
             // Kotlin multiplatform versions.
-            kotlin:'1.4.31',
-            serialization:'1.1.0',
-            coroutines:'1.4.3',
+            kotlin:'1.5.20',
+            serialization:'1.2.1',
+            coroutines:'1.5.0',
 
             // JVM versions.
             jvmTarget:'1.6',

--- a/carp.clients.core/build.gradle
+++ b/carp.clients.core/build.gradle
@@ -23,27 +23,3 @@ kotlin {
         }
     }
 }
-
-// HACK: Dokka currently does not work for multiplatform projects.
-// The following is a workaround to load dependent sources manually.
-dokka {
-    // Add source sets of 'carp.protocols.core'.
-    sourceRoot {
-        path = project(':carp.protocols.core').kotlin.sourceSets.commonMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["Common"]
-    }
-    sourceRoot {
-        path = project(':carp.protocols.core').kotlin.sourceSets.jvmMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["JVM"]
-    }
-
-    // Add source sets of 'carp.deployment.core'.
-    sourceRoot {
-        path = project(':carp.deployments.core').kotlin.sourceSets.commonMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["Common"]
-    }
-    sourceRoot {
-        path = project(':carp.deployments.core').kotlin.sourceSets.jvmMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["JVM"]
-    }
-}

--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/ClientCodeSamples.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/ClientCodeSamples.kt
@@ -33,7 +33,7 @@ import kotlin.test.*
 class ClientCodeSamples
 {
     @Test
-    @Suppress( "UnusedPrivateMember" )
+    @Suppress( "UnusedPrivateMember", "UNUSED_VARIABLE" )
     fun readme() = runSuspendTest {
         val (participationService, deploymentService) = createEndpoints()
         val dataCollectorFactory = createDataCollectorFactory()

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
@@ -24,7 +24,8 @@ import kotlin.reflect.KClass
  */
 @Serializable( CustomInputSerializer::class )
 @SerialName( CUSTOM_INPUT_TYPE_NAME )
-data class CustomInput<T : Any>( val input: T ) : Data
+@Suppress( "Immutable" ) // TODO: `assumeImmutable` configuration in detekt.yml is not working.
+data class CustomInput( val input: Any ) : Data
 
 
 /**
@@ -33,10 +34,10 @@ data class CustomInput<T : Any>( val input: T ) : Data
  * @param supportedDataTypes The input data types this serializer can serialize.
  *   A serializer should be registered for these classes.
  */
-class CustomInputSerializer( vararg supportedDataTypes: KClass<*> ) : KSerializer<CustomInput<*>>
+class CustomInputSerializer( vararg supportedDataTypes: KClass<*> ) : KSerializer<CustomInput>
 {
     @InternalSerializationApi
-    // TODO: Can we use the fully qualified type name to register serializers here, like kotlinx.serialization doess? How?
+    // TODO: Can we use the fully qualified type name to register serializers here, like kotlinx.serialization does? How?
     val dataTypeMap: Map<String, KSerializer<out Any>> = supportedDataTypes.map { it.simpleName!! to it.serializer() }.toMap()
 
     @ExperimentalSerializationApi
@@ -49,7 +50,7 @@ class CustomInputSerializer( vararg supportedDataTypes: KClass<*> ) : KSerialize
 
     @ExperimentalSerializationApi
     @InternalSerializationApi
-    override fun deserialize( decoder: Decoder ): CustomInput<*> =
+    override fun deserialize( decoder: Decoder ): CustomInput =
         decoder.decodeStructure( descriptor )
         {
             // Read dataType.
@@ -67,7 +68,7 @@ class CustomInputSerializer( vararg supportedDataTypes: KClass<*> ) : KSerialize
 
     @ExperimentalSerializationApi
     @InternalSerializationApi
-    override fun serialize( encoder: Encoder, value: CustomInput<*> ) =
+    override fun serialize( encoder: Encoder, value: CustomInput ) =
         encoder.encodeStructure( descriptor )
         {
             val input = value.input

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
@@ -80,6 +80,7 @@ data class AltBeaconDeviceRegistration(
 
     override val deviceId: String =
         // TODO: Remove this workaround once JS serialization bug is fixed: https://github.com/Kotlin/kotlinx.serialization/issues/716
+        @Suppress( "SENSELESS_COMPARISON" )
         if ( arrayOf( manufacturerId, organizationId, majorId, minorId ).any { it == null } ) ""
         else "$manufacturerId:$organizationId:$majorId:$minorId"
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ParticipantAttribute.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/users/ParticipantAttribute.kt
@@ -113,7 +113,7 @@ sealed class ParticipantAttribute
         // Early out in case data is of the wrong type.
         val isCorrectDataType = when ( this )
         {
-            is CustomParticipantAttribute<*> -> data is CustomInput<*> && isValidCustomData( inputElement, data )
+            is CustomParticipantAttribute<*> -> data is CustomInput && isValidCustomData( inputElement, data )
             is DefaultParticipantAttribute -> registeredInputDataTypes.dataClasses[ inputType ]!!.isInstance( data )
         }
         if ( !isCorrectDataType ) return false
@@ -139,7 +139,7 @@ sealed class ParticipantAttribute
         // Custom input should be wrapped by `CustomInput` and contain an object of the expected input type.
         if ( this is CustomParticipantAttribute<*> )
         {
-            require( data is CustomInput<*> && isValidCustomData( inputElement, data ) )
+            require( data is CustomInput && isValidCustomData( inputElement, data ) )
                 { "Data is not of expected type for this attribute." }
             return data.input
         }
@@ -152,6 +152,6 @@ sealed class ParticipantAttribute
         return converter( data )
     }
 
-    private fun isValidCustomData( inputElement: InputElement<*>, data: CustomInput<*> ) =
+    private fun isValidCustomData( inputElement: InputElement<*>, data: CustomInput ) =
         inputElement.getDataClass().isInstance( data.input )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializer.kt
@@ -106,17 +106,11 @@ abstract class UnknownPolymorphicSerializer<P : Any, W : P>(
         return createWrapper( className, jsonSource, decoder.json )
     }
 
-    // HACK: Since `Json.configuration` is internal, this is a workaround to find the configured class discriminator.
-    //   I requested it to be public: https://github.com/Kotlin/kotlinx.serialization/issues/1323
     private fun getClassDiscriminator( json: Json ): String
     {
-        var extractedDiscriminator: String? = null
-        Json( json )
-        {
-            if ( useArrayPolymorphism ) throw unsupportedException
-            extractedDiscriminator = classDiscriminator
-        }
-        return extractedDiscriminator!!
+        if ( json.configuration.useArrayPolymorphism ) throw unsupportedException
+
+        return json.configuration.classDiscriminator
     }
 
     /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ChannelConventionEventBus.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ChannelConventionEventBus.kt
@@ -26,7 +26,7 @@ abstract class ChannelConventionEventBus : EventBus()
     {
         handlers
             .groupBy { it.eventSource }
-            .forEach { (source, handlers) -> subscribeToChannel( source, ::redirectEvent ) }
+            .forEach { (source, _) -> subscribeToChannel( source, ::redirectEvent ) }
     }
 
     private suspend fun redirectEvent( event: IntegrationEvent<*> )

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/UUIDTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/UUIDTest.kt
@@ -22,12 +22,12 @@ class UUIDTest
         assertEquals( id, parsed )
     }
 
+    @Serializable
+    data class Id( val id: UUID? )
+
     @Test
     fun can_serialize_and_deserialize_nullable_UUID()
     {
-        @Serializable
-        data class Id( val id: UUID? )
-
         val json = createDefaultJSON()
 
         val id = Id( UUID( "00000000-0000-0000-0000-000000000000" ) )

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializerTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializerTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.Serializable
@@ -143,6 +144,7 @@ class UnknownPolymorphicSerializerTest
     }
 
     @Test
+    @ExperimentalSerializationApi
     fun supports_non_json_encoders_for_known_types()
     {
         val toSerialize = DerivingType( "Test" )
@@ -154,6 +156,7 @@ class UnknownPolymorphicSerializerTest
     }
 
     @Test
+    @ExperimentalSerializationApi
     fun does_not_support_non_json_encoders_for_unknown_types()
     {
         class UnregisteredType( override val toOverrideProperty: String ) : BaseType()

--- a/carp.deployments.core/build.gradle
+++ b/carp.deployments.core/build.gradle
@@ -20,17 +20,3 @@ kotlin {
         }
     }
 }
-
-// HACK: Dokka currently does not work for multiplatform projects.
-// The following is a workaround to load dependent sources manually.
-dokka {
-    // Add source sets of 'carp.protocols.core'.
-    sourceRoot {
-        path = project(':carp.protocols.core').kotlin.sourceSets.commonMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["Common"]
-    }
-    sourceRoot {
-        path = project(':carp.protocols.core').kotlin.sourceSets.jvmMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["JVM"]
-    }
-}

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/MasterDeviceDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/MasterDeviceDeployment.kt
@@ -76,6 +76,7 @@ data class MasterDeviceDeployment(
      */
     val lastUpdateDate: DateTime =
         // TODO: Remove this workaround once JS serialization bug is fixed: https://github.com/Kotlin/kotlinx.serialization/issues/716
+        @Suppress( "SENSELESS_COMPARISON" )
         if ( connectedDeviceConfigurations == null || configuration == null ) DateTime.now()
         else connectedDeviceConfigurations.values.plus( configuration )
             .map { it.registrationCreationDate.msSinceUTC }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/DeploymentCodeSamples.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/DeploymentCodeSamples.kt
@@ -25,7 +25,7 @@ import kotlin.test.*
 class DeploymentCodeSamples
 {
     @Test
-    @Suppress( "UnusedPrivateMember" )
+    @Suppress( "UnusedPrivateMember", "UNUSED_VARIABLE" )
     fun readme() = runSuspendTest {
         val deploymentService: DeploymentService = createDeploymentEndpoint()
         val trackPatientStudy: StudyProtocol = createExampleProtocol()

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
@@ -21,7 +21,7 @@ import kotlin.test.*
 class ProtocolsCodeSamples
 {
     @Test
-    @Suppress( "UnusedPrivateMember" )
+    @Suppress( "UnusedPrivateMember", "UNUSED_VARIABLE" )
     fun readme() = runSuspendTest {
         // Create a new study protocol.
         val owner = ProtocolOwner()

--- a/carp.studies.core/build.gradle
+++ b/carp.studies.core/build.gradle
@@ -21,27 +21,3 @@ kotlin {
         }
     }
 }
-
-// HACK: Dokka currently does not work for multiplatform projects.
-// The following is a workaround to load dependent sources manually.
-dokka {
-    // Add source sets of 'carp.protocols.core'.
-    sourceRoot {
-        path = project(':carp.protocols.core').kotlin.sourceSets.commonMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["Common"]
-    }
-    sourceRoot {
-        path = project(':carp.protocols.core').kotlin.sourceSets.jvmMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["JVM"]
-    }
-
-    // Add source sets of 'carp.deployments.core'.
-    sourceRoot {
-        path = project(':carp.deployments.core').kotlin.sourceSets.commonMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["Common"]
-    }
-    sourceRoot {
-        path = project(':carp.deployments.core').kotlin.sourceSets.jvmMain.kotlin.srcDirs[0] // There is only one source dir.
-        platforms = ["JVM"]
-    }
-}

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
@@ -32,7 +32,7 @@ import kotlin.test.*
 class StudiesCodeSamples
 {
     @Test
-    @Suppress( "UnusedPrivateMember" )
+    @Suppress( "UnusedPrivateMember", "UNUSED_VARIABLE" )
     fun readme() = runSuspendTest {
         val (studyService, recruitmentService) = createEndpoints()
 

--- a/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/serialization/ConcreteTypesSerializationTest.kt
+++ b/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/serialization/ConcreteTypesSerializationTest.kt
@@ -52,6 +52,7 @@ abstract class ConcreteTypesSerializationTest(
         {
             // Get serializer.
             val type = toSerialize::class
+            @Suppress( "UNCHECKED_CAST" )
             val serializer = polymorphicSerializers[ type ] as? KSerializer<Any>
             assertNotNull( serializer, "No serializer registered for type '$type'" )
 

--- a/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/serialization/ConcreteTypesSerializationTest.kt
+++ b/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/serialization/ConcreteTypesSerializationTest.kt
@@ -75,8 +75,10 @@ fun getPolymorphicSerializers( serialModule: SerializersModule ): Map<KClass<*>,
         {
             val serializers: MutableMap<KClass<*>, KSerializer<*>> = mutableMapOf()
 
-            override fun <T : Any> contextual( kClass: KClass<T>, serializer: KSerializer<T> ) =
-                throw UnsupportedOperationException()
+            override fun <T : Any> contextual(
+                kClass: KClass<T>,
+                provider: (typeArgumentsSerializers: List<KSerializer<*>>) -> KSerializer<*>
+            ) = throw UnsupportedOperationException()
 
             override fun <Base : Any, Sub : Base> polymorphic(
                 baseClass: KClass<Base>,

--- a/detekt.yml
+++ b/detekt.yml
@@ -84,7 +84,7 @@ verify-implementation:
     assumeNoAnnotations: *assume-no-annotations
     assumeImmutable: [
       'dk.cachet.carp.common.application.DateTime',
-      'dk.cachet.carp.common.application.data.input.CustomInput.T',
+      'dk.cachet.carp.common.application.data.input.CustomInput',
       'dk.cachet.carp.common.application.sampling.BatteryAwareSamplingConfiguration.TConfig',
       'kotlinx.serialization.json.Json'
     ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 # We are early adopters of Kotlin Multiplatform and don't mind frequent API changes in subsequent Kotlin releases.
 kotlin.mpp.stability.nowarn=true
+
+# TODO: Prevent dokka out of memory errors. Is this really needed? https://github.com/Kotlin/dokka/issues/1405
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
@@ -6,7 +6,7 @@ declare module 'carp.core-kotlin-carp.common'
     import HashMap = kotlin.collections.HashMap
     import HashSet = kotlin.collections.HashSet
 
-    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
+    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-js-legacy'
     import Json = kotlinx.serialization.json.Json
     
     

--- a/typescript-declarations/@types/carp.core-kotlin-carp.deployments.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.deployments.core/index.d.ts
@@ -5,7 +5,7 @@ declare module 'carp.core-kotlin-carp.deployments.core'
     import HashMap = kotlin.collections.HashMap
     import HashSet = kotlin.collections.HashSet
 
-    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
+    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-js-legacy'
     import Json = kotlinx.serialization.json.Json
 
     import { dk as cdk } from 'carp.core-kotlin-carp.common'

--- a/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
@@ -5,7 +5,7 @@ declare module 'carp.core-kotlin-carp.studies.core'
     import HashMap = kotlin.collections.HashMap
     import HashSet = kotlin.collections.HashSet
 
-    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
+    import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-js-legacy'
     import Json = kotlinx.serialization.json.Json
 
     import { dk as cdk } from 'carp.core-kotlin-carp.common'

--- a/typescript-declarations/@types/kotlinx-serialization-kotlinx-serialization-core-js-legacy/index.d.ts
+++ b/typescript-declarations/@types/kotlinx-serialization-kotlinx-serialization-core-js-legacy/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
+declare module 'kotlinx-serialization-kotlinx-serialization-core-js-legacy'
 {
     namespace kotlinx.serialization.builtins
     {

--- a/typescript-declarations/@types/kotlinx-serialization-kotlinx-serialization-json-js-legacy/index.d.ts
+++ b/typescript-declarations/@types/kotlinx-serialization-kotlinx-serialization-json-js-legacy/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
+declare module 'kotlinx-serialization-kotlinx-serialization-json-js-legacy'
 {
     namespace kotlinx.serialization.json
     {

--- a/typescript-declarations/package-lock.json
+++ b/typescript-declarations/package-lock.json
@@ -28,15 +28,6 @@
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -81,6 +72,23 @@
         }
       }
     },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -98,9 +106,9 @@
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-      "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -120,9 +128,9 @@
       "dev": true
     },
     "@tsconfig/node12": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.8.tgz",
-      "integrity": "sha512-LM6XwBhjZRls1qJGpiM/It09SntEwe9M0riXRfQ9s6XlJQG0JPGl92ET18LtGeYh/GuOtafIXqwZeqLOd0FNFQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
       "dev": true
     },
     "@tsconfig/node14": {
@@ -138,55 +146,54 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",
-      "integrity": "sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==",
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
+      "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+      "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
       "dev": true
     },
     "@types/mocha": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.2.tgz",
-      "integrity": "sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.2.tgz",
+      "integrity": "sha512-jJs9ErFLP403I+hMLGnqDRWT0RYKSvArxuBVh2veudHV7ifEC1WAmjJADacZ7mRbA2nWgHtn8xyECMAot0SkAw==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.26.0.tgz",
-      "integrity": "sha512-yA7IWp+5Qqf+TLbd8b35ySFOFzUfL7i+4If50EqvjT6w35X8Lv0eBHb6rATeWmucks37w+zV+tWnOXI9JlG6Eg==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.3.tgz",
+      "integrity": "sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.26.0",
-        "@typescript-eslint/scope-manager": "4.26.0",
+        "@typescript-eslint/experimental-utils": "4.28.3",
+        "@typescript-eslint/scope-manager": "4.28.3",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
-        "lodash": "^4.17.21",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.26.0.tgz",
-      "integrity": "sha512-TH2FO2rdDm7AWfAVRB5RSlbUhWxGVuxPNzGT7W65zVfl8H/WeXTk1e69IrcEVsBslrQSTDKQSaJD89hwKrhdkw==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.3.tgz",
+      "integrity": "sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.26.0",
-        "@typescript-eslint/types": "4.26.0",
-        "@typescript-eslint/typescript-estree": "4.26.0",
+        "@typescript-eslint/scope-manager": "4.28.3",
+        "@typescript-eslint/types": "4.28.3",
+        "@typescript-eslint/typescript-estree": "4.28.3",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -203,41 +210,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.26.0.tgz",
-      "integrity": "sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.3.tgz",
+      "integrity": "sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.26.0",
-        "@typescript-eslint/types": "4.26.0",
-        "@typescript-eslint/typescript-estree": "4.26.0",
+        "@typescript-eslint/scope-manager": "4.28.3",
+        "@typescript-eslint/types": "4.28.3",
+        "@typescript-eslint/typescript-estree": "4.28.3",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.26.0.tgz",
-      "integrity": "sha512-G6xB6mMo4xVxwMt5lEsNTz3x4qGDt0NSGmTBNBPJxNsrTXJSm21c6raeYroS2OwQsOyIXqKZv266L/Gln1BWqg==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.3.tgz",
+      "integrity": "sha512-/8lMisZ5NGIzGtJB+QizQ5eX4Xd8uxedFfMBXOKuJGP0oaBBVEMbJVddQKDXyyB0bPlmt8i6bHV89KbwOelJiQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.26.0",
-        "@typescript-eslint/visitor-keys": "4.26.0"
+        "@typescript-eslint/types": "4.28.3",
+        "@typescript-eslint/visitor-keys": "4.28.3"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.26.0.tgz",
-      "integrity": "sha512-rADNgXl1kS/EKnDr3G+m7fB9yeJNnR9kF7xMiXL6mSIWpr3Wg5MhxyfEXy/IlYthsqwBqHOr22boFbf/u6O88A==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.3.tgz",
+      "integrity": "sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.0.tgz",
-      "integrity": "sha512-GHUgahPcm9GfBuy3TzdsizCcPjKOAauG9xkz9TR8kOdssz2Iz9jRCSQm6+aVFa23d5NcSpo1GdHGSQKe0tlcbg==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.3.tgz",
+      "integrity": "sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.26.0",
-        "@typescript-eslint/visitor-keys": "4.26.0",
+        "@typescript-eslint/types": "4.28.3",
+        "@typescript-eslint/visitor-keys": "4.28.3",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -246,12 +253,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.0.tgz",
-      "integrity": "sha512-cw4j8lH38V1ycGBbF+aFiLUls9Z0Bw8QschP3mkth50BbWzgFS33ISIgBzUMuQ2IdahoEv/rXstr8Zhlz4B1Zg==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.3.tgz",
+      "integrity": "sha512-ri1OzcLnk1HH4gORmr1dllxDzzrN6goUIz/P4MHFV0YZJDCADPR3RvYNp0PW2SetKTThar6wlbFTL00hV2Q+fg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.26.0",
+        "@typescript-eslint/types": "4.28.3",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -286,9 +293,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true
     },
     "acorn-walk": {
@@ -325,35 +332,18 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
     },
     "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^2.0.1"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -513,6 +503,30 @@
         "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -536,6 +550,22 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "chokidar": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -545,6 +575,46 @@
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
         "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "color-convert": {
@@ -721,9 +791,9 @@
       }
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "enquirer": {
@@ -736,9 +806,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -749,14 +819,14 @@
         "has-symbols": "^1.0.2",
         "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.2",
-        "is-string": "^1.0.5",
-        "object-inspect": "^1.9.0",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.0"
+        "unbox-primitive": "^1.0.1"
       },
       "dependencies": {
         "object.assign": {
@@ -793,14 +863,6 @@
         "is-set": "^2.0.2",
         "is-string": "^1.0.5",
         "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
       }
     },
     "es-to-primitive": {
@@ -881,13 +943,14 @@
       }
     },
     "eslint": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
-      "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+      "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -927,26 +990,11 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
         }
       }
     },
@@ -1067,17 +1115,16 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       }
     },
     "fast-json-stable-stringify": {
@@ -1093,9 +1140,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
+      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -1120,12 +1167,13 @@
       }
     },
     "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       }
     },
     "flat": {
@@ -1135,14 +1183,6 @@
       "dev": true,
       "requires": {
         "is-buffer": "~2.0.3"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-          "dev": true
-        }
       }
     },
     "flat-cache": {
@@ -1156,9 +1196,9 @@
       }
     },
     "flatted": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
+      "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
       "dev": true
     },
     "form-data": {
@@ -1244,9 +1284,9 @@
       }
     },
     "globals": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -1415,6 +1455,12 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true
+    },
     "is-callable": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
@@ -1434,9 +1480,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-glob": {
@@ -1514,6 +1560,12 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -1617,13 +1669,12 @@
       }
     },
     "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
@@ -1657,33 +1708,6 @@
       "dev": true,
       "requires": {
         "chalk": "^4.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "lru-cache": {
@@ -1774,31 +1798,6 @@
         "yargs-unparser": "1.6.1"
       },
       "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "chokidar": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-          "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
-          "dev": true,
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1806,31 +1805,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
           }
         },
         "glob": {
@@ -1853,12 +1827,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
         "js-yaml": {
           "version": "3.14.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
@@ -1867,54 +1835,6 @@
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "readdirp": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-          "dev": true,
-          "requires": {
-            "picomatch": "^2.2.1"
           }
         },
         "strip-json-comments": {
@@ -1930,24 +1850,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
           }
         }
       }
@@ -1977,9 +1879,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
       "dev": true
     },
     "object-keys": {
@@ -2024,21 +1926,21 @@
       }
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "requires": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       }
     },
     "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^3.0.2"
       }
     },
     "p-try": {
@@ -2063,9 +1965,9 @@
       "dev": true
     },
     "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
     "path-is-absolute": {
@@ -2148,6 +2050,15 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
       }
     },
     "regexpp": {
@@ -2281,10 +2192,28 @@
         "is-fullwidth-code-point": "^3.0.0"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
       }
@@ -2312,14 +2241,14 @@
       "dev": true
     },
     "string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "requires": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "string.prototype.trimend": {
@@ -2343,12 +2272,12 @@
       }
     },
     "strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^4.1.0"
+        "ansi-regex": "^5.0.0"
       }
     },
     "strip-json-comments": {
@@ -2387,9 +2316,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
-          "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
+          "version": "8.6.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+          "integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -2398,49 +2327,11 @@
             "uri-js": "^4.2.2"
           }
         },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
-        },
-        "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
         }
       }
     },
@@ -2480,9 +2371,9 @@
       }
     },
     "ts-node": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
-      "integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.1.0.tgz",
+      "integrity": "sha512-6szn3+J9WyG2hE+5W8e0ruZrzyk1uFLYye6IGMBadnOzDh8aP7t8CbFpsfCiEx2+wMixAhjFt7lOZC4+l+WbEA==",
       "dev": true,
       "requires": {
         "@tsconfig/node10": "^1.0.7",
@@ -2534,9 +2425,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "unbox-primitive": {
@@ -2715,13 +2606,42 @@
         "strip-ansi": "^5.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -2778,6 +2698,89 @@
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
         "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "yargs-parser": {
@@ -2904,9 +2907,9 @@
           }
         },
         "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "version": "15.0.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
+          "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/typescript-declarations/package.json
+++ b/typescript-declarations/package.json
@@ -3,19 +3,19 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "@types/chai": "4.2.18",
-    "@types/mocha": "8.2.2",
-    "@types/node": "15.12.2",
-    "@typescript-eslint/eslint-plugin": "4.26.0",
-    "@typescript-eslint/parser": "4.26.0",
-    "@typescript-eslint/typescript-estree": "4.26.0",
-    "@typescript-eslint/types": "4.26.0",
+    "@types/chai": "4.2.21",
+    "@types/mocha": "8.2.3",
+    "@types/node": "16.3.2",
+    "@typescript-eslint/eslint-plugin": "4.28.3",
+    "@typescript-eslint/parser": "4.28.3",
+    "@typescript-eslint/typescript-estree": "4.28.3",
+    "@typescript-eslint/types": "4.28.3",
     "chai": "4.2.0",
-    "eslint": "7.28.0",
+    "eslint": "7.30.0",
     "mocha": "8.1.3",
     "jsdom": "16.6.0",
     "jsdom-global": "3.0.2",
-    "ts-node": "10.0.0",
-    "typescript": "4.3.2"
+    "ts-node": "10.1.0",
+    "typescript": "4.3.5"
   }
 }

--- a/typescript-declarations/tests/carp.common.ts
+++ b/typescript-declarations/tests/carp.common.ts
@@ -5,7 +5,7 @@ import { kotlin } from 'kotlin'
 import { Long } from 'kotlin'
 import toSet = kotlin.collections.toSet_us0mfu$
 
-import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
+import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-js-legacy'
 import Json = kotlinx.serialization.json.Json
 
 import { dk } from 'carp.core-kotlin-carp.common'

--- a/typescript-declarations/tests/carp.protocols.core.ts
+++ b/typescript-declarations/tests/carp.protocols.core.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import VerifyModule from './VerifyModule'
 
-import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
+import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-js-legacy'
 import Json = kotlinx.serialization.json.Json
 
 import { dk as cdk } from 'carp.core-kotlin-carp.common'

--- a/typescript-declarations/tests/carp.studies.core.ts
+++ b/typescript-declarations/tests/carp.studies.core.ts
@@ -8,9 +8,9 @@ import HashSet = kotlin.collections.HashSet
 import toMap = kotlin.collections.toMap_v2dak7$
 import toSet = kotlin.collections.toSet_us0mfu$
 
-import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-jsLegacy'
+import { kotlinx } from 'kotlinx-serialization-kotlinx-serialization-json-js-legacy'
 import Json = kotlinx.serialization.json.Json
-import { kotlinx as kotlinxcore } from 'kotlinx-serialization-kotlinx-serialization-core-jsLegacy'
+import { kotlinx as kotlinxcore } from 'kotlinx-serialization-kotlinx-serialization-core-js-legacy'
 import ListSerializer = kotlinxcore.serialization.builtins.ListSerializer_swdriu$
 
 import { dk as cdk } from 'carp.core-kotlin-carp.common'

--- a/typescript-declarations/tests/kotlinx-serialization.ts
+++ b/typescript-declarations/tests/kotlinx-serialization.ts
@@ -6,7 +6,7 @@ describe( "kotlinx-serialization", () => {
         const instances = new Array<any>()
 
         const moduleVerifier = new VerifyModule(
-            'kotlinx-serialization-kotlinx-serialization-core-jsLegacy',
+            'kotlinx-serialization-kotlinx-serialization-core-js-legacy',
             instances
         )
         await moduleVerifier.verify()
@@ -16,7 +16,7 @@ describe( "kotlinx-serialization", () => {
         const instances = new Array<any>()
 
         const moduleVerifier = new VerifyModule(
-            'kotlinx-serialization-kotlinx-serialization-json-jsLegacy',
+            'kotlinx-serialization-kotlinx-serialization-json-js-legacy',
             instances
         )
         await moduleVerifier.verify()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/778006/125532355-eccfdfca-7cb5-479f-8ddd-3e5f48984aaa.png)

- Upgrade to Kotlin 1.5.21, serialization 1.2.2, and coroutines 1.5.1 (Closes #256).
- With Kotlin up-to-date, I attempted to switch to the JS IR backend to try generating TypeScript, but this still doesn't work (#156).
- Finally upgraded to dokka 1.5.0 to generate Javadoc for the Maven publications (Closes #28). With that in place, we are likely also ready to publish full multiplatform documentation next (#285).
- Switched to new sonatype nexus publication plugin; old one was no longer maintained and sometimes made publication fail (Closes #83). This very likely also closes #154.
- Various other minor dependency updates: detekt 1.18.0-RC1 and npm dependencies for the `verifyTsDeclarations` module/task.

Lastly, I also cleaned up the build output a bit by suppressing warnings which we know aren't a problem.