### PR TITLE
Allow changing `StudyProtocol` name and description

### DIFF
--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
@@ -24,7 +24,8 @@ interface ProtocolService : ApplicationService<ProtocolService, ProtocolService.
      *
      * @param versionTag An optional label used to identify this first version of the [protocol]. "Initial" by default.
      * @throws IllegalArgumentException when:
-     *   - [protocol] already exists
+     *   - a [protocol] with the same id already exists
+     *   - a different [protocol] with the same owner and name in the latest version already exists
      *   - [protocol] is invalid
      */
     suspend fun add( protocol: StudyProtocolSnapshot, versionTag: String = "Initial" )
@@ -36,6 +37,7 @@ interface ProtocolService : ApplicationService<ProtocolService, ProtocolService.
      * @param versionTag An optional unique label used to identify this specific version of the [protocol]. The current date/time by default.
      * @throws IllegalArgumentException when:
      *   - [protocol] is not yet stored in the repository
+     *   - a different [protocol] with the same owner and name in the latest version already exists
      *   - [protocol] is invalid
      *   - the [versionTag] is already in use
      */

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
@@ -17,7 +17,8 @@ class ProtocolServiceHost( private val repository: StudyProtocolRepository ) : P
      *
      * @param versionTag An optional label used to identify this first version of the [protocol]. "Initial" by default.
      * @throws IllegalArgumentException when:
-     *   - [protocol] already exists
+     *   - a [protocol] with the same id already exists
+     *   - a different [protocol] with the same owner and name in the latest version already exists
      *   - [protocol] is invalid
      */
     override suspend fun add( protocol: StudyProtocolSnapshot, versionTag: String )
@@ -33,6 +34,7 @@ class ProtocolServiceHost( private val repository: StudyProtocolRepository ) : P
      * @param versionTag An optional unique label used to identify this specific version of the [protocol]. The current date/time by default.
      * @throws IllegalArgumentException when:
      *   - [protocol] is not yet stored in the repository
