### PR TITLE
Use custom application service exceptions

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApplicationServiceException.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApplicationServiceException.kt
@@ -1,0 +1,53 @@
+package dk.cachet.carp.common.application.services
+
+import kotlin.reflect.KCallable
+
+
+/**
+ * An argument passed to the application service [endpoint] is invalid.
+ *
+ * When the application service is exposed as a web service, this maps to response status code 400 (Bad Request).
+ */
+class ApplicationServiceArgumentException(
+    val endpoint: KCallable<*>,
+    cause: Throwable? = null,
+    message: String? = null
+) : IllegalArgumentException( "Illegal argument passed to \"${endpoint.name}\": ${message ?: cause?.message}", cause )
+
+
+/**
+ * The requested operation exposed by [endpoint] is invalid given the current state of the objects it acts on.
+ *
+ * When this application service is exposed as a web service, this maps to response status code 409 (Conflict).
+ */
+class ApplicationServiceStateException(
+    val endpoint: KCallable<*>,
+    cause: Throwable? = null,
+    message: String? = null
+) : IllegalArgumentException( "Illegal state while calling \"${endpoint.name}\": ${message ?: cause?.message}", cause )
+
+
+/**
+ * Catches [IllegalArgumentException]s that are thrown from [block] and
+ * wraps them as [ApplicationServiceArgumentException] with the additional [endpoint] information.
+ */
+suspend fun <TReturn> wrapArgumentExceptions( endpoint: KCallable<*>, block: suspend () -> TReturn ): TReturn =
+    try { block() }
+    catch ( ex: IllegalArgumentException ) { throw ApplicationServiceArgumentException( endpoint, ex ) }
+
+/**
+ * Catches [IllegalStateException]s that are thrown from [block] and
+ * wraps them as [ApplicationServiceStateException] with the additional [endpoint] information.
+ */
+suspend fun <TReturn> wrapStateExceptions( endpoint: KCallable<*>, block: suspend () -> TReturn ): TReturn =
+    try { block() }
+    catch ( ex: IllegalStateException ) { throw ApplicationServiceStateException( endpoint, ex ) }
+
+/**
+ * Catches [IllegalArgumentException]s and [IllegalStateException]s that are thrown from [block] and
+ * wraps them in the corresponding application service exceptions with the additional [endpoint] information.
+ */
+suspend fun <TReturn> wrapExceptions( endpoint: KCallable<*>, block: suspend() -> TReturn ): TReturn =
+    try { block() }
+    catch ( ex: IllegalArgumentException ) { throw ApplicationServiceArgumentException( endpoint, ex ) }
+    catch ( ex: IllegalStateException ) { throw ApplicationServiceStateException( endpoint, ex ) }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
@@ -4,6 +4,8 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.AnyDeviceDescriptor
 import dk.cachet.carp.common.application.devices.DeviceRegistration
 import dk.cachet.carp.common.application.services.ApplicationService
+import dk.cachet.carp.common.application.services.ApplicationServiceArgumentException
+import dk.cachet.carp.common.application.services.ApplicationServiceStateException
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.deployments.application.users.ParticipantInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
@@ -48,7 +50,7 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
      * An invitation (and account details) is delivered to the person managing the identity,
      * or should be handed out manually to the relevant participant by the person managing the identity.
      *
-     * @throws IllegalArgumentException when:
+     * @throws ApplicationServiceArgumentException when:
      *  - a deployment with [id] already exists
      *  - [protocol] is invalid
      *  - [invitations] is empty
@@ -77,14 +79,14 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
     /**
      * Get the status for a study deployment with the given [studyDeploymentId].
      *
-     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist.
+     * @throws ApplicationServiceArgumentException when a deployment with [studyDeploymentId] does not exist.
      */
     suspend fun getStudyDeploymentStatus( studyDeploymentId: UUID ): StudyDeploymentStatus
 
     /**
      * Get the statuses for a set of deployments with the specified [studyDeploymentIds].
      *
-     * @throws IllegalArgumentException when [studyDeploymentIds] contains an ID for which no deployment exists.
+     * @throws ApplicationServiceArgumentException when [studyDeploymentIds] contains an ID for which no deployment exists.
      */
     suspend fun getStudyDeploymentStatusList( studyDeploymentIds: Set<UUID> ): List<StudyDeploymentStatus>
 
@@ -93,31 +95,31 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
      *
      * @param registration A matching configuration for the device with [deviceRoleName].
      *
-     * @throws IllegalArgumentException when:
+     * @throws ApplicationServiceArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [deviceRoleName] is not present in the deployment or is already registered and a different [registration] is specified than a previous request
      * - [registration] is invalid for the specified device or uses a device ID which has already been used as part of registration of a different device
