### PR TITLE
Add method to get default `SamplingConfiguration` for a data type on a device

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Two key **design goals** differentiate this project from similar projects:
 ## Table of Contents
 
 - [Architecture](#architecture)
+  - [Common](docs/carp-common.md)
+    - [Data types](docs/carp-common.md#data-types)
+    - [Device descriptors](docs/carp-common.md#device-descriptors)
+    - [Sampling schemes and configurations](docs/carp-common.md#sampling-schemes-and-configurations)
+    - [Tasks](docs/carp-common.md#tasks)
+    - [Triggers](docs/carp-common.md#triggers)
   - [Protocols](docs/carp-protocols.md)
     - [Domain objects](docs/carp-protocols.md#domain-objects)
     - [Application services](docs/carp-protocols.md#application-services)
@@ -32,8 +38,6 @@ Two key **design goals** differentiate this project from similar projects:
   - [Data](docs/carp-data.md)
     - [Data streams](docs/carp-data.md#data-streams)
     - [Application services](docs/carp-data.md#application-services)
-  - [Common](docs/carp-common.md)
-    - [Built-in types](docs/carp-common.md#built-in-types)
 - [Infrastructure helpers](#infrastructure-helpers)
   - [Serialization](#serialization)
   - [Request objects](#request-objects)

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
@@ -31,6 +31,7 @@ data class AltBeacon( override val roleName: String ) : DeviceDescriptor<AltBeac
     object Tasks : TaskDescriptorList()
 
     override fun getSupportedDataTypes(): Set<DataType> = Sensors.keys
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap = Sensors
 
     override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration> = emptyMap()
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLEHeartRateDevice.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLEHeartRateDevice.kt
@@ -41,6 +41,7 @@ data class BLEHeartRateDevice(
 
 
     override fun getSupportedDataTypes(): Set<DataType> = Sensors.keys
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap = Sensors
     override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration> = emptyMap()
 
     override fun createDeviceRegistrationBuilder(): MACAddressDeviceRegistrationBuilder = MACAddressDeviceRegistrationBuilder()

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/CustomProtocolDevice.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/CustomProtocolDevice.kt
@@ -23,6 +23,7 @@ data class CustomProtocolDevice( override val roleName: String ) :
 
     // Measures and data types are defined in the custom `CustomProtocolTask.studyProtocol` and thus not managed by core.
     override fun getSupportedDataTypes(): Set<DataType> = Sensors.keys
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap = Sensors
 
     override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration> = emptyMap()
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceDescriptor.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceDescriptor.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.application.Immutable
 import dk.cachet.carp.common.application.ImplementAsDataClass
 import dk.cachet.carp.common.application.Trilean
 import dk.cachet.carp.common.application.data.DataType
+import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.application.sampling.SamplingConfigurationMapBuilder
 import kotlinx.serialization.Polymorphic
@@ -44,6 +45,23 @@ abstract class DeviceDescriptor<
      *       We might also want to check whether the sampling configuration instances are valid.
      */
     abstract val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration>
+
+    /**
+     * Get the default sampling configuration to be used for measurements of [dataType].
+     * The configuration to use may still be overridden by individual data stream measures.
+     */
+    fun getDefaultSamplingConfiguration( dataType: DataType ): SamplingConfiguration =
+        defaultSamplingConfiguration[ dataType ]
+            ?: getDataTypeSamplingSchemes()[ dataType ]?.default
+            ?: throw IllegalArgumentException( "The specified `dataType` is not supported on this device." )
+
+    /**
+     * Return sampling schemes for all the sensors available on this device.
+     *
+     * Implementations of [DeviceDescriptor] should simply return the mandatory inner object
+     * `object Sensors : DataTypeSamplingSchemeMap()` here.
+     */
+    protected abstract fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap
 
     protected abstract fun createDeviceRegistrationBuilder(): TRegistrationBuilder
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt
@@ -65,6 +65,7 @@ data class Smartphone(
     }
 
     override fun getSupportedDataTypes(): Set<DataType> = Sensors.keys
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap = Sensors
 
     override fun createDeviceRegistrationBuilder(): SmartphoneDeviceRegistrationBuilder = SmartphoneDeviceRegistrationBuilder()
     override fun getRegistrationClass(): KClass<SmartphoneDeviceRegistration> = SmartphoneDeviceRegistration::class

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/BatteryAwareSampling.kt
@@ -31,7 +31,10 @@ abstract class BatteryAwareSamplingScheme<
      * By default, sampling should be disabled at this point.
      */
     val critical: TConfig? = null
-) : DataTypeSamplingScheme<BatteryAwareSamplingConfigurationBuilder<TConfig, TBuilder>>( dataType )
+) : DataTypeSamplingScheme<BatteryAwareSamplingConfigurationBuilder<TConfig, TBuilder>>(
+    dataType,
+    BatteryAwareSamplingConfiguration( normal, low, critical )
+)
 {
     private val configurationKlass: KClass<out TConfig> = normal::class
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/DataTypeSamplingScheme.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/DataTypeSamplingScheme.kt
@@ -13,7 +13,11 @@ abstract class DataTypeSamplingScheme<TConfigBuilder : SamplingConfigurationBuil
     /**
      * Information about the data type this sampling scheme relates to.
      */
-    val dataType: DataTypeMetaData
+    val dataType: DataTypeMetaData,
+    /**
+     * The default [SamplingConfiguration] to use when no other configuration is specified.
+     */
+    val default: SamplingConfiguration
 )
 {
     /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/GranularitySampling.kt
@@ -10,7 +10,10 @@ import kotlinx.serialization.Serializable
  * The levels of granularity correspond to expected degrees of power consumption.
  */
 class GranularitySamplingScheme( dataType: DataTypeMetaData, val defaultGranularity: Granularity ) :
-    DataTypeSamplingScheme<GranularitySamplingConfigurationBuilder>( dataType )
+    DataTypeSamplingScheme<GranularitySamplingConfigurationBuilder>(
+        dataType,
+        GranularitySamplingConfiguration( defaultGranularity )
+    )
 {
     override fun createSamplingConfigurationBuilder(): GranularitySamplingConfigurationBuilder =
         GranularitySamplingConfigurationBuilder( defaultGranularity )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt
@@ -11,7 +11,10 @@ import kotlin.time.Duration
  * Sampling scheme which allows configuring a time interval in between subsequent measurements.
  */
 class IntervalSamplingScheme( dataType: DataTypeMetaData, val defaultMeasureInterval: Duration ) :
-    DataTypeSamplingScheme<IntervalSamplingConfigurationBuilder>( dataType )
+    DataTypeSamplingScheme<IntervalSamplingConfigurationBuilder>(
+        dataType,
+        IntervalSamplingConfiguration( defaultMeasureInterval )
+    )
 {
     override fun createSamplingConfigurationBuilder(): IntervalSamplingConfigurationBuilder =
         IntervalSamplingConfigurationBuilder( defaultMeasureInterval )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/NoOptionsSampling.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/NoOptionsSampling.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
  * Sampling scheme which does not allow any sampling configuration.
  */
 class NoOptionsSamplingScheme( dataType: DataTypeMetaData ) :
-    DataTypeSamplingScheme<NoOptionsSamplingConfigurationBuilder>( dataType )
+    DataTypeSamplingScheme<NoOptionsSamplingConfigurationBuilder>( dataType, NoOptionsSamplingConfiguration )
 {
     override fun createSamplingConfigurationBuilder(): NoOptionsSamplingConfigurationBuilder =
         NoOptionsSamplingConfigurationBuilder

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/Measure.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/Measure.kt
@@ -22,7 +22,8 @@ sealed class Measure
          */
         val type: DataType,
         /**
-         * Override the default configuration on how to sample the data stream of the matching [type] on the device.
+         * Optionally, override the default configuration on how to sample the data stream of the matching [type] on the device.
+         * In case `null` is specified, the default configuration is derived from the [DeviceDescriptor].
          */
         val overrideSamplingConfiguration: SamplingConfiguration? = null
     ) : Measure()

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/DurationSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/DurationSerializer.kt
@@ -12,7 +12,8 @@ import kotlin.time.Duration
 /**
  * Serializes [Duration] by converting it to microseconds.
  */
-object DurationSerializer : KSerializer<Duration> {
+object DurationSerializer : KSerializer<Duration>
+{
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor( "$NAMESPACE.${Duration::class.simpleName!!}", PrimitiveKind.STRING )
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
@@ -8,6 +8,7 @@ import dk.cachet.carp.common.application.devices.DeviceDescriptor
 import dk.cachet.carp.common.application.devices.DeviceRegistration
 import dk.cachet.carp.common.application.devices.DeviceRegistrationBuilder
 import dk.cachet.carp.common.application.devices.MasterDeviceDescriptor
+import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -30,8 +31,10 @@ data class CustomDeviceDescriptor(
 
     override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration>
 
-    // This information is not serialized. Therefore, the supported types are unknown.
+    // This information is not serialized. Therefore, the supported types and sampling schemes are unknown.
     override fun getSupportedDataTypes(): Set<DataType> = emptySet()
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap =
+        throw UnsupportedOperationException( "The concrete type of this device is not known. Therefore, sampling schemes are unknown." )
 
     init
     {
@@ -67,8 +70,10 @@ data class CustomMasterDeviceDescriptor(
 
     override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration>
 
-    // This information is not serialized. Therefore, the supported types are unknown.
+    // This information is not serialized. Therefore, the supported types and sampling schemes are unknown.
     override fun getSupportedDataTypes(): Set<DataType> = emptySet()
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap =
+        throw UnsupportedOperationException( "The concrete type of this device is not known. Therefore, sampling schemes are unknown." )
 
     init
     {
@@ -97,6 +102,8 @@ private data class BaseMembers(
 ) : DeviceDescriptor<DeviceRegistration, DeviceRegistrationBuilder<DeviceRegistration>>()
 {
     override fun getSupportedDataTypes(): Set<DataType> =
+        throw UnsupportedOperationException()
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap =
         throw UnsupportedOperationException()
     override fun createDeviceRegistrationBuilder(): DeviceRegistrationBuilder<DeviceRegistration> =
         throw UnsupportedOperationException()

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubDataTypes.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubDataTypes.kt
@@ -32,7 +32,7 @@ val STUB_DATA_TIME_SPAN_TYPE: DataType = DataType.fromString( StubDataTypes.STUB
 
 
 class StubDataTypeSamplingScheme :
-    DataTypeSamplingScheme<NoOptionsSamplingConfigurationBuilder>( StubDataTypes.STUB )
+    DataTypeSamplingScheme<NoOptionsSamplingConfigurationBuilder>( StubDataTypes.STUB, NoOptionsSamplingConfiguration )
 {
     override fun createSamplingConfigurationBuilder(): NoOptionsSamplingConfigurationBuilder = NoOptionsSamplingConfigurationBuilder
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubDeviceDescriptor.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubDeviceDescriptor.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.devices.DefaultDeviceRegistration
 import dk.cachet.carp.common.application.devices.DefaultDeviceRegistrationBuilder
 import dk.cachet.carp.common.application.devices.DeviceDescriptor
+import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
@@ -21,7 +22,13 @@ data class StubDeviceDescriptor(
 ) :
     DeviceDescriptor<DefaultDeviceRegistration, DefaultDeviceRegistrationBuilder>()
 {
-    override fun getSupportedDataTypes(): Set<DataType> = setOf( STUB_DATA_TYPE )
+    object Sensors : DataTypeSamplingSchemeMap()
+    {
+        val STUB_DATA = add( StubDataTypeSamplingScheme() )
+    }
+
+    override fun getSupportedDataTypes(): Set<DataType> = Sensors.keys
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap = Sensors
     override fun createDeviceRegistrationBuilder(): DefaultDeviceRegistrationBuilder = DefaultDeviceRegistrationBuilder()
     override fun getRegistrationClass(): KClass<DefaultDeviceRegistration> = DefaultDeviceRegistration::class
     override fun isValidRegistration( registration: DefaultDeviceRegistration ): Trilean = Trilean.TRUE

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubMasterDeviceDescriptor.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/test/StubMasterDeviceDescriptor.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.devices.DefaultDeviceRegistration
 import dk.cachet.carp.common.application.devices.DefaultDeviceRegistrationBuilder
 import dk.cachet.carp.common.application.devices.MasterDeviceDescriptor
+import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
@@ -20,7 +21,13 @@ data class StubMasterDeviceDescriptor(
     override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration> = emptyMap()
 ) : MasterDeviceDescriptor<DefaultDeviceRegistration, DefaultDeviceRegistrationBuilder>()
 {
-    override fun getSupportedDataTypes(): Set<DataType> = setOf( STUB_DATA_TYPE )
+    object Sensors : DataTypeSamplingSchemeMap()
+    {
+        val STUB_DATA = add( StubDataTypeSamplingScheme() )
+    }
+
+    override fun getSupportedDataTypes(): Set<DataType> = Sensors.keys
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap = Sensors
     override fun createDeviceRegistrationBuilder(): DefaultDeviceRegistrationBuilder = DefaultDeviceRegistrationBuilder()
     override fun getRegistrationClass(): KClass<DefaultDeviceRegistration> = DefaultDeviceRegistration::class
     override fun isValidRegistration( registration: DefaultDeviceRegistration ) = Trilean.TRUE

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/DeviceDescriptorTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/DeviceDescriptorTest.kt
@@ -1,0 +1,49 @@
+package dk.cachet.carp.common.application.devices
+
+import dk.cachet.carp.common.application.data.DataType
+import dk.cachet.carp.common.application.sampling.BatteryAwareSamplingConfiguration
+import dk.cachet.carp.common.application.sampling.Granularity
+import dk.cachet.carp.common.application.sampling.GranularitySamplingConfiguration
+import kotlin.test.*
+
+
+/**
+ * Tests for [DeviceDescriptor].
+ */
+class DeviceDescriptorTest
+{
+    @Test
+    fun getDefaultSamplingConfiguration_succeeds()
+    {
+        val typeMetaData = Smartphone.Sensors.GEOLOCATION
+        val device = Smartphone( "Irrelevant" )
+
+        val configuration = device.getDefaultSamplingConfiguration( typeMetaData.dataType.type )
+        assertEquals( typeMetaData.default, configuration )
+    }
+
+    @Test
+    fun getDefaultSamplingConfiguration_returns_overridden_defaultSamplingConfiguration()
+    {
+        val typeMetaData = Smartphone.Sensors.GEOLOCATION
+        val dataType = typeMetaData.dataType.type
+        val configurationOverride = BatteryAwareSamplingConfiguration(
+            GranularitySamplingConfiguration( Granularity.Coarse ),
+            GranularitySamplingConfiguration( Granularity.Coarse ),
+            GranularitySamplingConfiguration( Granularity.Coarse )
+        )
+        val device = Smartphone( "Irrelevant", mapOf( dataType to configurationOverride ) )
+
+        val configuration = device.getDefaultSamplingConfiguration( dataType )
+        assertEquals( configurationOverride, configuration )
+    }
+
+    @Test
+    fun getDefaultSamplingConfiguration_fails_for_unsupported_type()
+    {
+        val device = Smartphone( "Irrelevant" )
+
+        val unsupportedType = DataType( "unsupported", "type" )
+        assertFailsWith<IllegalArgumentException> { device.getDefaultSamplingConfiguration( unsupportedType ) }
+    }
+}

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/DataTypeSamplingSchemeTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/sampling/DataTypeSamplingSchemeTest.kt
@@ -10,7 +10,10 @@ import kotlin.time.Duration
  */
 class DataTypeSamplingSchemeTest
 {
-    class TestSamplingScheme : DataTypeSamplingScheme<IntervalSamplingConfigurationBuilder>( StubDataTypes.STUB )
+    class TestSamplingScheme : DataTypeSamplingScheme<IntervalSamplingConfigurationBuilder>(
+        StubDataTypes.STUB,
+        IntervalSamplingConfiguration( Duration.seconds( 1 ) )
+    )
     {
         val maxDuration: Duration = Duration.seconds( 42 )
 

--- a/docs/carp-common.md
+++ b/docs/carp-common.md
@@ -1,12 +1,10 @@
 # carp.common [![Maven Central](https://maven-badges.herokuapp.com/maven-central/dk.cachet.carp.common/carp.common/badge.svg?color=orange)](https://mvnrepository.com/artifact/dk.cachet.carp.common) [![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/dk.cachet.carp.common/carp.common?server=https%3A%2F%2Foss.sonatype.org)](https://oss.sonatype.org/content/repositories/snapshots/dk/cachet/carp/common/)
 
 Implements helper classes and base types relied upon by all subsystems.
-Primarily, this contains the [built-in types](#built-in-types) used to [define study protocols](carp-protocols.md#domain-objects)
+Primarily, this contains the built-in types used to [define study protocols](carp-protocols.md#domain-objects)
 which subsequently get passed to the deployments and clients subsystem.
 
-## Built-in types
-
-### Data types
+## Data types
 
 `DataType`s are identified by a given _name_ within a _namespace_ and prescribe the data contained within each data point when measured.
 When a data type describes data over the course of a time interval, the time interval is stored within the header (shared by all data types) and not in data-type specific data.
@@ -26,7 +24,7 @@ All of the built-in data types belong to the namespace: **dk.cachet.carp**.
 | [signalstrength](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/SignalStrength.kt) | The received signal strength of a wireless device. |
 | [triggeredtask](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/TriggeredTask.kt) | A task which was started or stopped by a trigger, referring to identifiers in the study protocol. |
 
-### Device descriptors
+## Device descriptors
 
 | Class | Master | Description |
 | --- | :---: | --- |
@@ -35,9 +33,19 @@ All of the built-in data types belong to the namespace: **dk.cachet.carp**.
 | [BLEHeartRateDevice](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLEHeartRateDevice.kt) | | A Bluetooth device which implements a Heart Rate service. |
 | [CustomProtocolDevice](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/CustomProtocolDevice.kt) | Yes | A master device which uses a single `CustomProtocolTask` to determine how to run a study on the device. |
 
-### Sampling schemes
+## Sampling schemes and configurations
 
 Supports specifying the sampling scheme for a [`DataType`](#data-types), including possible options, defaults, and constraints.
+
+From sampling _schemes_, matching sampling _configurations_ can be created.
+Per data type, only one `SamplingConfiguration` is ever active on a device.
+The sampling configuration to be used is determined on clients in order of priority:
+
+1. The sampling configuration, if specified in the study protocol, of the `Measure.DataStream` in the last triggered _active_ `TaskDescriptor`. 
+   Once a task stops, it is no longer "active".
+2. The default sampling configuration, if specified in the study protocol, for the `DeviceDescriptor`.
+   This can be retrieved through `MasterDeviceDeployment` on the client.
+3. The default sampling configuration hardcoded in the `Sensors` sampling schemes of the concrete `DeviceDescriptor`, if none of the previous configurations are present.
 
 Some sampling schemes support specifying a different sampling configuration depending on how much battery is left,
 indicated by the "Battery-aware" column.
@@ -50,7 +58,7 @@ These extend from [BatteryAwareSampling](../carp.common/src/commonMain/kotlin/dk
 | [IntervalSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/IntervalSampling.kt) | | Specify a time interval in between subsequent measurements. |
 | [NoOptionsSampling](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/sampling/NoOptionsSampling.kt) | | Does not allow any sampling configuration. |
 
-### Tasks
+## Tasks
 
 | Class | Description |
 | --- | --- |
@@ -58,7 +66,7 @@ These extend from [BatteryAwareSampling](../carp.common/src/commonMain/kotlin/dk
 | [CustomProtocolTask](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/CustomProtocolTask.kt) | Contains a definition on how to run tasks, measures, and triggers which differs from the CARP domain model. |
 | [WebTask](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/WebTask.kt) | Redirects to a web page which contains the task which needs to be performed. |
 
-### Triggers
+## Triggers
 
 | Class | Description |
 | --- | --- |

--- a/docs/carp-protocols.md
+++ b/docs/carp-protocols.md
@@ -37,7 +37,7 @@ Most of these are abstract base types. For information on concrete types extendi
 
 ## Extending domain objects
 
-In case the [currently supported built-in types](carp-common.md#built-in-types) do not provide the functionality you require, the following abstract classes can be extended to model your own custom study logic:
+In case the [currently supported built-in types](carp-common.md) do not provide the functionality you require, the following abstract classes can be extended to model your own custom study logic:
 
 - Extend `DeviceDescriptor` or `MasterDeviceDescriptor` to add support for a new type of device, and extend `DeviceRegistration` to specify how a single instance of this device should be uniquely identified, the capabilities it has, and device-specific configuration options needed for the device to operate.
 Example: [`AltBeacon`](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt).  


### PR DESCRIPTION
@thaiphandinh can use this to simplify retrieving the default sampling configuration for any data type through `DeviceDescriptor`. This can facilitate a more generic implementation to pass the required `SamplingConfiguration` to the data collector.

Of course, this way the _concrete_ `SamplingConfiguration` type is unknown, so you will still need to cast to the expected configuration per data type. Hope this helps.

Closes #310 

I tried to also fix a TODO I encountered:

> TODO: Verify whether all configured data types are supported by this device (supported data streams), probably in init.
>   We might also want to check whether the sampling configuration instances are valid.

However, this proved too be too difficult for now. Instead, I created a new issue for this: https://github.com/cph-cachet/carp.core-kotlin/issues/312