+     *   - a different [protocol] with the same owner and name in the latest version already exists
      *   - [protocol] is invalid
      *   - the [versionTag] is already in use
      */

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -33,11 +33,11 @@ class StudyProtocol(
     /**
      * A unique descriptive name for the protocol assigned by the protocol owner.
      */
-    val name: String,
+    name: String,
     /**
      * An optional description for the study protocol.
      */
-    val description: String? = null,
+    description: String? = null,
     id: UUID = UUID.randomUUID(),
     createdOn: Instant = Clock.System.now()
 ) : StudyProtocolComposition(
@@ -50,6 +50,8 @@ class StudyProtocol(
 {
     sealed class Event : DomainEvent()
     {
+        data class NameChanged( val name: String ) : Event()
+        data class DescriptionChanged( val description: String? ) : Event()
         data class MasterDeviceAdded( val device: AnyMasterDeviceDescriptor ) : Event()
         data class ConnectedDeviceAdded( val connected: AnyDeviceDescriptor, val master: AnyMasterDeviceDescriptor ) : Event()
         data class TriggerAdded( val trigger: Trigger<*> ) : Event()
@@ -120,6 +122,37 @@ class StudyProtocol(
             return protocol
         }
     }
+
+
+    private var _name: String = name
+    /**
+     * A unique descriptive name for the protocol assigned by the protocol owner.
+     */
+    var name: String
+        get() = _name
+        set( value )
+        {
+            if ( _name != value )
+            {
+                _name = value
+                event( Event.NameChanged( value ) )
+            }
+        }
+
+    private var _description: String? = description
+    /**
+     * An optional description for the study protocol.
+     */
+    var description: String?
+        get() = _description
+        set( value )
+        {
+            if ( _description != value )
+            {
+                _description = value
+                event( Event.DescriptionChanged( value ) )
+            }
+        }
 
 
     /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepository.kt
@@ -16,24 +16,29 @@ interface StudyProtocolRepository
      * Add the specified study [protocol] to the repository.
      *
      * @param version Identifies this first initial version of the [protocol].
-     * @throws IllegalArgumentException when a [protocol] with the same owner and name already exists.
+     * @throws IllegalArgumentException when:
+     *   - a [protocol] with the same id already exists
+     *   - a different [protocol] with the same owner and name in the latest version already exists
      */
     suspend fun add( protocol: StudyProtocol, version: ProtocolVersion )
 
     /**
      * Add a new [version] for the specified study [protocol] in the repository,
-     * of which a previous version with the same owner and name is already stored.
+     * of which a previous version with the same id is already stored.
      *
      * @throws IllegalArgumentException when:
      *   - the [protocol] is not yet stored in the repository
      *   - the tag specified in [version] is already in use
+     *   - a different [protocol] with the same owner and name in the latest version already exists
      */
     suspend fun addVersion( protocol: StudyProtocol, version: ProtocolVersion )
 
     /**
      * Replace a [version] of a [protocol], of which a previous version with the same owner and name is already stored.
      *
-     * @throws IllegalArgumentException when the [protocol] with [version] to replace is not found.
+     * @throws IllegalArgumentException when:
+     *   - the [protocol] with [version] to replace is not found
+     *   - a different [protocol] with the same owner and name in the latest version already exists
      */
     suspend fun replace( protocol: StudyProtocol, version: ProtocolVersion )
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolRepositoryTest.kt
@@ -65,10 +65,8 @@ interface StudyProtocolRepositoryTest
         val originalProtocolName = "Study"
         val protocol = StudyProtocol( ownerId, originalProtocolName )
         repo.add( protocol, ProtocolVersion( "Initial" ) )
-        repo.addVersion(
-            StudyProtocol( ownerId, "New name", null, protocol.id ),
-            ProtocolVersion( "Second version" )
-        )
+        protocol.name = "New name"
+        repo.addVersion( protocol, ProtocolVersion( "Second version" ) )
 
         val priorNameProtocol = StudyProtocol( ownerId, originalProtocolName )
         repo.add( priorNameProtocol, ProtocolVersion( "Latest" ) )
@@ -116,10 +114,10 @@ interface StudyProtocolRepositoryTest
         val protocol2 = StudyProtocol( ownerId, "Study 2" )
         repo.add( protocol2, ProtocolVersion( "Initial" ) )
 
-        val newVersionProtocol2 = StudyProtocol( ownerId, protocol.name, null, protocol2.id )
+        protocol2.name = protocol.name
         assertFailsWith<IllegalArgumentException>
         {
-            repo.addVersion( newVersionProtocol2, ProtocolVersion( "New version" ) )
+            repo.addVersion( protocol2, ProtocolVersion( "New version" ) )
         }
     }
 
@@ -155,11 +153,8 @@ interface StudyProtocolRepositoryTest
         val protocol2 = StudyProtocol( ownerId, "Study 2" )
         repo.add( protocol2, ProtocolVersion( "Initial" ) )
 
-        val replaceVersionProtocol2 = StudyProtocol( ownerId, protocol.name, null, protocol2.id )
-        assertFailsWith<IllegalArgumentException>
-        {
-            repo.replace( replaceVersionProtocol2, ProtocolVersion( "New version" ) )
-        }
+        protocol2.name = protocol.name
+        assertFailsWith<IllegalArgumentException> { repo.replace( protocol2, ProtocolVersion( "New version" ) ) }
     }
 
     @Test

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.protocols.domain
 
 
+import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.devices.AnyMasterDeviceDescriptor
 import dk.cachet.carp.common.application.triggers.TaskControl.Control as Control
@@ -104,6 +105,40 @@ class StudyProtocolTest
         }
     }
 