-     * @throws IllegalStateException when this deployment has stopped.
+     * @throws ApplicationServiceStateException when this deployment has stopped.
      */
     suspend fun registerDevice( studyDeploymentId: UUID, deviceRoleName: String, registration: DeviceRegistration ): StudyDeploymentStatus
 
     /**
      * Unregister the device with the specified [deviceRoleName] for the study deployment with [studyDeploymentId].
      *
-     * @throws IllegalArgumentException when:
+     * @throws ApplicationServiceArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [deviceRoleName] is not present in the deployment
-     * @throws IllegalStateException when this deployment has stopped.
+     * @throws ApplicationServiceStateException when this deployment has stopped.
      */
     suspend fun unregisterDevice( studyDeploymentId: UUID, deviceRoleName: String ): StudyDeploymentStatus
 
     /**
      * Get the deployment configuration for the master device with [masterDeviceRoleName] in the study deployment with [studyDeploymentId].
      *
-     * @throws IllegalArgumentException when:
+     * @throws ApplicationServiceArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [masterDeviceRoleName] is not present in the deployment
-     * @throws IllegalStateException when the deployment for the requested master device is not yet available.
+     * @throws ApplicationServiceStateException when the deployment for the requested master device is not yet available.
      */
     suspend fun getDeviceDeploymentFor( studyDeploymentId: UUID, masterDeviceRoleName: String ): MasterDeviceDeployment
 
@@ -127,11 +129,11 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
      * using the device deployment with timestamp [deviceDeploymentLastUpdatedOn],
      * i.e., that the study deployment was loaded on the device and that the necessary runtime is available to run it.
      *
-     * @throws IllegalArgumentException when:
+     * @throws ApplicationServiceArgumentException when:
      * - a deployment with [studyDeploymentId] does not exist
      * - [masterDeviceRoleName] is not present in the deployment
      * - the [deviceDeploymentLastUpdatedOn] does not match the expected timestamp. The deployment might be outdated.
-     * @throws IllegalStateException when the deployment cannot be deployed yet, or the deployment has stopped.
+     * @throws ApplicationServiceStateException when the deployment cannot be deployed yet, or the deployment has stopped.
      */
     suspend fun deploymentSuccessful(
         studyDeploymentId: UUID,
@@ -143,7 +145,7 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
      * Stop the study deployment with the specified [studyDeploymentId].
      * No further changes to this deployment will be allowed and no more data will be collected.
      *
-     * @throws IllegalArgumentException when a deployment with [studyDeploymentId] does not exist.
+     * @throws ApplicationServiceArgumentException when a deployment with [studyDeploymentId] does not exist.
      */
     suspend fun stop( studyDeploymentId: UUID ): StudyDeploymentStatus
 }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/DeploymentRepository.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/DeploymentRepository.kt
@@ -18,31 +18,10 @@ interface DeploymentRepository
     suspend fun getStudyDeploymentBy( id: UUID ): StudyDeployment? = getStudyDeploymentsBy( setOf( id ) ).firstOrNull()
 
     /**
-     * Return the [StudyDeployment] with the specified [id].
-     *
-     * @throws IllegalArgumentException when no study deployment is found.
-     */
-    suspend fun getStudyDeploymentOrThrowBy( id: UUID ): StudyDeployment = getStudyDeploymentBy( id )
-        ?: throw IllegalArgumentException( "A deployment with ID '$id' does not exist." )
-
-    /**
      * Return all [StudyDeployment]s matching any of the specified [ids].
      * Ids that are not found are ignored.
      */
     suspend fun getStudyDeploymentsBy( ids: Set<UUID> ): List<StudyDeployment>
-
-    /**
-     * Return all [StudyDeployment]s matching the specified [ids].
-     *
-     * @throws IllegalArgumentException when no deployment exists for one of the specified [ids].
-     */
-    suspend fun getStudyDeploymentsOrThrowBy( ids: Set<UUID> ): List<StudyDeployment>
-    {
-        val deployments = getStudyDeploymentsBy( ids )
-        require( ids.size == deployments.size ) { "No deployment exists for one of the specified studyDeploymentIds." }
-
-        return deployments
-    }
 
     /**
      * Update a [studyDeployment] which is already stored in this repository.

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
@@ -250,7 +250,11 @@ class StudyDeployment( val protocolSnapshot: StudyProtocolSnapshot, val id: UUID
     /**
      * Register the specified [device] for this deployment using the passed [registration] options.
      *
-     * @throws IllegalArgumentException when the passed device is not part of this deployment or is already registered.
+     * @throws IllegalArgumentException when:
+     *  - the passed device is not part of this deployment
+     *  - the passed device is already registered
+     *  - the device registration is not valid for the device
+     *  - the deviceId in registration is already in use by a device of the same type
      * @throws IllegalStateException when this deployment has stopped.
      */
     fun registerDevice( device: AnyDeviceDescriptor, registration: DeviceRegistration )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceTest.kt
