### PR TITLE
Add a display name to `DeviceRegistration`

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ client.configure {
     // Depending on the device type, different options are available.
     // E.g., for a smartphone, a UUID deviceId is generated. To override this default:
     deviceId = "xxxxxxxxx"
+    deviceDisplayName = "Pixel 6 Pro (Android 12)"
 }
 var status: StudyStatus = client.addStudy( studyDeploymentId, deviceToUse )
 

--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/ClientCodeSamples.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/ClientCodeSamples.kt
@@ -53,6 +53,7 @@ class ClientCodeSamples
             // Depending on the device type, different options are available.
             // E.g., for a smartphone, a UUID deviceId is generated. To override this default:
             deviceId = "xxxxxxxxx"
+            deviceDisplayName = "Pixel 6 Pro (Android 12)"
         }
         var status: StudyStatus = client.addStudy( studyDeploymentId, deviceToUse )
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
@@ -71,7 +71,9 @@ data class AltBeaconDeviceRegistration(
      * The average received signal strength at 1 meter from the beacon in decibel-milliwatts (dBm).
      * This value is constrained from -127 to 0.
      */
-    val referenceRssi: Short
+    val referenceRssi: Short,
+    @Required
+    override val deviceDisplayName: String? = null // TODO: We could map known manufacturerId's to display names.
 ) : DeviceRegistration()
 {
     companion object
@@ -93,7 +95,7 @@ data class AltBeaconDeviceRegistration(
 
 
 @Serializable( with = NotSerializable::class )
-class AltBeaconDeviceRegistrationBuilder : DeviceRegistrationBuilder<AltBeaconDeviceRegistration>
+class AltBeaconDeviceRegistrationBuilder : DeviceRegistrationBuilder<AltBeaconDeviceRegistration>()
 {
     /**
      * The beacon's device manufacturer's company identifier code as maintained by the Bluetooth SIG assigned numbers database.
@@ -123,6 +125,12 @@ class AltBeaconDeviceRegistrationBuilder : DeviceRegistrationBuilder<AltBeaconDe
      */
     var referenceRssi: Short = 0
 
-    override fun build(): AltBeaconDeviceRegistration =
-        AltBeaconDeviceRegistration( manufacturerId, organizationId, majorId, minorId, referenceRssi )
+    override fun build(): AltBeaconDeviceRegistration = AltBeaconDeviceRegistration(
+        manufacturerId,
+        organizationId,
+        majorId,
+        minorId,
+        referenceRssi,
+        deviceDisplayName
+    )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLESerialNumberDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLESerialNumberDeviceRegistration.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 
@@ -10,19 +11,24 @@ import kotlinx.serialization.Serializable
  * to uniquely identify the device.
  */
 @Serializable
-data class BLESerialNumberDeviceRegistration( val serialNumber: String ) : DeviceRegistration()
+data class BLESerialNumberDeviceRegistration(
+    val serialNumber: String,
+    @Required
+    override val deviceDisplayName: String? = null
+) : DeviceRegistration()
 {
     init
     {
         require( serialNumber.isNotBlank() )
     }
 
+    @Required
     override val deviceId: String = serialNumber
 }
 
 
 @Serializable( with = NotSerializable::class )
-class BLESerialNumberDeviceRegistrationBuilder : DeviceRegistrationBuilder<BLESerialNumberDeviceRegistration>
+class BLESerialNumberDeviceRegistrationBuilder : DeviceRegistrationBuilder<BLESerialNumberDeviceRegistration>()
 {
     /**
      * The serial number as broadcast by the Device Information GATT service.
@@ -31,5 +37,6 @@ class BLESerialNumberDeviceRegistrationBuilder : DeviceRegistrationBuilder<BLESe
      */
     var serialNumber: String = ""
 
-    override fun build(): BLESerialNumberDeviceRegistration = BLESerialNumberDeviceRegistration( serialNumber )
+    override fun build(): BLESerialNumberDeviceRegistration =
+        BLESerialNumberDeviceRegistration( serialNumber, deviceDisplayName )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 
@@ -11,20 +12,24 @@ import kotlinx.serialization.Serializable
  * The base class can't be made concrete since this would prevent being able to serialize extending types (constructors may not contain parameters which are not properties).
  */
 @Serializable
-data class DefaultDeviceRegistration( override val deviceId: String ) : DeviceRegistration()
+data class DefaultDeviceRegistration(
+    @Required
+    override val deviceId: String = UUID.randomUUID().toString()
+) : DeviceRegistration()
 
 
 /**
  * A default device registration builder which solely involves assigning a unique ID to the device.
  * By default, a unique ID (UUID) is generated.
- *
- * @param deviceId
- *   Override the default assigned UUID which has been set as device ID.
- *   Make sure this ID is unique for the type of device you are creating a registration for.
  */
 @Serializable( with = NotSerializable::class )
-class DefaultDeviceRegistrationBuilder( var deviceId: String = UUID.randomUUID().toString() ) :
-    DeviceRegistrationBuilder<DefaultDeviceRegistration>
+class DefaultDeviceRegistrationBuilder : DeviceRegistrationBuilder<DefaultDeviceRegistration>
 {
+    /**
+     * Override the default assigned UUID which has been set as device ID.
+     * Make sure this ID is unique for the type of device you are creating a registration for.
+     */
+    var deviceId: String = UUID.randomUUID().toString()
+
     override fun build(): DefaultDeviceRegistration = DefaultDeviceRegistration( deviceId )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
@@ -14,16 +14,18 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class DefaultDeviceRegistration(
     @Required
+    override val deviceDisplayName: String? = null,
+    @Required
     override val deviceId: String = UUID.randomUUID().toString()
 ) : DeviceRegistration()
 
 
 /**
- * A default device registration builder which solely involves assigning a unique ID to the device.
+ * A default device registration builder which solely involves assigning a display name and unique ID to the device.
  * By default, a unique ID (UUID) is generated.
  */
 @Serializable( with = NotSerializable::class )
-class DefaultDeviceRegistrationBuilder : DeviceRegistrationBuilder<DefaultDeviceRegistration>
+class DefaultDeviceRegistrationBuilder : DeviceRegistrationBuilder<DefaultDeviceRegistration>()
 {
     /**
      * Override the default assigned UUID which has been set as device ID.
@@ -31,5 +33,5 @@ class DefaultDeviceRegistrationBuilder : DeviceRegistrationBuilder<DefaultDevice
      */
     var deviceId: String = UUID.randomUUID().toString()
 
-    override fun build(): DefaultDeviceRegistration = DefaultDeviceRegistration( deviceId )
+    override fun build(): DefaultDeviceRegistration = DefaultDeviceRegistration( deviceDisplayName, deviceId )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceRegistration.kt
@@ -31,6 +31,13 @@ abstract class DeviceRegistration
     @Required
     abstract val deviceId: String
 
+    /**
+     * An optional concise textual representation for display purposes describing the key specifications of the device.
+     * E.g., device manufacturer, name, and operating system version.
+     */
+    @Required
+    abstract val deviceDisplayName: String?
+
     @Required
     val registrationCreatedOn: Instant = Clock.System.now()
 }
@@ -44,12 +51,20 @@ abstract class DeviceRegistration
  */
 @Serializable( NotSerializable::class )
 @DeviceRegistrationBuilderDsl
-interface DeviceRegistrationBuilder<T : DeviceRegistration>
+abstract class DeviceRegistrationBuilder<T : DeviceRegistration>
 {
+    /**
+     * An optional concise textual representation for display purposes describing the key specifications of the device.
+     * E.g., device manufacturer, name, and operating system version.
+     *
+     * In case this is not set, the builder may derive a default name based on the other registration properties.
+     */
+    var deviceDisplayName: String? = null
+
     /**
      * Build the immutable [DeviceRegistration] using the current configuration of this [DeviceRegistrationBuilder].
      */
-    fun build(): T
+    abstract fun build(): T
 }
 
 /**

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistration.kt
@@ -10,7 +10,11 @@ import kotlinx.serialization.Serializable
  * A [DeviceRegistration] for devices which have a MAC address.
  */
 @Serializable
-data class MACAddressDeviceRegistration( val macAddress: MACAddress ) : DeviceRegistration()
+data class MACAddressDeviceRegistration(
+    val macAddress: MACAddress,
+    @Required
+    override val deviceDisplayName: String? = null
+) : DeviceRegistration()
 {
     // TODO: Remove this workaround once JS serialization bug is fixed: https://github.com/Kotlin/kotlinx.serialization/issues/716
     @Suppress( "UNNECESSARY_SAFE_CALL" )
@@ -20,9 +24,10 @@ data class MACAddressDeviceRegistration( val macAddress: MACAddress ) : DeviceRe
 
 
 @Serializable( with = NotSerializable::class )
-class MACAddressDeviceRegistrationBuilder : DeviceRegistrationBuilder<MACAddressDeviceRegistration>
+class MACAddressDeviceRegistrationBuilder : DeviceRegistrationBuilder<MACAddressDeviceRegistration>()
 {
     var macAddress: String = ""
 
-    override fun build(): MACAddressDeviceRegistration = MACAddressDeviceRegistration( MACAddress.parse( macAddress ) )
+    override fun build(): MACAddressDeviceRegistration =
+        MACAddressDeviceRegistration( MACAddress.parse( macAddress ), deviceDisplayName )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
@@ -158,15 +158,20 @@ data class CustomDeviceRegistration(
 ) : DeviceRegistration(), UnknownPolymorphicWrapper
 {
     @Serializable
-    private data class BaseMembers( override val deviceId: String ) : DeviceRegistration()
+    private data class BaseMembers(
+        override val deviceId: String,
+        override val deviceDisplayName: String?
+    ) : DeviceRegistration()
 
     override val deviceId: String
+    override val deviceDisplayName: String?
 
     init
     {
         val json = Json( serializer ) { ignoreUnknownKeys = true }
         val baseMembers = json.decodeFromString( BaseMembers.serializer(), jsonSource )
         deviceId = baseMembers.deviceId
+        deviceDisplayName = baseMembers.deviceDisplayName
     }
 }
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/TestInstances.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/TestInstances.kt
@@ -49,7 +49,7 @@ val commonInstances = listOf(
     Smartphone( "User's phone" ),
 
     // Shared device registrations in `devices` namespace.
-    DefaultDeviceRegistration( "Some device" ),
+    DefaultDeviceRegistration(),
     MACAddressDeviceRegistration( MACAddress( "00-00-00-00-00-00" ) ),
 
     // `sampling` namespace.

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/AltBeaconTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/AltBeaconTest.kt
@@ -33,23 +33,27 @@ class AltBeaconTest
             organizationId = UUID( "00000000-0000-0000-0000-000000000002" )
             majorId = 3
             minorId = 4
+            deviceDisplayName = "AltBeacon"
         }.build()
 
         assertEquals( 1, registration.manufacturerId )
         assertEquals( UUID( "00000000-0000-0000-0000-000000000002" ), registration.organizationId )
         assertEquals( 3, registration.majorId )
         assertEquals( 4, registration.minorId )
+        assertEquals( "AltBeacon", registration.deviceDisplayName )
     }
 
     @Test
-    fun registration_deviceId_is_serialized()
+    fun registration_deviceId_and_deviceDisplayName_is_serialized()
     {
-        val registration = AltBeaconDeviceRegistration( 0, UUID.randomUUID(), 0, 0, 0 )
+        val registration = AltBeaconDeviceRegistration( 0, UUID.randomUUID(), 0, 0, 0, "Device" )
 
         val json = createDefaultJSON()
         val serialized = json.encodeToString( AltBeaconDeviceRegistration.serializer(), registration )
         val jsonElement = json.parseToJsonElement( serialized ).jsonObject
         val serializedDeviceId = jsonElement[ DeviceRegistration::deviceId.name ]?.jsonPrimitive?.content
         assertEquals( registration.deviceId, serializedDeviceId )
+        val serializedDeviceDisplayName = jsonElement[ DeviceRegistration::deviceDisplayName.name ]?.jsonPrimitive?.content
+        assertEquals( registration.deviceDisplayName, serializedDeviceDisplayName )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistrationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistrationTest.kt
@@ -9,12 +9,17 @@ import kotlin.test.*
 class DefaultDeviceRegistrationTest
 {
     @Test
-    fun builder_sets_deviceId()
+    fun builder_sets_properties()
     {
+        val deviceId = "Custom ID"
+        val deviceDisplayName = "Device name"
+
         val registration = DefaultDeviceRegistrationBuilder().apply {
-            deviceId = "Custom ID"
+            this.deviceId = deviceId
+            this.deviceDisplayName = deviceDisplayName
         }.build()
 
-        assertEquals( "Custom ID", registration.deviceId )
+        assertEquals( deviceId, registration.deviceId )
+        assertEquals( deviceDisplayName, registration.deviceDisplayName )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistrationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistrationTest.kt
@@ -11,7 +11,7 @@ class DefaultDeviceRegistrationTest
     @Test
     fun builder_sets_deviceId()
     {
-        val registration = DefaultDeviceRegistrationBuilder( "Default ID" ).apply {
+        val registration = DefaultDeviceRegistrationBuilder().apply {
             deviceId = "Custom ID"
         }.build()
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistrationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistrationTest.kt
@@ -13,26 +13,30 @@ import kotlin.test.*
 class MACAddressDeviceRegistrationTest
 {
     @Test
-    fun builder_sets_deviceId()
+    fun builder_sets_properties()
     {
         val mac = "00-11-22-33-44-55"
         val registration = MACAddressDeviceRegistrationBuilder().apply {
             macAddress = mac
+            deviceDisplayName = "Device"
         }.build()
 
         assertEquals( mac, registration.deviceId )
+        assertEquals( "Device", registration.deviceDisplayName )
     }
 
     @Test
-    fun deviceId_is_serialized()
+    fun deviceId_and_deviceDisplayName_is_serialized()
     {
         val mac = "00-11-22-33-44-55"
-        val registration = MACAddressDeviceRegistration( MACAddress( mac ) )
+        val registration = MACAddressDeviceRegistration( MACAddress( mac ), "Device name" )
 
         val json = createDefaultJSON()
         val serialized = json.encodeToString( MACAddressDeviceRegistration.serializer(), registration )
         val jsonElement = json.parseToJsonElement( serialized ).jsonObject
         val serializedDeviceId = jsonElement[ DeviceRegistration::deviceId.name ]?.jsonPrimitive?.content
         assertEquals( registration.deviceId, serializedDeviceId )
+        val serializedDeviceDisplayName = jsonElement[ DeviceRegistration::deviceDisplayName.name ]?.jsonPrimitive?.content
+        assertEquals( registration.deviceDisplayName, serializedDeviceDisplayName )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/DeviceRegistrationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/DeviceRegistrationTest.kt
@@ -15,7 +15,7 @@ class DeviceRegistrationTest
     @Test
     fun can_serialize_and_deserialize_device_registration_using_JSON()
     {
-        val default: DeviceRegistration = DefaultDeviceRegistration( "Test" )
+        val default: DeviceRegistration = DefaultDeviceRegistration()
 
         val serialized = testJson.encodeToString( DeviceRegistration.serializer(), default )
         val parsed: DeviceRegistration = testJson.decodeFromString( serialized )
@@ -50,7 +50,7 @@ class DeviceRegistrationTest
 
     private fun serializeUnknownDeviceRegistration(): String
     {
-        val registration = DefaultDeviceRegistration( "Test" )
+        val registration = DefaultDeviceRegistration()
         var serialized = testJson.encodeToString( DeviceRegistration.serializer(), registration )
         serialized = serialized.replace( "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration", "com.unknown.CustomRegistration" )
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
@@ -30,7 +30,7 @@ val unknownInstances = listOf(
     unknown( StubData() ) { CustomData( it.first, it.second, it.third ) },
     unknown( StubDeviceDescriptor() ) { CustomDeviceDescriptor( it.first, it.second, it.third ) },
     unknown( StubMasterDeviceDescriptor() ) { CustomMasterDeviceDescriptor( it.first, it.second, it.third ) },
-    unknown( DefaultDeviceRegistration( "id" ) ) { CustomDeviceRegistration( it.first, it.second, it.third ) },
+    unknown( DefaultDeviceRegistration() ) { CustomDeviceRegistration( it.first, it.second, it.third ) },
     unknown( StubSamplingConfiguration( "" ) ) { CustomSamplingConfiguration( it.first, it.second, it.third ) },
     unknown( StubTaskDescriptor() ) { CustomTaskDescriptor( it.first, it.second, it.third ) },
     unknown( StubTrigger( "source" ) ) { CustomTrigger( it.first, it.second, it.third ) },

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializersTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializersTest.kt
@@ -131,6 +131,7 @@ class CustomDeviceRegistrationTest
 
         val custom = CustomDeviceRegistration( "Irrelevant", serialized, JSON )
         assertEquals( registration.deviceId, custom.deviceId )
+        assertEquals( registration.deviceDisplayName, custom.deviceDisplayName )
     }
 
     @Serializable

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializersTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializersTest.kt
@@ -126,7 +126,7 @@ class CustomDeviceRegistrationTest
     @Test
     fun initialization_from_json_extracts_base_DeviceRegistration_properties()
     {
-        val registration = DefaultDeviceRegistration( "Unknown" )
+        val registration = DefaultDeviceRegistration()
         val serialized: String = JSON.encodeToString( DefaultDeviceRegistration.serializer(), registration )
 
         val custom = CustomDeviceRegistration( "Irrelevant", serialized, JSON )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceMock.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceMock.kt
@@ -32,7 +32,7 @@ class DeploymentServiceMock(
             StudyDeploymentStatus.DeployingDevices( Clock.System.now(), UUID.randomUUID(), emptyList(), emptyList(), null )
         private val emptyMasterDeviceDeployment: MasterDeviceDeployment = MasterDeviceDeployment(
             StubMasterDeviceDescriptor(),
-            DefaultDeviceRegistration( "Test" ) )
+            DefaultDeviceRegistration() )
     }
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
@@ -115,7 +115,7 @@ class ValidationTest
         val deviceRoleName = "Master"
         val protocol = createSingleMasterDeviceProtocol( deviceRoleName ).getSnapshot()
 
-        val preregistrations = mapOf( "Unknown" to DefaultDeviceRegistration( "ID" ) )
+        val preregistrations = mapOf( "Unknown" to DefaultDeviceRegistration() )
 
         assertFailsWith<IllegalArgumentException> {
             protocol.throwIfInvalidPreregistrations( preregistrations )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
@@ -129,7 +129,12 @@ class ValidationTest
         val connectedRoleName = "Connected"
         val protocol = createSingleMasterWithConnectedDeviceProtocol( masterRoleName, connectedRoleName ).getSnapshot()
 
-        val invalidRegistration = object : DeviceRegistration() { override val deviceId: String = "Invalid" }
+        val invalidRegistration =
+            object : DeviceRegistration()
+            {
+                override val deviceId: String = "Invalid"
+                override val deviceDisplayName: String? = null
+            }
         val preregistrations = mapOf( connectedRoleName to invalidRegistration )
 
         assertFailsWith<IllegalArgumentException> {

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/StudyDeploymentTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/StudyDeploymentTest.kt
@@ -140,7 +140,7 @@ class StudyDeploymentTest
         protocol.addMasterDevice( device )
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
-        val registration = DefaultDeviceRegistration( "0" )
+        val registration = DefaultDeviceRegistration()
         deployment.registerDevice( device, registration )
 
         assertEquals( 1, deployment.registeredDevices.size )
@@ -182,7 +182,7 @@ class StudyDeploymentTest
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
         val invalidDevice = StubMasterDeviceDescriptor( "Not part of deployment" )
-        val registration = DefaultDeviceRegistration( "0" )
+        val registration = DefaultDeviceRegistration()
 
         assertFailsWith<IllegalArgumentException>
         {
@@ -199,11 +199,11 @@ class StudyDeploymentTest
         protocol.addMasterDevice( device )
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
-        deployment.registerDevice( device, DefaultDeviceRegistration( "0" ) )
+        deployment.registerDevice( device, DefaultDeviceRegistration() )
 
         assertFailsWith<IllegalArgumentException>
         {
-            deployment.registerDevice( device, DefaultDeviceRegistration( "1" ))
+            deployment.registerDevice( device, DefaultDeviceRegistration() )
         }
         assertEquals( 1, deployment.consumeEvents().filterIsInstance<StudyDeployment.Event.DeviceRegistered>().count() )
     }
@@ -227,8 +227,8 @@ class StudyDeploymentTest
         protocol.addConnectedDevice( connectedCustom, masterCustom )
 
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
-        deployment.registerDevice( masterCustom, DefaultDeviceRegistration( "0" ) )
-        deployment.registerDevice( connectedCustom, DefaultDeviceRegistration( "1" ) )
+        deployment.registerDevice( masterCustom, DefaultDeviceRegistration() )
+        deployment.registerDevice( connectedCustom, DefaultDeviceRegistration() )
     }
 
     @Test
@@ -241,7 +241,7 @@ class StudyDeploymentTest
         protocol.addConnectedDevice( connected, master )
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
-        val registration = DefaultDeviceRegistration( "0" )
+        val registration = DefaultDeviceRegistration()
         deployment.registerDevice( master, registration )
 
         assertFailsWith<IllegalArgumentException>
@@ -268,8 +268,9 @@ class StudyDeploymentTest
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
 
         // Even though these two devices are registered using the same ID, this should succeed since they are of different types.
-        deployment.registerDevice( device1Custom, DefaultDeviceRegistration( "0" ) )
-        deployment.registerDevice( device2Custom, DefaultDeviceRegistration( "0" ) )
+        val registration = DefaultDeviceRegistration()
+        deployment.registerDevice( device1Custom, registration )
+        deployment.registerDevice( device2Custom, registration )
     }
 
     @Test
@@ -295,7 +296,7 @@ class StudyDeploymentTest
         val device = StubMasterDeviceDescriptor()
         protocol.addMasterDevice( device )
         val deployment: StudyDeployment = studyDeploymentFor( protocol )
-        val registration = DefaultDeviceRegistration( "0" )
+        val registration = DefaultDeviceRegistration()
         deployment.registerDevice( device, registration )
 
         deployment.unregisterDevice( device )
@@ -547,7 +548,7 @@ class StudyDeploymentTest
         protocol.addTaskControl( master.atStartOfStudy().start( masterTask, master ) )
         protocol.addTaskControl( master.atStartOfStudy().start( connectedTask, connected ) )
         val deployment = studyDeploymentFor( protocol )
-        val registration = DefaultDeviceRegistration( "Registered master" )
+        val registration = DefaultDeviceRegistration()
         deployment.registerDevice( master, registration )
         deployment.registerDevice( connected, connected.createRegistration() )
 
@@ -556,7 +557,7 @@ class StudyDeploymentTest
         protocol.addMasterDevice( ignoredMaster ) // Normally, this dependent device would block obtaining deployment.
 
         val deviceDeployment: MasterDeviceDeployment = deployment.getDeviceDeploymentFor( master )
-        assertEquals( "Registered master", deviceDeployment.registration.deviceId )
+        assertEquals( registration, deviceDeployment.registration )
         assertEquals( protocol.getConnectedDevices( master ).toSet(), deviceDeployment.connectedDevices )
         assertEquals( 1, deviceDeployment.connectedDeviceRegistrations.count() )
         assertEquals( protocol.applicationData, deviceDeployment.applicationData )
@@ -580,13 +581,14 @@ class StudyDeploymentTest
         val master = protocol.masterDevices.first { it.roleName == "Master" }
         val connected = protocol.devices.first { it.roleName == "Connected" }
         val deployment = studyDeploymentFor( protocol )
-        deployment.registerDevice( master, DefaultDeviceRegistration( "0" ) )
+        deployment.registerDevice( master, DefaultDeviceRegistration() )
 
-        deployment.registerDevice( connected, DefaultDeviceRegistration( "42" ) )
+        val preregistration = DefaultDeviceRegistration()
+        deployment.registerDevice( connected, preregistration )
         val deviceDeployment = deployment.getDeviceDeploymentFor( master )
 
         assertEquals( "Connected", deviceDeployment.connectedDeviceRegistrations.keys.single() )
-        assertEquals( "42", deviceDeployment.connectedDeviceRegistrations.getValue( "Connected" ).deviceId )
+        assertEquals( preregistration, deviceDeployment.connectedDeviceRegistrations.getValue( "Connected" ) )
     }
 
     @Test
@@ -595,7 +597,7 @@ class StudyDeploymentTest
         val protocol = createSingleMasterWithConnectedDeviceProtocol( "Master", "Connected" )
         val master = protocol.masterDevices.first { it.roleName == "Master" }
         val deployment = studyDeploymentFor( protocol )
-        deployment.registerDevice( master, DefaultDeviceRegistration( "0" ) )
+        deployment.registerDevice( master, DefaultDeviceRegistration() )
 
         val deviceDeployment = deployment.getDeviceDeploymentFor( master )
 
@@ -615,8 +617,8 @@ class StudyDeploymentTest
         val task = StubTaskDescriptor( "Stub task", listOf( measure ) )
         protocol.addTaskControl( StubTrigger( sourceMaster ).start( task, targetMaster ) )
         val deployment = studyDeploymentFor( protocol )
-        deployment.registerDevice( sourceMaster, DefaultDeviceRegistration( "0" ) )
-        deployment.registerDevice( targetMaster, DefaultDeviceRegistration( "1" ) )
+        deployment.registerDevice( sourceMaster, DefaultDeviceRegistration() )
+        deployment.registerDevice( targetMaster, DefaultDeviceRegistration() )
 
         val sourceDeployment = deployment.getDeviceDeploymentFor( sourceMaster )
         val targetDeployment = deployment.getDeviceDeploymentFor( targetMaster )
@@ -774,7 +776,7 @@ class StudyDeploymentTest
         val protocol = createSingleMasterWithConnectedDeviceProtocol( "Master", "Connected" )
         val master = protocol.masterDevices.first { it.roleName == "Master" }
         val deployment = studyDeploymentFor( protocol )
-        deployment.registerDevice( master, DefaultDeviceRegistration( "0" ) )
+        deployment.registerDevice( master, DefaultDeviceRegistration() )
         val deviceDeployment = deployment.getDeviceDeploymentFor( master )
 
         assertFailsWith<IllegalStateException> { deployment.deviceDeployed( master, deviceDeployment.lastUpdatedOn ) }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequestsTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequestsTest.kt
@@ -26,7 +26,7 @@ class DeploymentServiceRequestsTest : ApplicationServiceRequestsTest<DeploymentS
             DeploymentServiceRequest.RemoveStudyDeployments( emptySet() ),
             DeploymentServiceRequest.GetStudyDeploymentStatus( UUID.randomUUID() ),
             DeploymentServiceRequest.GetStudyDeploymentStatusList( setOf( UUID.randomUUID() ) ),
-            DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration( "Device ID" ) ),
+            DeploymentServiceRequest.RegisterDevice( UUID.randomUUID(), "Test role", DefaultDeviceRegistration() ),
             DeploymentServiceRequest.UnregisterDevice( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.GetDeviceDeploymentFor( UUID.randomUUID(), "Test role" ),
             DeploymentServiceRequest.DeviceDeployed( UUID.randomUUID(), "Test role", Clock.System.now() ),

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentSnapshotTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentSnapshotTest.kt
@@ -77,7 +77,7 @@ class StudyDeploymentSnapshotTest
         val master = StubMasterDeviceDescriptor( "Stub" )
         protocol.addMasterDevice( master )
         val deployment = studyDeploymentFor( protocol )
-        val registration = DefaultDeviceRegistration( "0" )
+        val registration = DefaultDeviceRegistration()
         deployment.registerDevice( master, registration )
 
         var serialized: String = JSON.encodeToString( deployment.getSnapshot() )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentTest.kt
@@ -70,7 +70,7 @@ class StudyDeploymentTest
         val master = StubMasterDeviceDescriptor( "Unknown" )
         protocol.addMasterDevice( master )
         val deployment = studyDeploymentFor( protocol )
-        val registration = DefaultDeviceRegistration( "0" )
+        val registration = DefaultDeviceRegistration()
         deployment.registerDevice( master, registration )
 
         // Mimic unknown device and registration.

--- a/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
@@ -92,6 +92,7 @@ declare module 'carp.core-kotlin-carp.common'
             static get Companion(): DeviceRegistration$Companion  
             
             readonly deviceId: string
+            readonly deviceDisplayName: string | null;
             readonly registrationCreatedOn: Instant
         }
         interface DeviceRegistration$Companion { serializer(): any }

--- a/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
@@ -98,7 +98,7 @@ declare module 'carp.core-kotlin-carp.common'
 
         class DefaultDeviceRegistration extends DeviceRegistration
         {
-            constructor( deviceId: string )
+            constructor( deviceId?: string )
         }
 
         class Smartphone extends DeviceDescriptor

--- a/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
@@ -39,12 +39,12 @@ declare module 'carp.core-kotlin-carp.common'
         {
             static get Companion(): RecurrenceRule$Companion
 
-            toString(): String
+            toString(): string
         }
         interface RecurrenceRule$Companion
         {
             serializer(): any
-            fromString_61zpoe$( rrule: String ): RecurrenceRule
+            fromString_61zpoe$( rrule: string ): RecurrenceRule
         }
 
         class TimeOfDay
@@ -84,7 +84,7 @@ declare module 'carp.core-kotlin-carp.common'
     {
         abstract class DeviceDescriptor
         {
-            readonly roleName: String
+            readonly roleName: string
         }
 
         abstract class DeviceRegistration
@@ -113,17 +113,17 @@ declare module 'carp.core-kotlin-carp.common'
     {
         abstract class TaskDescriptor
         {
-            readonly name: String
-            readonly description?: String
+            readonly name: string
+            readonly description: string | null;
         }
 
         class WebTask extends TaskDescriptor
         {
-            constructor( name: String, measures: any, description: String, url: String )
+            constructor( name: string, measures: any, description: string, url: string )
 
             static get Companion(): WebTask$Companion
 
-            readonly url: String
+            readonly url: string
         }
         interface WebTask$Companion { serializer(): any }
     }
@@ -134,12 +134,12 @@ declare module 'carp.core-kotlin-carp.common'
         abstract class Trigger
         {
             readonly requiresMasterDevice: Boolean
-            readonly sourceDeviceRoleName: String
+            readonly sourceDeviceRoleName: string
         }
 
         class ElapsedTimeTrigger extends Trigger
         {
-            constructor( sourceDeviceRoleName: String, elapsedTime: Duration )
+            constructor( sourceDeviceRoleName: string, elapsedTime: Duration )
 
             readonly elapsedTime: Duration
 
@@ -147,15 +147,15 @@ declare module 'carp.core-kotlin-carp.common'
 
         class ManualTrigger extends Trigger
         {
-            constructor( sourceDeviceRoleName: String, label: String, description?: String )
+            constructor( sourceDeviceRoleName: string, label: string, description?: string | null )
 
-            readonly label: String
-            readonly description?: String
+            readonly label: string
+            readonly description: string | null;
         }
 
         class ScheduledTrigger extends Trigger
         {
-            constructor( sourceDeviceRoleName: String, time: TimeOfDay, recurrenceRule: RecurrenceRule )
+            constructor( sourceDeviceRoleName: string, time: TimeOfDay, recurrenceRule: RecurrenceRule )
 
             readonly time: TimeOfDay
             readonly recurrenceRule: RecurrenceRule
@@ -163,11 +163,11 @@ declare module 'carp.core-kotlin-carp.common'
 
         class TaskControl
         {
-            constructor( triggerId: Number, taskName: String, destinationDeviceRoleName: String, control: Number )
+            constructor( triggerId: Number, taskName: string, destinationDeviceRoleName: string, control: Number )
 
             readonly triggerId: Number
-            readonly taskName: String
-            readonly destinationDeviceRoleName: String
+            readonly taskName: string
+            readonly destinationDeviceRoleName: string
             readonly control: Number
         }
     }

--- a/typescript-declarations/@types/carp.core-kotlin-carp.deployments.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.deployments.core/index.d.ts
@@ -38,8 +38,8 @@ declare module 'carp.core-kotlin-carp.deployments.core'
             abstract class NotDeployed
             {
                 readonly isReadyForDeployment: Boolean
-                readonly remainingDevicesToRegisterToObtainDeployment: HashSet<String>
-                readonly remainingDevicesToRegisterBeforeDeployment: HashSet<String>
+                readonly remainingDevicesToRegisterToObtainDeployment: HashSet<string>
+                readonly remainingDevicesToRegisterBeforeDeployment: HashSet<string>
 
             }
             class Unregistered extends NotDeployed
@@ -47,16 +47,16 @@ declare module 'carp.core-kotlin-carp.deployments.core'
                 constructor(
                     device: any,
                     canBeDeployed: Boolean,
-                    remainingDevicesToRegisterToObtainDeployment: HashSet<String>,
-                    remainingDevicesToRegisterBeforeDeployment: HashSet<String> )
+                    remainingDevicesToRegisterToObtainDeployment: HashSet<string>,
+                    remainingDevicesToRegisterBeforeDeployment: HashSet<string> )
             }
             class Registered extends NotDeployed
             {
                 constructor(
                     device: any,
                     canBeDeployed: Boolean,
-                    remainingDevicesToRegisterToObtainDeployment: HashSet<String>,
-                    remainingDevicesToRegisterBeforeDeployment: HashSet<String> )
+                    remainingDevicesToRegisterToObtainDeployment: HashSet<string>,
+                    remainingDevicesToRegisterBeforeDeployment: HashSet<string> )
             }
             class Deployed extends DeviceDeploymentStatus 
             {
@@ -66,8 +66,8 @@ declare module 'carp.core-kotlin-carp.deployments.core'
             {
                 constructor(
                     device: any,
-                    remainingDevicesToRegisterToObtainDeployment: HashSet<String>,
-                    remainingDevicesToRegisterBeforeDeployment: HashSet<String> )
+                    remainingDevicesToRegisterToObtainDeployment: HashSet<string>,
+                    remainingDevicesToRegisterBeforeDeployment: HashSet<string> )
             }
         }
 
@@ -82,7 +82,7 @@ declare module 'carp.core-kotlin-carp.deployments.core'
                 tasks?: HashSet<any>,
                 triggers?: HashMap<number, any>,
                 taskControls?: HashSet<any>,
-                applicationData?: String | null )
+                applicationData?: string | null )
 
                 static get Companion(): MasterDeviceDeployment$Companion
 
@@ -93,7 +93,7 @@ declare module 'carp.core-kotlin-carp.deployments.core'
                 readonly tasks: HashSet<any>
                 readonly triggers: HashMap<number, any>
                 readonly taskControls: HashSet<any>
-                readonly applicationData: String | null
+                readonly applicationData: string | null
         }
         interface MasterDeviceDeployment$Companion { serializer(): any }
 
@@ -237,7 +237,7 @@ declare module 'carp.core-kotlin-carp.deployments.core'
         {
             class CreateStudyDeployment extends DeploymentServiceRequest
             {
-                constructor( protocol: StudyProtocolSnapshot, invitations: ArrayList<ParticipantInvitation>, connectedDevicePreregistrations?: HashMap<String, DeviceRegistration> )
+                constructor( protocol: StudyProtocolSnapshot, invitations: ArrayList<ParticipantInvitation>, connectedDevicePreregistrations?: HashMap<string, DeviceRegistration> )
             }
             class GetStudyDeploymentStatus extends DeploymentServiceRequest
             {

--- a/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
@@ -180,7 +180,7 @@ declare module 'carp.core-kotlin-carp.studies.core'
         {
             class CreateStudy extends StudyServiceRequest
             {
-                constructor( ownerId: UUID, name: string, description?: string | null, invitation?: StudyInvitation )
+                constructor( ownerId: UUID, name: string, description?: string | null, invitation?: StudyInvitation | null )
             }
             class SetInternalDescription extends StudyServiceRequest
             {

--- a/typescript-declarations/tests/carp.common.ts
+++ b/typescript-declarations/tests/carp.common.ts
@@ -52,7 +52,7 @@ describe( "carp.common", () => {
             new Text( "How are you feeling?" ),
             Text.Companion,
             [ "DeviceDescriptor", new Smartphone( "Role", toSet( [] ) ) ],
-            [ "DeviceRegistration", new DefaultDeviceRegistration( "some device id" ) ],
+            [ "DeviceRegistration", new DefaultDeviceRegistration() ],
             DeviceRegistration.Companion,
             [ "TaskDescriptor", new WebTask( "name", undefined, "", "url.com" ) ],
             new WebTask( "name", undefined, "", "url.com" ),


### PR DESCRIPTION
The main reason for adding this is to display a concise representation to researchers in the study manager of the devices being used. E.g., "Pixel 6 Pro (Android 12)" for a `Smartphone`.

Even though manufacturers and Android operating system will probably be added as dedicated fields to a future `SmartphoneDeviceRegistration`, a general way of rendering _any_ device registration will be needed. The frontend shouldn't have to typecheck concrete `DeviceRegistration` types to render a useful column providing this information.

After some consideration, I made this field _optional_. Initially, it wasn't, leading me to having to add for example "Smartphone" as the default name for a Smartphone device. However, displaying fallback values is a frontend concern. While "Pixel 6 Pro (Android 12)" will work just fine in any locale, something like "Unknown device" won't.

In addition, I realized some mistakes I made in the current TS declarations. @ltj feel free to ignore those. @jeyjey626 could you have a look 👀 ?

Closes #281 