+
+    @Test
+    fun name_and_description_change_succeeds()
+    {
+        val protocol = StudyProtocol( UUID.randomUUID(), "Initial name" )
+
+        val newName = "New name"
+        val newDescription = "New description"
+        protocol.name = newName
+        protocol.description = newDescription
+        assertEquals( newName, protocol.name )
+        assertEquals( newDescription, protocol.description )
+        val events = protocol.consumeEvents()
+        assertEquals(
+            StudyProtocol.Event.NameChanged( newName ),
+            events.filterIsInstance<StudyProtocol.Event.NameChanged>().single()
+        )
+        assertEquals(
+            StudyProtocol.Event.DescriptionChanged( newDescription ),
+            events.filterIsInstance<StudyProtocol.Event.DescriptionChanged>().single()
+        )
+    }
+
+    @Test
+    fun name_and_description_change_triggers_no_event_for_same_values()
+    {
+        val name = "Name"
+        val description = "Description"
+        val protocol = StudyProtocol( UUID.randomUUID(), name, description )
+
+        protocol.name = name
+        protocol.description = description
+        assertTrue( protocol.consumeEvents().isEmpty() )
+    }
 
     @Test
     fun one_master_device_needed_for_deployment()

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/StudyProtocolTest.kt
@@ -418,6 +418,7 @@ class StudyProtocolTest
         val snapshot: StudyProtocolSnapshot = protocol.getSnapshot()
         val fromSnapshot = StudyProtocol.fromSnapshot( snapshot )
 
+        assertEquals( protocol.id, fromSnapshot.id )
         assertEquals( protocol.ownerId, fromSnapshot.ownerId )
         assertEquals( protocol.name, fromSnapshot.name )
         assertEquals( protocol.description, fromSnapshot.description )
@@ -427,9 +428,9 @@ class StudyProtocolTest
         assertEquals( protocol.triggers, fromSnapshot.triggers )
         assertEquals( protocol.tasks, fromSnapshot.tasks )
         protocol.triggers.forEach {
-            val triggeredTasks = protocol.getTaskControls( it.id )
-            val fromSnapshotTriggeredTasks = fromSnapshot.getTaskControls( it.id )
-            assertEquals( triggeredTasks.count(), triggeredTasks.intersect( fromSnapshotTriggeredTasks ).count() )
+            val triggeredTasks = protocol.getTaskControls( it.id ).toSet()
+            val fromSnapshotTriggeredTasks = fromSnapshot.getTaskControls( it.id ).toSet()
+            assertEquals( triggeredTasks, fromSnapshotTriggeredTasks )
         }
         assertEquals( protocol.expectedParticipantData, fromSnapshot.expectedParticipantData )
         assertEquals( protocol.applicationData, fromSnapshot.applicationData )
@@ -443,10 +444,12 @@ class StudyProtocolTest
         masterDevice: AnyMasterDeviceDescriptor
     ): Boolean
     {
-        val protocolConnected = protocol.getConnectedDevices( masterDevice ).sortedWith( compareBy { it.roleName } )
-        val snapshotConnected = fromSnapshot.getConnectedDevices( masterDevice ).sortedWith( compareBy { it.roleName } )
+        val protocolConnected = protocol.getConnectedDevices( masterDevice ).toSet()
+        val snapshotConnected = fromSnapshot.getConnectedDevices( masterDevice ).toSet()
 
-        val areSameDevices = snapshotConnected.count() == protocolConnected.intersect( snapshotConnected ).count()
-        return areSameDevices && protocolConnected.filterIsInstance<AnyMasterDeviceDescriptor>().all { connectedDevicesAreSame( protocol, fromSnapshot, it ) }
+        val areSameDevices = protocolConnected == snapshotConnected
+        return areSameDevices && protocolConnected.filterIsInstance<AnyMasterDeviceDescriptor>().all {
+            connectedDevicesAreSame( protocol, fromSnapshot, it )
+        }
     }
 }


### PR DESCRIPTION
In a previous PR, it was determined that the _identity_ of `StudyProtocol` should be a `UUID`, as opposed to how it was originally defined: a composite key of study owner and study name.

The changes in this PR use that change to allow changing a protocol's name. In addition, I made `description` mutable, as I don't recall why I ever decided for it to be immutable.

But, like before, study names still need to be unique to owners. This is a constraint which needs to be implemented by the repository. Check the updated repository unit tests for guidance what is expected of concrete infrastructure implementations.

Closes #185 