@@ -1,6 +1,8 @@
 package dk.cachet.carp.deployments.application
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApplicationServiceArgumentException
+import dk.cachet.carp.common.application.services.ApplicationServiceStateException
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.deployments.application.users.ParticipantInvitation
 import dk.cachet.carp.deployments.application.users.StudyInvitation
@@ -59,7 +61,7 @@ abstract class DeploymentServiceTest
             AccountIdentity.fromUsername( "User" ),
             StudyInvitation( "Some study" )
         )
-        assertFailsWith<IllegalArgumentException> {
+        assertFailsWith<ApplicationServiceArgumentException> {
             deploymentService.createStudyDeployment( studyDeploymentId, protocol.getSnapshot(), listOf( invitation ) )
         }
     }
@@ -73,8 +75,8 @@ abstract class DeploymentServiceTest
 
         val removedIds = deploymentService.removeStudyDeployments( deploymentIds )
         assertEquals( deploymentIds, removedIds )
-        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatus( deploymentId1 ) }
-        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatus( deploymentId2 ) }
+        assertFailsWith<ApplicationServiceArgumentException> { deploymentService.getStudyDeploymentStatus( deploymentId1 ) }
+        assertFailsWith<ApplicationServiceArgumentException> { deploymentService.getStudyDeploymentStatus( deploymentId2 ) }
     }
 
     @Test
@@ -101,7 +103,7 @@ abstract class DeploymentServiceTest
     fun getStudyDeploymentStatus_fails_for_unknown_studyDeploymentId() = runSuspendTest {
         val deploymentService = createService()
 
-        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatus( unknownId ) }
+        assertFailsWith<ApplicationServiceArgumentException> { deploymentService.getStudyDeploymentStatus( unknownId ) }
     }
 
     @Test
@@ -128,7 +130,7 @@ abstract class DeploymentServiceTest
         val studyDeploymentId = addTestDeployment( deploymentService, "Test device" )
 
         val deploymentIds = setOf( studyDeploymentId, unknownId )
-        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatusList( deploymentIds ) }
+        assertFailsWith<ApplicationServiceArgumentException> { deploymentService.getStudyDeploymentStatusList( deploymentIds ) }
     }
 
     @Test
@@ -154,7 +156,7 @@ abstract class DeploymentServiceTest
         deploymentService.registerDevice( studyDeploymentId, master.roleName, registration )
         deploymentService.stop( studyDeploymentId )
 
-        assertFailsWith<IllegalStateException>
+        assertFailsWith<ApplicationServiceStateException>
         {
             deploymentService.registerDevice( studyDeploymentId, master.roleName, registration )
         }
@@ -186,7 +188,7 @@ abstract class DeploymentServiceTest
     fun stop_fails_for_unknown_studyDeploymentId() = runSuspendTest {
         val deploymentService = createService()
 
-        assertFailsWith<IllegalArgumentException> { deploymentService.stop( unknownId ) }
+        assertFailsWith<ApplicationServiceArgumentException> { deploymentService.stop( unknownId ) }
     }
 
     @Test
@@ -200,12 +202,12 @@ abstract class DeploymentServiceTest
         deploymentService.registerDevice( studyDeploymentId, connected.roleName, connected.createRegistration() )
         deploymentService.stop( studyDeploymentId )
 
-        assertFailsWith<IllegalStateException>
+        assertFailsWith<ApplicationServiceStateException>
             { deploymentService.registerDevice( studyDeploymentId, connected.roleName, connected.createRegistration() ) }
-        assertFailsWith<IllegalStateException>
+        assertFailsWith<ApplicationServiceStateException>
             { deploymentService.unregisterDevice( studyDeploymentId, master.roleName ) }
         val deviceDeployment = deploymentService.getDeviceDeploymentFor( studyDeploymentId, master.roleName )
-        assertFailsWith<IllegalStateException>
+        assertFailsWith<ApplicationServiceStateException>
             { deploymentService.deploymentSuccessful( studyDeploymentId, master.roleName, deviceDeployment.lastUpdatedOn ) }
     }
 


### PR DESCRIPTION
So far:

- Introduce custom `ApplicationServiceArgumentException` and `ApplicationServiceStateException`.
- Replaced previous exceptions with the new ones in `DeploymentService`.

This should already be sufficient for a draft review, as the remainder of the PR will simply replace exceptions in all remaining application services.

Closes #298 