### PR TITLE
Clearer `DeviceDescriptor` API for client subystem.

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceDescriptor.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceDescriptor.kt
@@ -58,6 +58,21 @@ abstract class DeviceDescriptor<
         defaultSamplingConfiguration.toMap()
 
     /**
+     * Do nothing in case [defaultSamplingConfiguration] is valid; throw [IllegalStateException] otherwise.
+     * Only known supported data types can be validated; unexpected data types are ignored.
+     */
+    fun validateDefaultSamplingConfiguration()
+    {
+        val canBeValidated = getSupportedDataTypes()
+        for ( (dataType, samplingConfiguration) in defaultSamplingConfiguration.filter { it.key in canBeValidated } )
+        {
+            val samplingScheme = checkNotNull( getDataTypeSamplingSchemes()[ dataType ] )
+            check( samplingScheme.isValid( samplingConfiguration ) )
+                { "The sampling configuration for data type `$dataType` is invalid." }
+        }
+    }
+
+    /**
      * Get the default sampling configuration to be used for measurements of [dataType],
      * as determined by a configuration overriding the default ([defaultSamplingConfiguration]), or if not present,
      * the default for this [dataType] defined by this device's sampling schemes ([getDataTypeSamplingSchemes]).

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
@@ -41,7 +41,7 @@ data class CustomDeviceDescriptor(
         val json = Json( serializer ) { ignoreUnknownKeys = true }
         val baseMembers = json.decodeFromString( BaseMembers.serializer(), jsonSource )
         roleName = baseMembers.roleName
-        defaultSamplingConfiguration = baseMembers.defaultSamplingConfiguration
+        defaultSamplingConfiguration = baseMembers.getModifiedDefaultSamplingConfigurations()
     }
 
     override fun createDeviceRegistrationBuilder(): DeviceRegistrationBuilder<DeviceRegistration> =
@@ -80,7 +80,7 @@ data class CustomMasterDeviceDescriptor(
         val json = Json( serializer ) { ignoreUnknownKeys = true }
         val baseMembers = json.decodeFromString( BaseMembers.serializer(), jsonSource )
         roleName = baseMembers.roleName
-        defaultSamplingConfiguration = baseMembers.defaultSamplingConfiguration
+        defaultSamplingConfiguration = baseMembers.getModifiedDefaultSamplingConfigurations()
     }
 
     override fun createDeviceRegistrationBuilder(): DeviceRegistrationBuilder<DeviceRegistration> =

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/DeviceDescriptorTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/DeviceDescriptorTest.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.sampling.BatteryAwareSamplingConfiguration
 import dk.cachet.carp.common.application.sampling.Granularity
 import dk.cachet.carp.common.application.sampling.GranularitySamplingConfiguration
+import dk.cachet.carp.common.application.sampling.NoOptionsSamplingConfiguration
 import kotlin.test.*
 
 
@@ -12,6 +13,28 @@ import kotlin.test.*
  */
 class DeviceDescriptorTest
 {
+    @Test
+    fun validateModifiedDefaultSamplingConfigurations_with_correct_configuration()
+    {
+        val validConfigurations = mapOf(
+            Smartphone.Sensors.GEOLOCATION.dataType.type to Smartphone.Sensors.GEOLOCATION.default
+        )
+        val device = Smartphone( "Irrelevant", validConfigurations )
+
+        device.validateDefaultSamplingConfiguration()
+    }
+
+    @Test
+    fun validateModifiedDefaultSamplingConfigurations_with_invalid_configuration()
+    {
+        val invalidConfigurations = mapOf(
+            Smartphone.Sensors.GEOLOCATION.dataType.type to NoOptionsSamplingConfiguration
+        )
+        val device = Smartphone( "Irrelevant", invalidConfigurations )
+
+        assertFailsWith<IllegalStateException> { device.validateDefaultSamplingConfiguration() }
+    }
+
     @Test
     fun getDefaultSamplingConfiguration_succeeds()
     {

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/SmartphoneTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/SmartphoneTest.kt
@@ -24,7 +24,7 @@ class SmartphoneTest
         }
 
         val type = Smartphone.Sensors.GEOLOCATION.dataType.type
-        val configuration = phone.defaultSamplingConfiguration[ type ] as? BatteryAwareSamplingConfiguration<*>
+        val configuration = phone.getModifiedDefaultSamplingConfigurations()[ type ] as? BatteryAwareSamplingConfiguration<*>
         assertNotNull( configuration )
         val configuredGranularity = configuration.normal as GranularitySamplingConfiguration
         assertEquals( expectedGranularity, configuredGranularity.granularity )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -127,7 +127,9 @@ class StudyProtocol private constructor( val ownerId: UUID, val name: String, va
      * Add a [masterDevice] which is responsible for aggregating and synchronizing incoming data.
      * Its role name should be unique in the protocol.
      *
-     * @throws IllegalArgumentException in case a device with the specified role name already exists.
+     * @throws IllegalArgumentException when:
+     *  - a device with the specified role name already exists
+     *  - [masterDevice] contains invalid default sampling configurations
      * @return True if the [masterDevice] has been added; false if it is already set as a master device.
      */
     override fun addMasterDevice( masterDevice: AnyMasterDeviceDescriptor ): Boolean =
@@ -141,6 +143,7 @@ class StudyProtocol private constructor( val ownerId: UUID, val name: String, va
      * @throws IllegalArgumentException when:
      *   - a device with the specified role name already exists
      *   - [masterDevice] is not part of the device configuration
+     *   - [device] contains invalid default sampling configurations
      * @return True if the [device] has been added; false if it is already connected to the specified [masterDevice].
      */
     override fun addConnectedDevice( device: AnyDeviceDescriptor, masterDevice: AnyMasterDeviceDescriptor ): Boolean =

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/DeviceConfiguration.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/DeviceConfiguration.kt
@@ -24,7 +24,9 @@ interface DeviceConfiguration
     /**
      * Add a master device which is responsible for aggregating and synchronizing incoming data.
      *
-     * @throws IllegalArgumentException in case a device with the specified role name already exists.
+     * @throws IllegalArgumentException when:
+     * - a device with the specified role name already exists
+     * - [masterDevice] contains invalid default sampling configurations
      * @param masterDevice A description of the master device to add. Its role name should be unique in the protocol.
      * @return True if the [masterDevice] has been added; false if it is already set as a master device.
      */
@@ -36,6 +38,7 @@ interface DeviceConfiguration
      * @throws IllegalArgumentException when:
      *   - a device with the specified role name already exists
      *   - [masterDevice] is not part of the device configuration
+     *   - [device] contains invalid default sampling configurations
      * @param device The device to be connected to a master device. Its role name should be unique in the protocol.
      * @return True if the [device] has been added; false if it is already connected to the specified [masterDevice].
      */

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/EmptyDeviceConfiguration.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/EmptyDeviceConfiguration.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.protocols.domain.configuration
 
 import dk.cachet.carp.common.application.devices.AnyDeviceDescriptor
 import dk.cachet.carp.common.application.devices.AnyMasterDeviceDescriptor
+import dk.cachet.carp.common.application.devices.DeviceDescriptor
 import dk.cachet.carp.common.domain.ExtractUniqueKeyMap
 
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/EmptyDeviceConfiguration.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/EmptyDeviceConfiguration.kt
@@ -34,6 +34,8 @@ internal class EmptyDeviceConfiguration : AbstractMap<String, AnyDeviceDescripto
 
     override fun addMasterDevice( masterDevice: AnyMasterDeviceDescriptor ): Boolean
     {
+        verifySamplingConfigurations( masterDevice )
+
         val isNewDevice: Boolean = _devices.tryAddIfKeyIsNew( masterDevice )
         _masterDevices.add( masterDevice )
 
@@ -42,6 +44,7 @@ internal class EmptyDeviceConfiguration : AbstractMap<String, AnyDeviceDescripto
 
     override fun addConnectedDevice( device: AnyDeviceDescriptor, masterDevice: AnyMasterDeviceDescriptor ): Boolean
     {
+        verifySamplingConfigurations( device )
         verifyMasterDevice( masterDevice )
 
         // Add device when not yet within this configuration.
@@ -77,7 +80,20 @@ internal class EmptyDeviceConfiguration : AbstractMap<String, AnyDeviceDescripto
     }
 
     /**
-     * Throws [IllegalArgumentException] when master device is not part of this configuration.
+     * Throws [IllegalArgumentException] when [device] contains one or more invalid sampling configurations.
+     */
+    private fun verifySamplingConfigurations( device: AnyDeviceDescriptor ) =
+        try { device.validateDefaultSamplingConfiguration() }
+        catch ( ex: IllegalStateException )
+        {
+            throw IllegalArgumentException(
+                "The device with role name `${device.roleName}` contains an invalid sampling configuration.",
+                ex
+            )
+        }
+
+    /**
+     * Throws [IllegalArgumentException] when [device] is not part of this configuration.
      */
     private fun verifyMasterDevice( device: AnyMasterDeviceDescriptor ) = require( device in devices )
         { "The passed master device with role name \"${device.roleName}\" is not part of this device configuration." }

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
@@ -54,7 +54,7 @@ class StudyProtocolSnapshotTest
         val parsed: StudyProtocolSnapshot = JSON.decodeFromString( serialized )
         val masterDevice = parsed.masterDevices.filterIsInstance<CustomMasterDeviceDescriptor>().singleOrNull()
         assertNotNull( masterDevice )
-        assertEquals( 1, masterDevice.defaultSamplingConfiguration.count() )
+        assertEquals( 1, masterDevice.getModifiedDefaultSamplingConfigurations().count() )
         assertEquals( 1, parsed.connectedDevices.filterIsInstance<CustomDeviceDescriptor>().count() )
         assertEquals( 1, parsed.tasks.filterIsInstance<CustomTaskDescriptor>().count() )
         val allMeasures = parsed.tasks.flatMap{ t -> t.measures }

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.protocols.infrastructure
 
+import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.devices.MasterDeviceDescriptor
 import dk.cachet.carp.common.application.tasks.Measure
 import dk.cachet.carp.common.infrastructure.serialization.CustomDeviceDescriptor
@@ -119,7 +120,7 @@ class StudyProtocolSnapshotTest
         // (1) Add unknown master with unknown sampling configuration and unknown connected device.
         val unknownSamplingConfiguration = StubSamplingConfiguration( "Unknown" )
         val samplingConfiguration = mapOf(
-            STUB_DATA_TYPE to unknownSamplingConfiguration
+            DataType( "unknown", "type" ) to unknownSamplingConfiguration
         )
         val master = StubMasterDeviceDescriptor( "Unknown", samplingConfiguration )
         protocol.addMasterDevice( master )


### PR DESCRIPTION
When `DeviceDescriptor` was used in the client subsystem, the multiple "default" sampling configurations were confusing. These changes aim to make the distinction clearer.

In addition, for known supported data types on `DeviceDescriptor`, the sampling configuration is now validated (https://github.com/cph-cachet/carp.core-kotlin/issues/312).

I'm still not 100% satisfied with the naming, as exemplified by the force push I did just now. 😂

Should we use `defaultSamplingConfigurations` (plural) instead? It's singular right now because I thought originally in JSON and the builder singular looked better, e.g.:

```
val phone = Smartphone( "Patient's phone" )
{
    // Configure device-specific options, e.g., frequency to collect data at.
    defaultSamplingConfiguration {
        geolocation { batteryNormal { granularity = Granularity.Balanced } }
    }
}
```