### PR TITLE
`SyncPoint` improvements

### DIFF
--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamBatch.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamBatch.kt
@@ -52,8 +52,9 @@ class MutableDataStreamBatch : DataStreamBatch
     /**
      * Append a sequence to a non-existing or previously appended data stream in this batch.
      *
-     * @throws IllegalArgumentException when the start of the [sequence] range precedes the end of
-     *   a previously appended sequence to the same data stream.
+     * @throws IllegalArgumentException when:
+     *  - the start of the [sequence] range precedes the end of a previously appended sequence to the same data stream
+     *  - the sync point of [sequence] is older than that of previous sequences in this batch
      */
     fun appendSequence( sequence: DataStreamSequence )
     {
@@ -69,6 +70,8 @@ class MutableDataStreamBatch : DataStreamBatch
         val last = sequenceList.last()
         require( last.range.last < sequence.range.first )
             { "Sequence range start lies before the end of a previously appended sequence to the same data stream." }
+        require( last.syncPoint.synchronizedOn <= sequence.syncPoint.synchronizedOn )
+            { "The sync point contained in this sequence can't have been obtained before a previous sync point." }
 
         // Merge sequence with last sequence if possible; add new sequence otherwise.
         if ( last.isImmediatelyFollowedBy( sequence ) )

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamPoint.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamPoint.kt
@@ -27,7 +27,7 @@ data class DataStreamPoint<out TData : Data>(
     /**
      * The most recent synchronization information which was determined for this or a previous [DataStreamPoint].
      */
-    val syncPoint: SyncPoint
+    val syncPoint: SyncPoint = SyncPoint.UTC
 )
 {
     init

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamSequence.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamSequence.kt
@@ -92,7 +92,7 @@ class MutableDataStreamSequence(
     override val dataStream: DataStreamId,
     override val firstSequenceId: Long,
     triggerIds: List<Int>,
-    override val syncPoint: SyncPoint
+    override val syncPoint: SyncPoint = SyncPoint.UTC
 ) : DataStreamSequence
 {
     override val triggerIds: List<Int> = triggerIds.toList()
@@ -154,7 +154,7 @@ object DataStreamSequenceSerializer : KSerializer<DataStreamSequence>
         override val firstSequenceId: Long,
         override val measurements: List<Measurement<*>>,
         override val triggerIds: List<Int>,
-        override val syncPoint: SyncPoint
+        override val syncPoint: SyncPoint = SyncPoint.UTC
     ) : DataStreamSequence
     {
         init { throwIfIllegalInitialization() }

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/SyncPoint.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/SyncPoint.kt
@@ -29,3 +29,13 @@ data class SyncPoint(
     @Required
     val relativeClockSpeed: Double = 1.0
 )
+{
+    companion object
+    {
+        /**
+         * The default [SyncPoint] for timestamps that are already synchronized to UTC time.
+         * A synchronization conversion using this sync point is a no-op.
+         */
+        val UTC: SyncPoint = SyncPoint( Instant.fromEpochSeconds( 0 ) )
+    }
+}

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/MutableDataStreamBatchTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/MutableDataStreamBatchTest.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.infrastructure.test.StubData
 import dk.cachet.carp.common.infrastructure.test.StubDataPoint
 import dk.cachet.carp.data.infrastructure.dataStreamId
 import dk.cachet.carp.data.infrastructure.measurement
+import kotlinx.datetime.Clock
 import kotlin.test.*
 
 
@@ -70,6 +71,33 @@ class MutableDataStreamBatchTest
     }
 
     @Test
+    fun appendSequence_succeeds_with_new_syncpoint()
+    {
+        val batch = MutableDataStreamBatch()
+        val dataStream = dataStreamId<StubData>( UUID.randomUUID(), "Device" )
+        val firstSequence = MutableDataStreamSequence(
+            dataStream,
+            0,
+            stubTriggerIds,
+            SyncPoint.UTC
+        )
+        firstSequence.appendMeasurements( measurement( StubData(), 0 ) )
+        batch.appendSequence( firstSequence )
+
+        val newSequence = MutableDataStreamSequence(
+            dataStream,
+            1,
+            stubTriggerIds,
+            stubSyncPoint
+        )
+        newSequence.appendMeasurements( measurement( StubData(), 0 ) )
+        batch.appendSequence( newSequence )
+
+        assertEquals( 2, batch.sequences.count() ) // Due to the different sync point, the sequence is not merged.
+        assertEquals( 2, batch.getDataStreamPoints( dataStream ).toList().count() )
+    }
+
+    @Test
     fun appendSequence_merges_sequence_when_there_is_no_sequence_gap()
     {
         val batch = MutableDataStreamBatch()
@@ -105,6 +133,30 @@ class MutableDataStreamBatchTest
         {
             batch.appendSequence( overlappingSequence )
         }
+    }
+
+    @Test
+    fun appendSequence_fails_for_older_sync_point()
+    {
+        val batch = MutableDataStreamBatch()
+        val dataStream = dataStreamId<StubData>( UUID.randomUUID(), "Device" )
+        val firstSequence = MutableDataStreamSequence(
+            dataStream,
+            0,
+            stubTriggerIds,
+            SyncPoint( Clock.System.now() )
+        )
+        firstSequence.appendMeasurements( measurement( StubData(), 0 ) )
+        batch.appendSequence( firstSequence )
+
+        val newSequence = MutableDataStreamSequence(
+            dataStream,
+            1,
+            stubTriggerIds,
+            SyncPoint.UTC
+        )
+        newSequence.appendMeasurements( measurement( StubData(), 0 ) )
+        assertFailsWith<IllegalArgumentException> { batch.appendSequence( newSequence ) }
     }
 
     @Test


### PR DESCRIPTION
Passing sync points is a complex use case only needed for devices which aren't already synchronized with UTC timestamps. Therefore, a default option `SyncPoint.UTC` is provided which indicates the timestamps corresponds to UTC timestamps in microseconds.

To help working with sync points, several helper functions will also be added.