### PR TITLE
Backwards compatibility for application services

### DIFF
--- a/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/ApplicationServiceRequestsTest.kt
+++ b/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/ApplicationServiceRequestsTest.kt
@@ -8,6 +8,8 @@ import dk.cachet.carp.test.runSuspendTest
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.elementDescriptors
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlin.test.*
 
 
@@ -63,6 +65,18 @@ abstract class ApplicationServiceRequestsTest<
             val serialized = json.encodeToString( requestSerializer, request )
             val parsed = json.decodeFromString( requestSerializer, serialized )
             assertEquals( request, parsed )
+        }
+    }
+
+    @Test
+    fun serialized_request_contains_api_version()
+    {
+        val json = createTestJSON()
+
+        requests.forEach {
+            val serialized = json.encodeToJsonElement( requestSerializer, it ) as JsonObject
+            val versionKey = ApplicationServiceRequest<*, *>::apiVersion.name
+            assertTrue( serialized[ versionKey ] is JsonElement )
         }
     }
 }

--- a/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/TestUUIDFactory.kt
+++ b/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/TestUUIDFactory.kt
@@ -1,0 +1,19 @@
+package dk.cachet.carp.common.test.infrastructure
+
+import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.UUIDFactory
+
+
+/**
+ * Creates a UUIDs counting up from 1.
+ */
+class TestUUIDFactory : UUIDFactory
+{
+    private var id = 1
+
+    override fun randomUUID(): UUID
+    {
+        val idHex = id++.toString( 16 ).padStart( 12, '0' )
+        return UUID( "00000000-0000-0000-0000-$idHex" )
+    }
+}

--- a/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/LoggedJsonRequest.kt
+++ b/carp.common.test/src/commonMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/LoggedJsonRequest.kt
@@ -1,0 +1,42 @@
+package dk.cachet.carp.common.test.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.services.LoggedRequest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+
+/**
+ * A non-typed version of [LoggedRequest], only mimicking the JSON structure.
+ */
+@ExperimentalSerializationApi
+@Serializable
+@JsonClassDiscriminator( "outcome" )
+sealed class LoggedJsonRequest
+{
+    abstract val request: JsonObject
+    abstract val precedingEvents: JsonArray
+    abstract val publishedEvents: JsonArray
+
+    @Serializable
+    @SerialName( "Succeeded" )
+    class Succeeded(
+        override val request: JsonObject,
+        override val precedingEvents: JsonArray,
+        override val publishedEvents: JsonArray,
+        val response: JsonElement
+    ) : LoggedJsonRequest()
+
+    @Serializable
+    @SerialName( "Failed" )
+    class Failed(
+        override val request: JsonObject,
+        override val precedingEvents: JsonArray,
+        override val publishedEvents: JsonArray,
+        val exceptionType: String
+    ) : LoggedJsonRequest()
+}

--- a/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -50,9 +50,9 @@ abstract class BackwardsCompatibilityTest<TService : ApplicationService<TService
                 minor = versionMatch.groups[ 2 ]!!.value.toInt()
             )
             assertFalse(
-                ApiVersion.isMoreRecent( version, currentVersion ),
-                "Impossible to have test sources for version \"${ApiVersion.toString( version )}\" " +
-                "which is more recent than the current API version \"${ApiVersion.toString( currentVersion )}\"."
+                version.isMoreRecent( currentVersion ),
+                "Impossible to have test sources for version \"$version\" " +
+                "which is more recent than the current API version \"$currentVersion\"."
             )
             version
         }
@@ -71,8 +71,7 @@ abstract class BackwardsCompatibilityTest<TService : ApplicationService<TService
     @Ignore
     fun test_requests_for_current_api_version_available()
     {
-        val currentVersion: String = ApiVersion.toString( currentVersion )
-        val testRequests = File( testRequestsFolder, currentVersion )
+        val testRequests = File( testRequestsFolder, currentVersion.toString() )
 
         assertTrue( testRequests.exists() )
     }
@@ -84,7 +83,7 @@ abstract class BackwardsCompatibilityTest<TService : ApplicationService<TService
         val loggedRequestsSerializer = ListSerializer( serializer<LoggedJsonRequest>() )
 
         val testFiles = compatibleTests.flatMap { version ->
-            val testDirectory = File( testRequestsFolder, ApiVersion.toString( version ) )
+            val testDirectory = File( testRequestsFolder, version.toString() )
             FileUtils.listFiles( testDirectory, arrayOf( "json" ), true )
         }
 

--- a/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.common.test/src/jvmMain/kotlin/dk/cachet/carp/common/test/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -1,0 +1,149 @@
+package dk.cachet.carp.common.test.infrastructure.versioning
+
+import dk.cachet.carp.common.application.ApplicationServiceInfo
+import dk.cachet.carp.common.application.services.ApiVersion
+import dk.cachet.carp.common.application.services.ApplicationService
+import dk.cachet.carp.common.application.services.EventBus
+import dk.cachet.carp.common.application.services.IntegrationEvent
+import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
+import dk.cachet.carp.common.infrastructure.test.createTestJSON
+import dk.cachet.carp.test.runSuspendTest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.serializer
+import org.apache.commons.io.FileUtils
+import java.io.File
+import kotlin.reflect.KClass
+import kotlin.test.*
+
+
+/**
+ * Tests whether old API requests are handled correctly by migrating them to the current API version,
+ * and transforming the response to be compatible with the old request.
+ */
+@ExperimentalSerializationApi
+@Suppress( "FunctionName" )
+abstract class BackwardsCompatibilityTest<TService : ApplicationService<TService, *>>(
+    applicationServiceKlass: KClass<TService>
+)
+{
+    private val serviceInfo = ApplicationServiceInfo( applicationServiceKlass.java )
+    private val currentVersion = serviceInfo.apiVersion
+
+    private val testRequestsFolder: File =
+        File( "src/commonTest/resources/test-requests/${serviceInfo.serviceName}" )
+    private lateinit var availableTestVersions: List<ApiVersion>
+
+    @BeforeTest
+    fun setup()
+    {
+        // Get available test versions.
+        val directories = testRequestsFolder.listFiles()?.filter { it.isDirectory } ?: emptyList()
+        availableTestVersions = directories.map {
+            val versionMatch = assertNotNull(
+                Regex( """(\d)\.(\d)""" ).find( it.name ),
+                "Unexpected version folder in \"$testRequestsFolder\": ${it.name}"
+            )
+            val version = ApiVersion(
+                major = versionMatch.groups[ 1 ]!!.value.toInt(),
+                minor = versionMatch.groups[ 2 ]!!.value.toInt()
+            )
+            assertFalse(
+                ApiVersion.isMoreRecent( version, currentVersion ),
+                "Impossible to have test sources for version \"${ApiVersion.toString( version )}\" " +
+                "which is more recent than the current API version \"${ApiVersion.toString( currentVersion )}\"."
+            )
+            version
+        }
+    }
+
+
+    abstract fun createService(): Pair<TService, EventBus>
+
+    private val json = createTestJSON()
+
+    /**
+     * Before releasing a new version, you need to copy the output of `OutputTestRequests`
+     * to test resources under a matching version folder to make this test pass.
+     */
+    @Test
+    @Ignore
+    fun test_requests_for_current_api_version_available()
+    {
+        val currentVersion: String = ApiVersion.toString( currentVersion )
+        val testRequests = File( testRequestsFolder, currentVersion )
+
+        assertTrue( testRequests.exists() )
+    }
+
+    @Test
+    @Ignore
+    fun can_replay_backwards_compatible_test_requests() = runSuspendTest {
+        val compatibleTests = availableTestVersions.filter { it.major == currentVersion.major }
+        val loggedRequestsSerializer = ListSerializer( serializer<LoggedJsonRequest>() )
+
+        val testFiles = compatibleTests.flatMap { version ->
+            val testDirectory = File( testRequestsFolder, ApiVersion.toString( version ) )
+            FileUtils.listFiles( testDirectory, arrayOf( "json" ), true )
+        }
+
+        testFiles
+            .associateWith { json.decodeFromString( loggedRequestsSerializer, it.readText() ) }
+            .forEach { replayLoggedRequests( it.key.absolutePath, it.value ) }
+    }
+
+
+    @Suppress( "UNCHECKED_CAST" )
+    private suspend fun replayLoggedRequests( fileName: String, loggedRequests: List<LoggedJsonRequest> )
+    {
+        val (service, eventBus) = createService()
+
+        loggedRequests.forEachIndexed { index, logged ->
+            val replayErrorBase = "Couldn't replay requests in: $fileName. Request #${index + 1}"
+
+            // TODO: Migrate request and preceding events to latest version.
+            val migratedRequest = logged.request
+            val migratedPrecedingEvents = logged.precedingEvents
+
+            // Publish preceding events.
+            migratedPrecedingEvents.forEach {
+                val event = json.decodeFromJsonElement( serviceInfo.eventSerializer, it )
+                val eventSource = checkNotNull( serviceInfo.getEventPublisher( event )?.kotlin )
+                    { "The event \"${event::class}\" isn't an expected event processed by \"${serviceInfo.serviceKlass}\"." }
+
+                // Cast to bypass generic constraint checking. We know the types line up.
+                eventBus.publish( eventSource as KClass<Nothing>, event as IntegrationEvent<Nothing>)
+            }
+
+            // Validate whether request outcome corresponds to log.
+            val request = json.decodeFromJsonElement( serviceInfo.requestObjectSerializer, migratedRequest )
+                as ApplicationServiceRequest<TService, *>
+            val response =
+                try { request.invokeOn( service ) }
+                catch ( ex: Exception )
+                {
+                    if ( logged !is LoggedJsonRequest.Failed ) throw ex
+                    else assertEquals(
+                        logged.exceptionType,
+                        ex::class.simpleName,
+                        "$replayErrorBase failed with the wrong exception type."
+                    )
+                }
+
+            // Validate response in case request should succeed.
+            if ( logged is LoggedJsonRequest.Succeeded )
+            {
+                // TODO: Migrate response to requested version.
+                val responseSerializer = request.getResponseSerializer() as KSerializer<Any?>
+                val migratedResponse = json.encodeToJsonElement( responseSerializer, response )
+
+                assertEquals(
+                    logged.response,
+                    migratedResponse,
+                    "$replayErrorBase returned the wrong response."
+                )
+            }
+        }
+    }
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/UUID.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/UUID.kt
@@ -17,7 +17,7 @@ expect class UUID( stringRepresentation: String )
     val stringRepresentation: String
 
 
-    companion object
+    companion object : UUIDFactory
     {
         /**
          * Parse common [UUID] representations, also allowing upper case hexadecimal digits.
@@ -26,11 +26,16 @@ expect class UUID( stringRepresentation: String )
          */
         fun parse( uuid: String ): UUID
 
-        fun randomUUID(): UUID
+        override fun randomUUID(): UUID
     }
 
 
     override fun toString(): String
+}
+
+interface UUIDFactory
+{
+    fun randomUUID(): UUID
 }
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
@@ -1,0 +1,12 @@
+package dk.cachet.carp.common.application.services
+
+
+/**
+ * Specifies the API version of an [ApplicationService].
+ * Within [major] versions, [minor] versions are backwards compatible.
+ *
+ * E.g. a 2.0 request will work on a 2.1 hosted service, but not on 1.0 or 3.0.
+ */
+@Target( AnnotationTarget.CLASS )
+@Retention( AnnotationRetention.RUNTIME )
+annotation class ApiVersion( val major: Int, val minor: Int )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
@@ -10,3 +10,16 @@ package dk.cachet.carp.common.application.services
 @Target( AnnotationTarget.CLASS )
 @Retention( AnnotationRetention.RUNTIME )
 annotation class ApiVersion( val major: Int, val minor: Int )
+{
+    companion object
+    {
+        fun toString( version: ApiVersion ) = "${version.major}.${version.minor}"
+
+        /**
+         * Determines whether [version] is more recent than [otherVersion].
+         */
+        fun isMoreRecent( version: ApiVersion, otherVersion: ApiVersion ): Boolean =
+            if ( version.major > otherVersion.major ) true
+            else version.major == otherVersion.major && version.minor > otherVersion.minor
+    }
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.Serializable
  * E.g. a 2.0 request will work on a 2.1 hosted service, but not on 1.0 or 3.0.
  */
 @Serializable( ApiVersionSerializer::class )
-class ApiVersion( val major: Int, val minor: Int )
+data class ApiVersion( val major: Int, val minor: Int )
 {
     init
     {

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/ApiVersion.kt
@@ -1,5 +1,9 @@
 package dk.cachet.carp.common.application.services
 
+import dk.cachet.carp.common.infrastructure.serialization.createCarpStringPrimitiveSerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+
 
 /**
  * Specifies the API version of an [ApplicationService].
@@ -7,19 +11,46 @@ package dk.cachet.carp.common.application.services
  *
  * E.g. a 2.0 request will work on a 2.1 hosted service, but not on 1.0 or 3.0.
  */
-@Target( AnnotationTarget.CLASS )
-@Retention( AnnotationRetention.RUNTIME )
-annotation class ApiVersion( val major: Int, val minor: Int )
+@Serializable( ApiVersionSerializer::class )
+class ApiVersion( val major: Int, val minor: Int )
 {
+    init
+    {
+        require( major >= 0 && minor >= 0 ) { "Major and minor number must be positive." }
+    }
+
+
     companion object
     {
-        fun toString( version: ApiVersion ) = "${version.major}.${version.minor}"
-
         /**
-         * Determines whether [version] is more recent than [otherVersion].
+         * Initializes an [ApiVersion] instance based on a string representation formatted as "<major>.<minor>".
          */
-        fun isMoreRecent( version: ApiVersion, otherVersion: ApiVersion ): Boolean =
-            if ( version.major > otherVersion.major ) true
-            else version.major == otherVersion.major && version.minor > otherVersion.minor
+        fun fromString( apiVersion: String ): ApiVersion
+        {
+            require( ApiVersionRegex.matches( apiVersion ) ) { "Invalid API version string representation." }
+
+            val (major, minor) = apiVersion.split( '.' )
+            return ApiVersion( major.toInt(), minor.toInt() )
+        }
     }
+
+
+    /**
+     * Determines whether this version is more recent than [otherVersion].
+     */
+    fun isMoreRecent( otherVersion: ApiVersion ): Boolean =
+        if ( major > otherVersion.major ) true
+        else major == otherVersion.major && minor > otherVersion.minor
+
+    override fun toString(): String = "$major.$minor"
 }
+
+
+/**
+ * Regular expression to match [ApiVersion] represented as a string in the format "<major>.<minor>".
+ */
+val ApiVersionRegex = Regex( """(\d)\.(\d)""" )
+
+
+object ApiVersionSerializer : KSerializer<ApiVersion> by
+    createCarpStringPrimitiveSerializer( { version -> ApiVersion.fromString( version ) } )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/DependentServices.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/DependentServices.kt
@@ -1,0 +1,11 @@
+package dk.cachet.carp.common.application.services
+
+import kotlin.reflect.KClass
+
+
+/**
+ * Lists services this service is dependent on since it subscribes to events it emits.
+ */
+@Target( AnnotationTarget.CLASS )
+@Retention( AnnotationRetention.RUNTIME )
+annotation class DependentServices( vararg val service: KClass<out ApplicationService<*, *>> )

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/IntegrationEvent.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/services/IntegrationEvent.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.common.application.services
 import dk.cachet.carp.common.application.Immutable
 import dk.cachet.carp.common.application.ImplementAsDataClass
 import kotlinx.serialization.Polymorphic
+import kotlinx.serialization.Required
 
 
 /**
@@ -15,6 +16,9 @@ import kotlinx.serialization.Polymorphic
 @ImplementAsDataClass
 interface IntegrationEvent<out TApplicationService : ApplicationService<out TApplicationService, *>>
 {
+    @Required
+    val apiVersion: ApiVersion
+
     /**
      * All events related to the same aggregate ID are handled in order,
      * or no ordering is required in case `null`.

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceRequest.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceRequest.kt
@@ -1,13 +1,19 @@
 package dk.cachet.carp.common.infrastructure.services
 
+import dk.cachet.carp.common.application.services.ApiVersion
+import dk.cachet.carp.common.application.services.ApplicationService
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 
 
 /**
  * A request for [TService] stored in memory, which can be invoked using [invokeOn].
  */
-interface ApplicationServiceRequest<TService, out TReturn>
+interface ApplicationServiceRequest<TService : ApplicationService<TService, *>, out TReturn>
 {
+    @Required
+    val apiVersion: ApiVersion
+
     fun getResponseSerializer(): KSerializer<out TReturn>
     suspend fun invokeOn( service: TService ): TReturn
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/EventBusLog.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/services/EventBusLog.kt
@@ -1,0 +1,39 @@
+package dk.cachet.carp.common.infrastructure.services
+
+
+import dk.cachet.carp.common.application.services.ApplicationService
+import dk.cachet.carp.common.application.services.EventBus
+import dk.cachet.carp.common.application.services.IntegrationEvent
+import kotlin.reflect.KClass
+
+
+/**
+ * Logs incoming events on an event bus that are requested to be observed.
+ */
+class EventBusLog( eventBus: EventBus, vararg toObserve: Subscription<*, *> )
+{
+    data class Subscription<
+        TService : ApplicationService<TService, TEvent>,
+        TEvent : IntegrationEvent<TService>
+    >( val eventSource: KClass<TService>, val eventType: KClass<TEvent> )
+    {
+        fun registerHandler( eventBus: EventBus, subscriber: Any, handler: suspend (TEvent) -> Unit ) =
+            eventBus.registerHandler( eventSource, eventType, subscriber, handler )
+    }
+
+
+    private val loggedEvents: MutableList<IntegrationEvent<*>> = mutableListOf()
+
+    init
+    {
+        toObserve.forEach {
+            it.registerHandler( eventBus, this ) { event -> loggedEvents.add( event ) }
+        }
+        eventBus.activateHandlers( this )
+    }
+
+    /**
+     * Retrieve all elements in the log and clear it after.
+     */
+    fun retrieveAndEmptyLog(): List<IntegrationEvent<*>> = loggedEvents.toList().also { loggedEvents.clear() }
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/versioning/ApplicationServiceApiMigrator.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/versioning/ApplicationServiceApiMigrator.kt
@@ -1,0 +1,88 @@
+package dk.cachet.carp.common.infrastructure.versioning
+
+import dk.cachet.carp.common.application.services.ApiVersion
+import dk.cachet.carp.common.application.services.ApplicationService
+import dk.cachet.carp.common.application.services.IntegrationEvent
+import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+
+/**
+ * Supports transforming between different API versions of [ApplicationServiceRequest] and [IntegrationEvent] objects.
+ */
+class ApplicationServiceApiMigrator<TService : ApplicationService<TService, *>>(
+    val runtimeVersion: ApiVersion,
+    val requestObjectSerializer: KSerializer<out ApplicationServiceRequest<TService, *>>
+)
+{
+    companion object
+    {
+        /**
+         * Retrieve the [ApiVersion] for the given [jsonObject].
+         *
+         * @throws IllegalArgumentException when [jsonObject] does not contain an [ApiVersion].
+         */
+        private fun getApiVersion( jsonObject: JsonObject ): ApiVersion
+        {
+            val requestVersionString = jsonObject[ "apiVersion" ]?.jsonPrimitive?.content
+            requireNotNull( requestVersionString )
+                { "Request object needs to contain `apiVersion` for migration to succeed." }
+
+            return ApiVersion.fromString( requestVersionString )
+        }
+    }
+
+
+    /**
+     * Migrate the [request] so that it matches [runtimeVersion] and deserialize using [json].
+     */
+    fun migrateRequest( json: Json, request: JsonObject ): MigratedRequest<TService>
+    {
+        val requestVersion = getApiVersion( request )
+        require( !requestVersion.isMoreRecent( runtimeVersion ) )
+            { "Request version ($requestVersion) is more recent than the runtime version ($runtimeVersion)." }
+
+        // Add migrations once needed.
+        require( requestVersion == runtimeVersion )
+            { "No migration for requests from $requestVersion to $runtimeVersion supported."}
+        val downgradeResponse =
+            {
+                response: JsonElement?, ex: Exception? ->
+                    if ( ex != null ) throw ex
+                    else response!!
+            }
+
+        val updatedRequest = json.decodeFromJsonElement( requestObjectSerializer, request )
+        return MigratedRequest( json, updatedRequest, downgradeResponse )
+    }
+}
+
+
+/**
+ * A [request] which can be invoked using [invokeOn] which will return the response expected by the version of the caller.
+ */
+class MigratedRequest<TService : ApplicationService<TService, *>>(
+    val json: Json,
+    val request: ApplicationServiceRequest<TService, *>,
+    private val downgradeResponse: (JsonElement?, Exception?) -> JsonElement
+)
+{
+    /**
+     * Invoke this request on [service] and convert the response to the version expected by the original caller.
+     */
+    suspend fun invokeOn( service: TService ): JsonElement
+    {
+        @Suppress( "TooGenericExceptionCaught" )
+        val response =
+            try { request.invokeOn( service ) }
+            catch ( ex: Exception ) { return downgradeResponse( null, ex ) }
+
+        @Suppress( "UNCHECKED_CAST" )
+        val responseJson = json.encodeToJsonElement( request.getResponseSerializer() as KSerializer<Any?>, response )
+        return downgradeResponse( responseJson, null )
+    }
+}

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/services/ApplicationServiceEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/services/ApplicationServiceEventBusTest.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.common.application.services
 
 import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
 import dk.cachet.carp.test.runSuspendTest
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.test.*
 
@@ -12,19 +13,31 @@ import kotlin.test.*
 class ApplicationServiceEventBusTest
 {
     interface TestService : ApplicationService<TestService, Event>
+    {
+        companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+    }
 
     @Serializable
     sealed class Event( override val aggregateId: String? = null ) : IntegrationEvent<TestService>
     {
+        @Required
+        override val apiVersion: ApiVersion = TestService.API_VERSION
+
         @Serializable
         object SomeEvent : Event()
     }
 
     interface OtherService : ApplicationService<OtherService, OtherEvent>
+    {
+        companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+    }
 
     @Serializable
     sealed class OtherEvent( override val aggregateId: String? = null ) : IntegrationEvent<OtherService>
     {
+        @Required
+        override val apiVersion: ApiVersion = OtherService.API_VERSION
+
         @Serializable
         object SomeOtherEvent : OtherEvent()
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/services/IntegrationEventTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/services/IntegrationEventTest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.common.application.services
 
 import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
@@ -18,6 +19,9 @@ class IntegrationEventTest
         @Serializable
         sealed class Event( override val aggregateId: String? = null ) : IntegrationEvent<Service>
         {
+            @Required
+            override val apiVersion: ApiVersion = ApiVersion( 1, 0 )
+
             @Serializable
             object SomeEvent : Event()
         }
@@ -29,10 +33,9 @@ class IntegrationEventTest
     {
         val event = Service.Event.SomeEvent
 
-        val json = Json { }
         val serializer = Service.Event.serializer()
-        val serialized = json.encodeToString( serializer, event )
-        val parsed = json.decodeFromString( serializer, serialized )
+        val serialized = Json.encodeToString( serializer, event )
+        val parsed = Json.decodeFromString( serializer, serialized )
 
         assertEquals( event, parsed )
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLogTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceLogTest.kt
@@ -16,7 +16,9 @@ class ApplicationServiceLogTest
     {
         val request: LoggedRequest<*, *> = LoggedRequest.Succeeded(
             request = TestServiceRequest.Operation( 42 ),
-            events = listOf( TestService.Event.OperationOccurred( 42 ) ),
+            // Preceding events would normally be of different application services.
+            precedingEvents = listOf( TestService.Event.OperationOccurred( 0 ) ),
+            publishedEvents = listOf( TestService.Event.OperationOccurred( 42 ) ),
             response = 42
         )
 
@@ -33,7 +35,9 @@ class ApplicationServiceLogTest
     {
         val request: LoggedRequest<*, *> = LoggedRequest.Failed(
             request = TestServiceRequest.Operation( 10 ),
-            events = listOf( TestService.Event.OperationOccurred( 10 ) ),
+            // Preceding events would normally be of different application services.
+            precedingEvents = listOf( TestService.Event.OperationOccurred( 0 ) ),
+            publishedEvents = listOf( TestService.Event.OperationOccurred( 10 ) ),
             exceptionType = IllegalArgumentException::class.simpleName!!
         )
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceRequestTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceRequestTest.kt
@@ -27,6 +27,9 @@ class ApplicationServiceRequestTest
         @Serializable
         sealed class Event( override val aggregateId: String? ) : IntegrationEvent<TestService>
         {
+            @Required
+            override val apiVersion: ApiVersion = API_VERSION
+
             @Serializable
             data class OperationOccurred( val parameter: Int ) : Event( parameter.toString() )
         }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceRequestTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ApplicationServiceRequestTest.kt
@@ -1,10 +1,12 @@
 package dk.cachet.carp.common.infrastructure.services
 
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.test.runSuspendTest
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
@@ -20,6 +22,8 @@ class ApplicationServiceRequestTest
 {
     interface TestService : ApplicationService<TestService, TestService.Event>
     {
+        companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+
         @Serializable
         sealed class Event( override val aggregateId: String? ) : IntegrationEvent<TestService>
         {
@@ -33,6 +37,8 @@ class ApplicationServiceRequestTest
     @Serializable
     sealed class TestServiceRequest<out TReturn> : ApplicationServiceRequest<TestService, TReturn>
     {
+        @Required
+        override val apiVersion: ApiVersion = TestService.API_VERSION
         object Serializer : KSerializer<TestServiceRequest<*>> by ignoreTypeParameters( ::serializer )
 
         @Serializable
@@ -47,7 +53,6 @@ class ApplicationServiceRequestTest
     @Test
     fun can_serialize_and_deserialize_request()
     {
-
         val request = TestServiceRequest.Operation( 42 )
         val serialized = Json.encodeToString( request )
         val parsed = Json.decodeFromString<TestServiceRequest.Operation>( serialized )

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ChannelConventionEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/ChannelConventionEventBusTest.kt
@@ -1,9 +1,11 @@
 package dk.cachet.carp.common.infrastructure.services
 
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.services.publish
 import dk.cachet.carp.test.runSuspendTest
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
 import kotlin.test.*
@@ -30,10 +32,16 @@ class ChannelConventionEventBusTest
     }
 
     interface TestService1 : ApplicationService<TestService1, Service1Event>
+    {
+        companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+    }
 
     @Serializable
     sealed class Service1Event( override val aggregateId: String? = null ) : IntegrationEvent<TestService1>
     {
+        @Required
+        override val apiVersion: ApiVersion = TestService1.API_VERSION
+
         @Serializable
         data class SomeEvent( val data: String ) : Service1Event()
 
@@ -42,10 +50,16 @@ class ChannelConventionEventBusTest
     }
 
     interface TestService2 : ApplicationService<TestService2, Service2Event>
+    {
+        companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+    }
 
     @Serializable
     sealed class Service2Event( override val aggregateId: String? = null ) : IntegrationEvent<TestService2>
     {
+        @Required
+        override val apiVersion: ApiVersion = TestService2.API_VERSION
+
         @Serializable
         data class SomeEvent( val data: String ) : Service2Event()
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/SingleThreadedEventBusTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/services/SingleThreadedEventBusTest.kt
@@ -1,10 +1,12 @@
 package dk.cachet.carp.common.infrastructure.services
 
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.services.publish
 import dk.cachet.carp.common.application.services.registerHandler
 import dk.cachet.carp.test.runSuspendTest
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.test.*
 
@@ -15,10 +17,16 @@ import kotlin.test.*
 class SingleThreadedEventBusTest
 {
     interface TestService : ApplicationService<TestService, BaseIntegrationEvent>
+    {
+        companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+    }
 
     @Serializable
     sealed class BaseIntegrationEvent( override val aggregateId: String? = null ) : IntegrationEvent<TestService>
     {
+        @Required
+        override val apiVersion: ApiVersion = TestService.API_VERSION
+
         @Serializable
         data class SomeIntegrationEvent( val data: String ) : BaseIntegrationEvent()
 

--- a/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/application/UUID.kt
+++ b/carp.common/src/jsMain/kotlin/dk/cachet/carp/common/application/UUID.kt
@@ -12,13 +12,13 @@ actual class UUID actual constructor( actual val stringRepresentation: String )
     }
 
 
-    actual companion object
+    actual companion object : UUIDFactory
     {
         @OptIn( ExperimentalStdlibApi::class )
         actual fun parse( uuid: String ): UUID = UUID( uuid.lowercase() )
 
         private const val base = 16
-        actual fun randomUUID(): UUID
+        actual override fun randomUUID(): UUID
         {
             // It does not seem like JS can generate true UUIDs, but this is a best effort:
             // https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.application
 
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
@@ -20,9 +21,12 @@ import java.net.URI
 @Suppress( "MagicNumber" )
 class ApplicationServiceInfo( val serviceKlass: Class<out ApplicationService<*, *>> )
 {
+    val serviceName: String = serviceKlass.simpleName
+    val apiVersion: ApiVersion = checkNotNull( serviceKlass.getAnnotation( ApiVersion::class.java ) )
+        { "Application service \"${serviceKlass.name}\" is missing an \"${ApiVersion::class.simpleName}\" annotation." }
+
     val subsystemName: String
     val subsystemNamespace: String
-    val serviceName: String = serviceKlass.simpleName
 
     val requestObjectName: String = "${serviceName}Request"
     val requestObjectClass: Class<*>

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
@@ -48,7 +48,10 @@ class ApplicationServiceInfo( val serviceKlass: ServiceClass )
         {
             val retrievedObject = klass
                 .declaredClasses.singleOrNull { it.simpleName == name }
-                ?.declaredFields?.singleOrNull { it.name.endsWith( "INSTANCE" ) }
+                ?.declaredFields?.singleOrNull {
+                    // May be prepended with $ signs.
+                    it.name.endsWith( "INSTANCE" )
+                }
                 ?.let {
                     it.isAccessible = true
                     it.get( null )

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/ApplicationServiceInfo.kt
@@ -2,15 +2,16 @@ package dk.cachet.carp.common.application
 
 import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
+import dk.cachet.carp.common.application.services.DependentServices
 import dk.cachet.carp.common.application.services.IntegrationEvent
-import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.common.infrastructure.services.LoggedRequestSerializer
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerializationException
+import kotlinx.serialization.SealedClassSerializer
 import kotlinx.serialization.serializer
 import java.net.URI
+import kotlin.reflect.KClass
 
 
 /**
@@ -21,9 +22,45 @@ import java.net.URI
 @Suppress( "MagicNumber" )
 class ApplicationServiceInfo( val serviceKlass: Class<out ApplicationService<*, *>> )
 {
+    companion object
+    {
+        private fun getEventSerializer(
+            serviceKlass: Class<out ApplicationService<*, *>>
+        ): SealedClassSerializer<IntegrationEvent<*>>
+        {
+            val eventKlassLookup = serviceKlass
+                .declaredClasses.singleOrNull { it.simpleName == "Event" }
+                ?.kotlin
+            val eventKlass = checkNotNull( eventKlassLookup )
+            {
+                "Could not find event serializer for \"${serviceKlass.name}\". " +
+                "Expected it to be defined as an inner class named \"Event\"."
+            }
+
+            // HACK: Seemingly a serializer can't be retrieved for sealed classes with no subtypes. A likely bug.
+            //  This can be safely ignored, since there are no events to be serialized.
+            if ( eventKlass.java.declaredClasses.isEmpty() )
+            {
+                return SealedClassSerializer(
+                    IntegrationEvent::class.qualifiedName!!,
+                    IntegrationEvent::class,
+                    emptyArray(),
+                    emptyArray()
+                )
+            }
+
+            @Suppress( "UNCHECKED_CAST" )
+            return eventKlass.serializer() as SealedClassSerializer<IntegrationEvent<*>>
+        }
+    }
+
+
     val serviceName: String = serviceKlass.simpleName
     val apiVersion: ApiVersion = checkNotNull( serviceKlass.getAnnotation( ApiVersion::class.java ) )
         { "Application service \"${serviceKlass.name}\" is missing an \"${ApiVersion::class.simpleName}\" annotation." }
+    val dependentServices: List<Class<out ApplicationService<*, *>>> =
+        serviceKlass.getAnnotation( DependentServices::class.java )
+            ?.service?.map { it.java } ?: emptyList()
 
     val subsystemName: String
     val subsystemNamespace: String
@@ -71,21 +108,26 @@ class ApplicationServiceInfo( val serviceKlass: Class<out ApplicationService<*, 
                 "Expected it to be defined as an inner object named \"Serializer\"."
             }
 
-        // Get event serializer.
-        val eventKlassLookup = serviceKlass
-            .declaredClasses.singleOrNull { it.simpleName == "Event" }
-            ?.kotlin
-        val eventKlass = checkNotNull( eventKlassLookup )
-            {
-                "Could not find event serializer for \"${serviceKlass.name}\". " +
-                "Expected it to be defined as an inner class named \"Event\"."
-            }
-        @Suppress( "UNCHECKED_CAST" )
-        eventSerializer =
-            try { eventKlass.serializer() as KSerializer<IntegrationEvent<*>> }
-            // HACK: Seemingly a serializer can't be retrieved for sealed classes with no subtypes. A likely bug.
-            //  This can be safely ignored, since there are no events to be serialized.
-            catch ( _: SerializationException ) { NotSerializable as KSerializer<IntegrationEvent<*>> }
+        // Get event serializer capable of serializing published events, as well as events the service subscribes to.
+        // TODO: Merging sealed serializers can potentially be made multiplatform and moved to `carp.common`.
+        val eventSerializers = dependentServices.plus( serviceKlass ).map { getEventSerializer( it ) }
+        // HACK: There is no public accessor to get the subclass serializers.
+        //  https://github.com/Kotlin/kotlinx.serialization/issues/1865
+        val subclassesField = SealedClassSerializer::class.java
+            .getDeclaredField( "class2Serializer" )
+            .apply { isAccessible = true }
+        val allSubclassSerializers = eventSerializers.flatMap {
+            @Suppress( "UNCHECKED_CAST" )
+            val serializers = subclassesField.get( it )
+                as Map<KClass<IntegrationEvent<*>>, KSerializer<IntegrationEvent<*>>>
+            serializers.toList()
+        }.toMap()
+        eventSerializer = SealedClassSerializer(
+            IntegrationEvent::class.qualifiedName!!,
+            IntegrationEvent::class,
+            allSubclassSerializers.keys.toTypedArray(),
+            allSubclassSerializers.values.toTypedArray()
+        )
 
         loggedRequestSerializer = LoggedRequestSerializer( requestObjectSerializer, eventSerializer )
 

--- a/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/UUID.kt
+++ b/carp.common/src/jvmMain/kotlin/dk/cachet/carp/common/application/UUID.kt
@@ -12,11 +12,11 @@ actual class UUID actual constructor( actual val stringRepresentation: String )
     }
 
 
-    actual companion object
+    actual companion object : UUIDFactory
     {
         @OptIn( ExperimentalStdlibApi::class )
         actual fun parse( uuid: String ): UUID = UUID( uuid.lowercase() )
-        actual fun randomUUID(): UUID = UUID( java.util.UUID.randomUUID().toString() )
+        actual override fun randomUUID(): UUID = UUID( java.util.UUID.randomUUID().toString() )
     }
 
 

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 
@@ -17,6 +18,10 @@ interface DataStreamService : ApplicationService<DataStreamService, DataStreamSe
 
     @Serializable
     sealed class Event : IntegrationEvent<DataStreamService>
+    {
+        @Required
+        override val apiVersion: ApiVersion = API_VERSION
+    }
 
 
     /**

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
@@ -11,9 +11,10 @@ import kotlinx.serialization.Serializable
 /**
  * Store and retrieve [DataStreamPoint]s for study deployments.
  */
-@ApiVersion( 1, 0 )
 interface DataStreamService : ApplicationService<DataStreamService, DataStreamService.Event>
 {
+    companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+
     @Serializable
     sealed class Event : IntegrationEvent<DataStreamService>
 

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.data.application
 
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import kotlinx.serialization.Serializable
@@ -10,6 +11,7 @@ import kotlinx.serialization.Serializable
 /**
  * Store and retrieve [DataStreamPoint]s for study deployments.
  */
+@ApiVersion( 1, 0 )
 interface DataStreamService : ApplicationService<DataStreamService, DataStreamService.Event>
 {
     @Serializable

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceLoggingProxy.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceLoggingProxy.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.data.infrastructure
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceLoggingProxy
+import dk.cachet.carp.common.infrastructure.services.EventBusLog
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.data.application.DataStreamBatch
 import dk.cachet.carp.data.application.DataStreamId
@@ -21,9 +22,10 @@ class DataStreamServiceLoggingProxy(
 ) :
     ApplicationServiceLoggingProxy<DataStreamService, DataStreamService.Event>(
         service,
-        DataStreamService::class,
-        DataStreamService.Event::class,
-        eventBus,
+        EventBusLog(
+            eventBus,
+            EventBusLog.Subscription( DataStreamService::class, DataStreamService.Event::class )
+        ),
         log
     ),
     DataStreamService

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceRequest.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceRequest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.data.infrastructure
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.data.application.DataStreamBatch
@@ -9,6 +10,7 @@ import dk.cachet.carp.data.application.DataStreamsConfiguration
 import dk.cachet.carp.data.application.DataStreamId
 import dk.cachet.carp.data.application.DataStreamService
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
@@ -19,6 +21,9 @@ import kotlinx.serialization.serializer
 @Serializable
 sealed class DataStreamServiceRequest<out TReturn> : ApplicationServiceRequest<DataStreamService, TReturn>
 {
+    @Required
+    override val apiVersion: ApiVersion = DataStreamService.API_VERSION
+
     object Serializer : KSerializer<DataStreamServiceRequest<*>> by ignoreTypeParameters( ::serializer )
 
 

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/versioning/DataStreamServiceApiMigrator.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/versioning/DataStreamServiceApiMigrator.kt
@@ -1,0 +1,11 @@
+package dk.cachet.carp.data.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
+import dk.cachet.carp.data.application.DataStreamService
+import dk.cachet.carp.data.infrastructure.DataStreamServiceRequest
+
+
+val DataStreamServiceApiMigrator = ApplicationServiceApiMigrator(
+    DataStreamService.API_VERSION,
+    DataStreamServiceRequest.Serializer
+)

--- a/carp.data.core/src/jvmTest/kotlin/dk/cachet/carp/data/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.data.core/src/jvmTest/kotlin/dk/cachet/carp/data/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -1,0 +1,17 @@
+@file:Suppress( "MatchingDeclarationName" )
+
+package dk.cachet.carp.data.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
+import dk.cachet.carp.common.test.infrastructure.versioning.BackwardsCompatibilityTest
+import dk.cachet.carp.data.application.DataStreamService
+import dk.cachet.carp.data.infrastructure.InMemoryDataStreamService
+import kotlinx.serialization.ExperimentalSerializationApi
+
+
+@ExperimentalSerializationApi
+class DataStreamServiceBackwardsCompatibilityTest :
+    BackwardsCompatibilityTest<DataStreamService>( DataStreamService::class )
+{
+    override fun createService() = Pair( InMemoryDataStreamService(), SingleThreadedEventBus() )
+}

--- a/carp.data.core/src/jvmTest/kotlin/dk/cachet/carp/data/infrastructure/versioning/OutputDataStreamServiceTestRequests.kt
+++ b/carp.data.core/src/jvmTest/kotlin/dk/cachet/carp/data/infrastructure/versioning/OutputDataStreamServiceTestRequests.kt
@@ -9,11 +9,10 @@ import dk.cachet.carp.data.infrastructure.InMemoryDataStreamService
 
 
 class OutputDataStreamServiceTestRequests :
-    OutputTestRequests<DataStreamService>(
-        DataStreamService::class,
-        DataStreamServiceLoggingProxy( InMemoryDataStreamService(), SingleThreadedEventBus() )
-    ),
+    OutputTestRequests<DataStreamService>( DataStreamService::class ),
     DataStreamServiceTest
 {
-    override fun createService(): DataStreamService = loggedService
+    override fun createService(): DataStreamService =
+        DataStreamServiceLoggingProxy( InMemoryDataStreamService(), SingleThreadedEventBus() )
+            .also { loggedService = it }
 }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.deployments.application
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.AnyDeviceDescriptor
 import dk.cachet.carp.common.application.devices.DeviceRegistration
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.deployments.application.users.ParticipantInvitation
@@ -15,6 +16,7 @@ import kotlinx.serialization.Serializable
  * Application service which allows deploying study protocols to participants
  * and retrieving [MasterDeviceDeployment]'s for participating master devices as defined in the protocol.
  */
+@ApiVersion( 1, 0 )
 interface DeploymentService : ApplicationService<DeploymentService, DeploymentService.Event>
 {
     @Serializable

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
@@ -16,9 +16,10 @@ import kotlinx.serialization.Serializable
  * Application service which allows deploying study protocols to participants
  * and retrieving [MasterDeviceDeployment]'s for participating master devices as defined in the protocol.
  */
-@ApiVersion( 1, 0 )
 interface DeploymentService : ApplicationService<DeploymentService, DeploymentService.Event>
 {
+    companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+
     @Serializable
     sealed class Event( override val aggregateId: String? ) : IntegrationEvent<DeploymentService>
     {

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentService.kt
@@ -9,6 +9,7 @@ import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.deployments.application.users.ParticipantInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.datetime.Instant
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 
@@ -24,6 +25,9 @@ interface DeploymentService : ApplicationService<DeploymentService, DeploymentSe
     sealed class Event( override val aggregateId: String? ) : IntegrationEvent<DeploymentService>
     {
         constructor( aggregateId: UUID ) : this( aggregateId.stringRepresentation )
+
+        @Required
+        override val apiVersion: ApiVersion = API_VERSION
 
         @Serializable
         data class StudyDeploymentCreated(

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
@@ -16,10 +16,11 @@ import kotlinx.serialization.Serializable
  * Application service which allows retrieving participations for study deployments,
  * and managing data related to participants which is input by users.
  */
-@ApiVersion( 1, 0 )
 @DependentServices( DeploymentService::class )
 interface ParticipationService : ApplicationService<ParticipationService, ParticipationService.Event>
 {
+    companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+
     @Serializable
     sealed class Event : IntegrationEvent<ParticipationService>
 

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
@@ -6,6 +6,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.services.ApiVersion
+import dk.cachet.carp.common.application.services.DependentServices
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployments.application.users.ParticipantData
 import kotlinx.serialization.Serializable
@@ -16,6 +17,7 @@ import kotlinx.serialization.Serializable
  * and managing data related to participants which is input by users.
  */
 @ApiVersion( 1, 0 )
+@DependentServices( DeploymentService::class )
 interface ParticipationService : ApplicationService<ParticipationService, ParticipationService.Event>
 {
     @Serializable

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
@@ -9,6 +9,7 @@ import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.DependentServices
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployments.application.users.ParticipantData
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 
@@ -23,6 +24,10 @@ interface ParticipationService : ApplicationService<ParticipationService, Partic
 
     @Serializable
     sealed class Event : IntegrationEvent<ParticipationService>
+    {
+        @Required
+        override val apiVersion: ApiVersion = API_VERSION
+    }
 
 
     /**

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationService.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.input.InputDataType
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployments.application.users.ParticipantData
 import kotlinx.serialization.Serializable
@@ -14,6 +15,7 @@ import kotlinx.serialization.Serializable
  * Application service which allows retrieving participations for study deployments,
  * and managing data related to participants which is input by users.
  */
+@ApiVersion( 1, 0 )
 interface ParticipationService : ApplicationService<ParticipationService, ParticipationService.Event>
 {
     @Serializable

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
@@ -56,7 +56,8 @@ class StudyDeployment private constructor(
         fun fromInvitations(
             protocolSnapshot: StudyProtocolSnapshot,
             invitations: List<ParticipantInvitation>,
-            id: UUID = UUID.randomUUID()
+            id: UUID = UUID.randomUUID(),
+            now: Instant = Clock.System.now()
         ): StudyDeployment
         {
             protocolSnapshot.throwIfInvalidInvitations( invitations )
@@ -64,7 +65,7 @@ class StudyDeployment private constructor(
                 ParticipantStatus( it.participantId, it.assignedMasterDeviceRoleNames )
             }
 
-            return StudyDeployment( protocolSnapshot, participants, id )
+            return StudyDeployment( protocolSnapshot, participants, id, now )
         }
 
         fun fromSnapshot( snapshot: StudyDeploymentSnapshot ): StudyDeployment
@@ -471,11 +472,10 @@ class StudyDeployment private constructor(
      * Stop this study deployment.
      * No further changes to this deployment are allowed and no more data should be collected.
      */
-    fun stop()
+    fun stop( now: Instant = Clock.System.now() )
     {
         if ( !isStopped )
         {
-            val now = Clock.System.now()
             stoppedOn = now
             event( Event.Stopped( now ) )
         }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceLoggingProxy.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceLoggingProxy.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.DeviceRegistration
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceLoggingProxy
+import dk.cachet.carp.common.infrastructure.services.EventBusLog
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.deployments.application.DeploymentService
 import dk.cachet.carp.deployments.application.MasterDeviceDeployment
@@ -24,9 +25,10 @@ class DeploymentServiceLoggingProxy(
 ) :
     ApplicationServiceLoggingProxy<DeploymentService, DeploymentService.Event>(
         service,
-        DeploymentService::class,
-        DeploymentService.Event::class,
-        eventBus,
+        EventBusLog(
+            eventBus,
+            EventBusLog.Subscription( DeploymentService::class, DeploymentService.Event::class )
+        ),
         log
     ),
     DeploymentService

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequest.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/DeploymentServiceRequest.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.deployments.infrastructure
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.DeviceRegistration
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.deployments.application.DeploymentService
@@ -11,6 +12,7 @@ import dk.cachet.carp.deployments.application.users.ParticipantInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
@@ -21,6 +23,9 @@ import kotlinx.serialization.serializer
 @Serializable
 sealed class DeploymentServiceRequest<out TReturn> : ApplicationServiceRequest<DeploymentService, TReturn>
 {
+    @Required
+    override val apiVersion: ApiVersion = DeploymentService.API_VERSION
+
     object Serializer : KSerializer<DeploymentServiceRequest<*>> by ignoreTypeParameters( ::serializer )
 
 

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/InMemoryAccountService.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/InMemoryAccountService.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.deployments.infrastructure
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.UUIDFactory
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.common.application.devices.AnyDeviceDescriptor
 import dk.cachet.carp.common.domain.users.Account
@@ -12,7 +13,7 @@ import dk.cachet.carp.deployments.domain.users.AccountService
 /**
  * An [AccountService] which holds accounts in memory as long as the instance is held in memory.
  */
-class InMemoryAccountService : AccountService
+class InMemoryAccountService( val uuidFactory: UUIDFactory = UUID.Companion ) : AccountService
 {
     private val accounts: MutableList<Account> = mutableListOf()
 
@@ -32,7 +33,7 @@ class InMemoryAccountService : AccountService
     {
         require( accounts.none { it.identity == identity } )
 
-        val account = Account( identity )
+        val account = Account( identity, uuidFactory.randomUUID() )
         accounts.add( account )
 
         return account

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceLoggingProxy.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceLoggingProxy.kt
@@ -7,6 +7,7 @@ import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceLoggingProxy
 import dk.cachet.carp.common.infrastructure.services.EventBusLog
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
+import dk.cachet.carp.deployments.application.DeploymentService
 import dk.cachet.carp.deployments.application.ParticipationService
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployments.application.users.ParticipantData
@@ -26,6 +27,7 @@ class ParticipationServiceLoggingProxy(
         EventBusLog(
             eventBus,
             EventBusLog.Subscription( ParticipationService::class, ParticipationService.Event::class ),
+            EventBusLog.Subscription( DeploymentService::class, DeploymentService.Event::class )
         ),
         log
     ),

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceLoggingProxy.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceLoggingProxy.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceLoggingProxy
+import dk.cachet.carp.common.infrastructure.services.EventBusLog
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.deployments.application.ParticipationService
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
@@ -22,9 +23,10 @@ class ParticipationServiceLoggingProxy(
 ) :
     ApplicationServiceLoggingProxy<ParticipationService, ParticipationService.Event>(
         service,
-        ParticipationService::class,
-        ParticipationService.Event::class,
-        eventBus,
+        EventBusLog(
+            eventBus,
+            EventBusLog.Subscription( ParticipationService::class, ParticipationService.Event::class ),
+        ),
         log
     ),
     ParticipationService

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceRequest.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationServiceRequest.kt
@@ -3,12 +3,14 @@ package dk.cachet.carp.deployments.infrastructure
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.input.InputDataType
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.deployments.application.ParticipationService
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation
 import dk.cachet.carp.deployments.application.users.ParticipantData
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
@@ -19,6 +21,9 @@ import kotlinx.serialization.serializer
 @Serializable
 sealed class ParticipationServiceRequest<out TReturn> : ApplicationServiceRequest<ParticipationService, TReturn>
 {
+    @Required
+    override val apiVersion: ApiVersion = ParticipationService.API_VERSION
+
     object Serializer : KSerializer<ParticipationServiceRequest<*>> by ignoreTypeParameters( ::serializer )
 
 

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/DeploymentServiceApiMigrator.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/DeploymentServiceApiMigrator.kt
@@ -1,0 +1,11 @@
+package dk.cachet.carp.deployments.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
+import dk.cachet.carp.deployments.application.DeploymentService
+import dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest
+
+
+val DeploymentServiceApiMigrator = ApplicationServiceApiMigrator(
+    DeploymentService.API_VERSION,
+    DeploymentServiceRequest.Serializer
+)

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/ParticipationServiceApiMigrator.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/ParticipationServiceApiMigrator.kt
@@ -1,0 +1,11 @@
+package dk.cachet.carp.deployments.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
+import dk.cachet.carp.deployments.application.ParticipationService
+import dk.cachet.carp.deployments.infrastructure.ParticipationServiceRequest
+
+
+val ParticipationServiceApiMigrator = ApplicationServiceApiMigrator(
+    ParticipationService.API_VERSION,
+    ParticipationServiceRequest.Serializer
+)

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHostTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHostTest.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.application.services.createApplicationServiceAdapte
 import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
 import dk.cachet.carp.data.infrastructure.InMemoryDataStreamService
 import dk.cachet.carp.deployments.infrastructure.InMemoryDeploymentRepository
+import dk.cachet.carp.test.TestClock
 
 
 /**
@@ -21,7 +22,8 @@ class DeploymentServiceHostTest : DeploymentServiceTest
             val deploymentService = DeploymentServiceHost(
                 InMemoryDeploymentRepository(),
                 InMemoryDataStreamService(),
-                eventBus.createApplicationServiceAdapter( DeploymentService::class )
+                eventBus.createApplicationServiceAdapter( DeploymentService::class ),
+                TestClock
             )
 
             return Pair( deploymentService, eventBus )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHostTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHostTest.kt
@@ -3,11 +3,13 @@ package dk.cachet.carp.deployments.application
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.application.services.createApplicationServiceAdapter
 import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
+import dk.cachet.carp.common.test.infrastructure.TestUUIDFactory
 import dk.cachet.carp.data.infrastructure.InMemoryDataStreamService
 import dk.cachet.carp.deployments.domain.users.ParticipantGroupService
 import dk.cachet.carp.deployments.infrastructure.InMemoryAccountService
 import dk.cachet.carp.deployments.infrastructure.InMemoryDeploymentRepository
 import dk.cachet.carp.deployments.infrastructure.InMemoryParticipationRepository
+import dk.cachet.carp.test.TestClock
 
 
 /**
@@ -24,9 +26,11 @@ class ParticipationServiceHostTest : ParticipationServiceTest
             val deploymentService = DeploymentServiceHost(
                 InMemoryDeploymentRepository(),
                 InMemoryDataStreamService(),
-                eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
+                eventBus.createApplicationServiceAdapter( DeploymentService::class ),
+                TestClock
+            )
 
-            val accountService = InMemoryAccountService()
+            val accountService = InMemoryAccountService( TestUUIDFactory() )
 
             val participationService = ParticipationServiceHost(
                 InMemoryParticipationRepository(),

--- a/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -1,0 +1,25 @@
+package dk.cachet.carp.deployments.infrastructure.versioning
+
+import dk.cachet.carp.common.test.infrastructure.versioning.BackwardsCompatibilityTest
+import dk.cachet.carp.deployments.application.DeploymentService
+import dk.cachet.carp.deployments.application.DeploymentServiceHostTest
+import dk.cachet.carp.deployments.application.ParticipationService
+import dk.cachet.carp.deployments.application.ParticipationServiceHostTest
+import kotlinx.serialization.ExperimentalSerializationApi
+
+
+@ExperimentalSerializationApi
+class DeploymentServiceBackwardsCompatibilityTest :
+    BackwardsCompatibilityTest<DeploymentService>( DeploymentService::class )
+{
+    override fun createService() = DeploymentServiceHostTest.createService()
+}
+
+
+@ExperimentalSerializationApi
+class ParticipationServiceBackwardsCompatibilityTest :
+    BackwardsCompatibilityTest<ParticipationService>( ParticipationService::class )
+{
+    override fun createService() = ParticipationServiceHostTest.createService()
+        .let { Pair( it.participationService, it.eventBus ) }
+}

--- a/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputDeploymentServiceTestRequests.kt
+++ b/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputDeploymentServiceTestRequests.kt
@@ -7,14 +7,15 @@ import dk.cachet.carp.deployments.application.DeploymentServiceTest
 import dk.cachet.carp.deployments.infrastructure.DeploymentServiceLoggingProxy
 
 
-private val services = DeploymentServiceHostTest.createService()
-
 class OutputDeploymentServiceTestRequests :
-    OutputTestRequests<DeploymentService>(
-        DeploymentService::class,
-        DeploymentServiceLoggingProxy( services.first, services.second )
-    ),
+    OutputTestRequests<DeploymentService>( DeploymentService::class ),
     DeploymentServiceTest
 {
-    override fun createService(): DeploymentService = loggedService
+    override fun createService(): DeploymentService
+    {
+        val services = DeploymentServiceHostTest.createService()
+
+        return DeploymentServiceLoggingProxy( services.first, services.second )
+            .also { loggedService = it }
+    }
 }

--- a/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputParticipationServiceTestRequests.kt
+++ b/carp.deployments.core/src/jvmTest/kotlin/dk/cachet/carp/deployments/infrastructure/versioning/OutputParticipationServiceTestRequests.kt
@@ -7,20 +7,21 @@ import dk.cachet.carp.deployments.application.ParticipationServiceTest
 import dk.cachet.carp.deployments.infrastructure.ParticipationServiceLoggingProxy
 
 
-private val services = ParticipationServiceHostTest.createService()
-
 class OutputParticipationServiceTestRequests :
-    OutputTestRequests<ParticipationService>(
-        ParticipationService::class,
-        ParticipationServiceLoggingProxy( services.participationService, services.eventBus )
-    ),
+    OutputTestRequests<ParticipationService>( ParticipationService::class ),
     ParticipationServiceTest
 {
-    override fun createService() =
-        ParticipationServiceTest.DependentServices(
-            loggedService,
+    override fun createService(): ParticipationServiceTest.DependentServices
+    {
+        val services = ParticipationServiceHostTest.createService()
+        val service = ParticipationServiceLoggingProxy( services.participationService, services.eventBus )
+        loggedService = service
+
+        return ParticipationServiceTest.DependentServices(
+            service,
             services.deploymentService,
             services.accountService,
             services.eventBus
         )
+    }
 }

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
@@ -12,9 +12,10 @@ import kotlinx.serialization.Serializable
 /**
  * Factory methods to create [StudyProtocolSnapshot]'s according to predefined templates.
  */
-@ApiVersion( 1, 0 )
 interface ProtocolFactoryService : ApplicationService<ProtocolFactoryService, ProtocolFactoryService.Event>
 {
+    companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+
     @Serializable
     sealed class Event : IntegrationEvent<ProtocolFactoryService>
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
@@ -6,6 +6,7 @@ import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.tasks.CustomProtocolTask
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 
@@ -18,6 +19,10 @@ interface ProtocolFactoryService : ApplicationService<ProtocolFactoryService, Pr
 
     @Serializable
     sealed class Event : IntegrationEvent<ProtocolFactoryService>
+    {
+        @Required
+        override val apiVersion: ApiVersion = API_VERSION
+    }
 
 
     /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryService.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.protocols.application
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.CustomProtocolDevice
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.tasks.CustomProtocolTask
@@ -11,6 +12,7 @@ import kotlinx.serialization.Serializable
 /**
  * Factory methods to create [StudyProtocolSnapshot]'s according to predefined templates.
  */
+@ApiVersion( 1, 0 )
 interface ProtocolFactoryService : ApplicationService<ProtocolFactoryService, ProtocolFactoryService.Event>
 {
     @Serializable

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHost.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHost.kt
@@ -1,17 +1,22 @@
 package dk.cachet.carp.protocols.application
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.UUIDFactory
 import dk.cachet.carp.common.application.devices.CustomProtocolDevice
 import dk.cachet.carp.common.application.tasks.CustomProtocolTask
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.start
+import kotlinx.datetime.Clock
 
 
 /**
  * Implementation of [ProtocolFactoryService] which provides factory methods
  * to create [StudyProtocolSnapshot]'s according to predefined templates.
 */
-class ProtocolFactoryServiceHost : ProtocolFactoryService
+class ProtocolFactoryServiceHost(
+    val uuidFactory: UUIDFactory = UUID.Companion,
+    val clock: Clock = Clock.System
+) : ProtocolFactoryService
 {
     /**
      * Create a study protocol to be deployed to a single device which has its own way of describing study protocols that
@@ -27,7 +32,7 @@ class ProtocolFactoryServiceHost : ProtocolFactoryService
         description: String?
     ): StudyProtocolSnapshot
     {
-        val protocol = StudyProtocol( ownerId, name, description )
+        val protocol = StudyProtocol( ownerId, name, description, uuidFactory.randomUUID(), clock.now() )
         val customDevice = CustomProtocolDevice( "Custom device" )
         protocol.addMasterDevice( customDevice )
         val task = CustomProtocolTask( "Custom device task", customProtocol )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
@@ -7,6 +7,7 @@ import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.users.ParticipantAttribute
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import kotlinx.datetime.Clock
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 
@@ -20,6 +21,10 @@ interface ProtocolService : ApplicationService<ProtocolService, ProtocolService.
 
     @Serializable
     sealed class Event : IntegrationEvent<ProtocolService>
+    {
+        @Required
+        override val apiVersion: ApiVersion = API_VERSION
+    }
 
 
     /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
@@ -14,9 +14,10 @@ import kotlinx.serialization.Serializable
  * Application service which allows managing (multiple versions of) [StudyProtocolSnapshot]'s,
  * which can be instantiated locally through [StudyProtocol].
  */
-@ApiVersion( 1, 0 )
 interface ProtocolService : ApplicationService<ProtocolService, ProtocolService.Event>
 {
+    companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+
     @Serializable
     sealed class Event : IntegrationEvent<ProtocolService>
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolService.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.protocols.application
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.users.ParticipantAttribute
@@ -13,6 +14,7 @@ import kotlinx.serialization.Serializable
  * Application service which allows managing (multiple versions of) [StudyProtocolSnapshot]'s,
  * which can be instantiated locally through [StudyProtocol].
  */
+@ApiVersion( 1, 0 )
 interface ProtocolService : ApplicationService<ProtocolService, ProtocolService.Event>
 {
     @Serializable

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHost.kt
@@ -4,13 +4,17 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.ParticipantAttribute
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.StudyProtocolRepository
+import kotlinx.datetime.Clock
 
 
 /**
  * Implementation of [ProtocolService] which allows managing (multiple versions of) [StudyProtocolSnapshot]'s,
  * which can be instantiated locally through [StudyProtocol].
  */
-class ProtocolServiceHost( private val repository: StudyProtocolRepository ) : ProtocolService
+class ProtocolServiceHost(
+    private val repository: StudyProtocolRepository,
+    private val clock: Clock = Clock.System
+) : ProtocolService
 {
     /**
      * Add the specified study [protocol].
@@ -24,7 +28,7 @@ class ProtocolServiceHost( private val repository: StudyProtocolRepository ) : P
     override suspend fun add( protocol: StudyProtocolSnapshot, versionTag: String )
     {
         val initializedProtocol = StudyProtocol.fromSnapshot( protocol )
-        repository.add( initializedProtocol, ProtocolVersion( versionTag ) )
+        repository.add( initializedProtocol, ProtocolVersion( versionTag, clock.now() ) )
     }
 
     /**
@@ -41,7 +45,7 @@ class ProtocolServiceHost( private val repository: StudyProtocolRepository ) : P
     override suspend fun addVersion( protocol: StudyProtocolSnapshot, versionTag: String )
     {
         val initializedProtocol = StudyProtocol.fromSnapshot( protocol )
-        repository.addVersion( initializedProtocol, ProtocolVersion( versionTag ) )
+        repository.addVersion( initializedProtocol, ProtocolVersion( versionTag, clock.now() ) )
     }
 
     /**

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceLoggingProxy.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceLoggingProxy.kt
@@ -11,7 +11,7 @@ import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 
 /**
  * A proxy for a protocol factory [service] which notifies of incoming requests and responses through [log]
- * and keeps a history of requests in [loggedRequests] and published events in [loggedEvents].
+ * and keeps a history of requests in [loggedRequests].
  */
 class ProtocolFactoryServiceLoggingProxy(
     service: ProtocolFactoryService,

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceLoggingProxy.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceLoggingProxy.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.protocols.infrastructure
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceLoggingProxy
+import dk.cachet.carp.common.infrastructure.services.EventBusLog
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.protocols.application.ProtocolFactoryService
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
@@ -19,9 +20,10 @@ class ProtocolFactoryServiceLoggingProxy(
 ) :
     ApplicationServiceLoggingProxy<ProtocolFactoryService, ProtocolFactoryService.Event>(
         service,
-        ProtocolFactoryService::class,
-        ProtocolFactoryService.Event::class,
-        eventBus,
+        EventBusLog(
+            eventBus,
+            EventBusLog.Subscription( ProtocolFactoryService::class, ProtocolFactoryService.Event::class )
+        ),
         log
     ),
     ProtocolFactoryService

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceRequest.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolFactoryServiceRequest.kt
@@ -1,11 +1,13 @@
 package dk.cachet.carp.protocols.infrastructure
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.protocols.application.ProtocolFactoryService
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
@@ -16,6 +18,9 @@ import kotlinx.serialization.serializer
 @Serializable
 sealed class ProtocolFactoryServiceRequest<out TReturn> : ApplicationServiceRequest<ProtocolFactoryService, TReturn>
 {
+    @Required
+    override val apiVersion: ApiVersion = ProtocolFactoryService.API_VERSION
+
     object Serializer : KSerializer<ProtocolFactoryServiceRequest<*>> by ignoreTypeParameters( ::serializer )
 
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceLoggingProxy.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceLoggingProxy.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.application.users.ParticipantAttribute
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceLoggingProxy
+import dk.cachet.carp.common.infrastructure.services.EventBusLog
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.protocols.application.ProtocolService
 import dk.cachet.carp.protocols.application.ProtocolVersion
@@ -21,9 +22,10 @@ class ProtocolServiceLoggingProxy(
 ) :
     ApplicationServiceLoggingProxy<ProtocolService, ProtocolService.Event>(
         service,
-        ProtocolService::class,
-        ProtocolService.Event::class,
-        eventBus,
+        EventBusLog(
+            eventBus,
+            EventBusLog.Subscription( ProtocolService::class, ProtocolService.Event::class )
+        ),
         log
     ),
     ProtocolService

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolServiceRequest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.protocols.infrastructure
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.users.ParticipantAttribute
 import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
@@ -9,6 +10,7 @@ import dk.cachet.carp.protocols.application.ProtocolVersion
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import kotlinx.datetime.Clock
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
@@ -19,6 +21,9 @@ import kotlinx.serialization.serializer
 @Serializable
 sealed class ProtocolServiceRequest<out TReturn> : ApplicationServiceRequest<ProtocolService, TReturn>
 {
+    @Required
+    override val apiVersion: ApiVersion = ProtocolService.API_VERSION
+
     object Serializer : KSerializer<ProtocolServiceRequest<*>> by ignoreTypeParameters( ::serializer )
 
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/ProtocolFactoryServiceApiMigrator.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/ProtocolFactoryServiceApiMigrator.kt
@@ -1,0 +1,11 @@
+package dk.cachet.carp.protocols.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
+import dk.cachet.carp.protocols.application.ProtocolFactoryService
+import dk.cachet.carp.protocols.infrastructure.ProtocolFactoryServiceRequest
+
+
+val ProtocolFactoryServiceApiMigrator = ApplicationServiceApiMigrator(
+    ProtocolFactoryService.API_VERSION,
+    ProtocolFactoryServiceRequest.Serializer
+)

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/ProtocolServiceApiMigrator.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/ProtocolServiceApiMigrator.kt
@@ -1,0 +1,11 @@
+package dk.cachet.carp.protocols.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
+import dk.cachet.carp.protocols.application.ProtocolService
+import dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest
+
+
+val ProtocolServiceApiMigrator = ApplicationServiceApiMigrator(
+    ProtocolService.API_VERSION,
+    ProtocolServiceRequest.Serializer
+)

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHostTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolFactoryServiceHostTest.kt
@@ -1,5 +1,8 @@
 package dk.cachet.carp.protocols.application
 
+import dk.cachet.carp.common.test.infrastructure.TestUUIDFactory
+import dk.cachet.carp.test.TestClock
+
 
 /**
  * Tests for [ProtocolFactoryServiceHost].
@@ -8,7 +11,7 @@ class ProtocolFactoryServiceHostTest : ProtocolFactoryServiceTest
 {
     companion object
     {
-        fun createService(): ProtocolFactoryService = ProtocolFactoryServiceHost()
+        fun createService(): ProtocolFactoryService = ProtocolFactoryServiceHost( TestUUIDFactory(), TestClock )
     }
 
     override fun createService(): ProtocolFactoryService = ProtocolFactoryServiceHostTest.createService()

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHostTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceHostTest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.protocols.application
 
 import dk.cachet.carp.protocols.infrastructure.InMemoryStudyProtocolRepository
+import dk.cachet.carp.test.TestClock
 
 
 /**
@@ -10,7 +11,7 @@ class ProtocolServiceHostTest : ProtocolServiceTest
 {
     companion object
     {
-        fun createService(): ProtocolService = ProtocolServiceHost( InMemoryStudyProtocolRepository() )
+        fun createService(): ProtocolService = ProtocolServiceHost( InMemoryStudyProtocolRepository(), TestClock )
     }
 
     override fun createService(): ProtocolService = ProtocolServiceHostTest.createService()

--- a/carp.protocols.core/src/jvmTest/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.protocols.core/src/jvmTest/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -1,0 +1,25 @@
+package dk.cachet.carp.protocols.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
+import dk.cachet.carp.common.test.infrastructure.versioning.BackwardsCompatibilityTest
+import dk.cachet.carp.protocols.application.ProtocolFactoryService
+import dk.cachet.carp.protocols.application.ProtocolFactoryServiceHostTest
+import dk.cachet.carp.protocols.application.ProtocolService
+import dk.cachet.carp.protocols.application.ProtocolServiceHostTest
+import kotlinx.serialization.ExperimentalSerializationApi
+
+
+@ExperimentalSerializationApi
+class ProtocolServiceBackwardsCompatibilityTest :
+    BackwardsCompatibilityTest<ProtocolService>( ProtocolService::class )
+{
+    override fun createService() = Pair( ProtocolServiceHostTest.createService(), SingleThreadedEventBus() )
+}
+
+
+@ExperimentalSerializationApi
+class ProtocolFactoryServiceBackwardsCompatibilityTest :
+    BackwardsCompatibilityTest<ProtocolFactoryService>( ProtocolFactoryService::class )
+{
+    override fun createService() = Pair( ProtocolFactoryServiceHostTest.createService(), SingleThreadedEventBus() )
+}

--- a/carp.protocols.core/src/jvmTest/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/OutputProtocolFactoryServiceTestRequests.kt
+++ b/carp.protocols.core/src/jvmTest/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/OutputProtocolFactoryServiceTestRequests.kt
@@ -9,11 +9,10 @@ import dk.cachet.carp.protocols.infrastructure.ProtocolFactoryServiceLoggingProx
 
 
 class OutputProtocolFactoryServiceTestRequests :
-    OutputTestRequests<ProtocolFactoryService>(
-        ProtocolFactoryService::class,
-        ProtocolFactoryServiceLoggingProxy( ProtocolFactoryServiceHostTest.createService(), SingleThreadedEventBus() )
-    ),
+    OutputTestRequests<ProtocolFactoryService>( ProtocolFactoryService::class ),
     ProtocolFactoryServiceTest
 {
-    override fun createService(): ProtocolFactoryService = loggedService
+    override fun createService(): ProtocolFactoryService =
+        ProtocolFactoryServiceLoggingProxy( ProtocolFactoryServiceHostTest.createService(), SingleThreadedEventBus() )
+            .also { loggedService = it }
 }

--- a/carp.protocols.core/src/jvmTest/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/OutputProtocolServiceTestRequests.kt
+++ b/carp.protocols.core/src/jvmTest/kotlin/dk/cachet/carp/protocols/infrastructure/versioning/OutputProtocolServiceTestRequests.kt
@@ -9,11 +9,10 @@ import dk.cachet.carp.protocols.infrastructure.ProtocolServiceLoggingProxy
 
 
 class OutputProtocolServiceTestRequests :
-    OutputTestRequests<ProtocolService>(
-        ProtocolService::class,
-        ProtocolServiceLoggingProxy( ProtocolServiceHostTest.createService(), SingleThreadedEventBus() )
-    ),
+    OutputTestRequests<ProtocolService>( ProtocolService::class ),
     ProtocolServiceTest
 {
-    override fun createService(): ProtocolService = loggedService
+    override fun createService(): ProtocolService =
+        ProtocolServiceLoggingProxy( ProtocolServiceHostTest.createService(), SingleThreadedEventBus() )
+            .also { loggedService = it }
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.studies.application.users.AssignParticipantDevices
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
@@ -13,6 +14,7 @@ import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
  * Application service which allows setting recruitment goals,
  * adding participants to studies, and creating deployments for them.
  */
+@ApiVersion( 1, 0 )
 interface RecruitmentService : ApplicationService<RecruitmentService, RecruitmentService.Event>
 {
     sealed class Event : IntegrationEvent<RecruitmentService>

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
@@ -5,6 +5,7 @@ import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.services.ApiVersion
+import dk.cachet.carp.common.application.services.DependentServices
 import dk.cachet.carp.studies.application.users.AssignParticipantDevices
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
@@ -15,6 +16,7 @@ import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
  * adding participants to studies, and creating deployments for them.
  */
 @ApiVersion( 1, 0 )
+@DependentServices( StudyService::class )
 interface RecruitmentService : ApplicationService<RecruitmentService, RecruitmentService.Event>
 {
     sealed class Event : IntegrationEvent<RecruitmentService>

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
@@ -6,9 +6,11 @@ import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.DependentServices
+import dk.cachet.carp.deployments.application.DeploymentService
 import dk.cachet.carp.studies.application.users.AssignParticipantDevices
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
+import kotlinx.serialization.Required
 
 
 /**
@@ -21,6 +23,10 @@ interface RecruitmentService : ApplicationService<RecruitmentService, Recruitmen
     companion object { val API_VERSION = ApiVersion( 1, 0 ) }
 
     sealed class Event : IntegrationEvent<RecruitmentService>
+    {
+        @Required
+        override val apiVersion: ApiVersion = DeploymentService.API_VERSION
+    }
 
 
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
@@ -15,10 +15,11 @@ import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
  * Application service which allows setting recruitment goals,
  * adding participants to studies, and creating deployments for them.
  */
-@ApiVersion( 1, 0 )
 @DependentServices( StudyService::class )
 interface RecruitmentService : ApplicationService<RecruitmentService, RecruitmentService.Event>
 {
+    companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+
     sealed class Event : IntegrationEvent<RecruitmentService>
 
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -6,6 +6,7 @@ import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 
@@ -20,6 +21,9 @@ interface StudyService : ApplicationService<StudyService, StudyService.Event>
     sealed class Event( override val aggregateId: String? ) : IntegrationEvent<StudyService>
     {
         constructor( aggregateId: UUID ) : this( aggregateId.stringRepresentation )
+
+        @Required
+        override val apiVersion: ApiVersion = API_VERSION
 
         @Serializable
         data class StudyCreated( val study: StudyDetails ) : Event( study.studyId )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -12,9 +12,10 @@ import kotlinx.serialization.Serializable
 /**
  * Application service which allows creating and managing studies.
  */
-@ApiVersion( 1, 0 )
 interface StudyService : ApplicationService<StudyService, StudyService.Event>
 {
+    companion object { val API_VERSION = ApiVersion( 1, 0 ) }
+
     @Serializable
     sealed class Event( override val aggregateId: String? ) : IntegrationEvent<StudyService>
     {

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyService.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.application.services.ApplicationService
 import dk.cachet.carp.common.application.services.IntegrationEvent
 import dk.cachet.carp.deployments.application.users.StudyInvitation
@@ -11,6 +12,7 @@ import kotlinx.serialization.Serializable
 /**
  * Application service which allows creating and managing studies.
  */
+@ApiVersion( 1, 0 )
 interface StudyService : ApplicationService<StudyService, StudyService.Event>
 {
     @Serializable

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/StudyServiceHost.kt
@@ -1,11 +1,13 @@
 package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.UUIDFactory
 import dk.cachet.carp.common.application.services.ApplicationServiceEventBus
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.studies.domain.Study
 import dk.cachet.carp.studies.domain.StudyRepository
+import kotlinx.datetime.Clock
 
 
 /**
@@ -13,7 +15,9 @@ import dk.cachet.carp.studies.domain.StudyRepository
  */
 class StudyServiceHost(
     private val repository: StudyRepository,
-    private val eventBus: ApplicationServiceEventBus<StudyService, StudyService.Event>
+    private val eventBus: ApplicationServiceEventBus<StudyService, StudyService.Event>,
+    private val uuidFactory: UUIDFactory = UUID.Companion,
+    private val clock: Clock = Clock.System
 ) : StudyService
 {
     /**
@@ -37,7 +41,7 @@ class StudyServiceHost(
     ): StudyStatus
     {
         val ensuredInvitation = invitation ?: StudyInvitation( name )
-        val study = Study( ownerId, name, description, ensuredInvitation )
+        val study = Study( ownerId, name, description, ensuredInvitation, uuidFactory.randomUUID(), clock.now() )
 
         repository.add( study )
         eventBus.publish( StudyService.Event.StudyCreated( study.getStudyDetails() ) )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
@@ -61,7 +61,7 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
      * Add a [Participant] identified by the specified [email] address.
      * In case the [email] was already added before, the same [Participant] is returned.
      */
-    fun addParticipant( email: EmailAddress ): Participant
+    fun addParticipant( email: EmailAddress, id: UUID = UUID.randomUUID() ): Participant
     {
         // Verify whether participant was already added.
         val identity = EmailAccountIdentity( email )
@@ -70,7 +70,7 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
         // Add new participant in case it was not added before.
         if ( participant == null )
         {
-            participant = Participant( identity )
+            participant = Participant( identity, id )
             _participants.add( participant )
             event( Event.ParticipantAdded( participant ) )
         }
@@ -156,13 +156,13 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
      * @throws IllegalArgumentException when one or more of the participants aren't in this recruitment.
      * @throws IllegalStateException when the study is not yet ready for deployment.
      */
-    fun addParticipantGroup( participantIds: Set<UUID> ): StagedParticipantGroup
+    fun addParticipantGroup( participantIds: Set<UUID>, id: UUID = UUID.randomUUID() ): StagedParticipantGroup
     {
         require( participantIds.all { id -> id in participants.map { it.id } } )
             { "One of the participants for which to create a participant group isn't part of this recruitment." }
         check( getStatus() is RecruitmentStatus.ReadyForDeployment ) { "The study is not yet ready for deployment." }
 
-        val group = StagedParticipantGroup()
+        val group = StagedParticipantGroup( id )
         group.addParticipants( participantIds )
 
         _participantGroups[ group.id ] = group

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceLoggingProxy.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceLoggingProxy.kt
@@ -7,6 +7,7 @@ import dk.cachet.carp.common.infrastructure.services.ApplicationServiceLoggingPr
 import dk.cachet.carp.common.infrastructure.services.EventBusLog
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.studies.application.RecruitmentService
+import dk.cachet.carp.studies.application.StudyService
 import dk.cachet.carp.studies.application.users.AssignParticipantDevices
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
@@ -26,6 +27,7 @@ class RecruitmentServiceLoggingProxy(
         EventBusLog(
             eventBus,
             EventBusLog.Subscription( RecruitmentService::class, RecruitmentService.Event::class ),
+            EventBusLog.Subscription( StudyService::class, StudyService.Event::class )
         ),
         log
     ),

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceLoggingProxy.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceLoggingProxy.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceLoggingProxy
+import dk.cachet.carp.common.infrastructure.services.EventBusLog
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.studies.application.RecruitmentService
 import dk.cachet.carp.studies.application.users.AssignParticipantDevices
@@ -22,9 +23,10 @@ class RecruitmentServiceLoggingProxy(
 ) :
     ApplicationServiceLoggingProxy<RecruitmentService, RecruitmentService.Event>(
         service,
-        RecruitmentService::class,
-        RecruitmentService.Event::class,
-        eventBus,
+        EventBusLog(
+            eventBus,
+            EventBusLog.Subscription( RecruitmentService::class, RecruitmentService.Event::class ),
+        ),
         log
     ),
     RecruitmentService

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequest.kt
@@ -2,6 +2,7 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.studies.application.RecruitmentService
@@ -9,6 +10,7 @@ import dk.cachet.carp.studies.application.users.AssignParticipantDevices
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
@@ -19,6 +21,9 @@ import kotlinx.serialization.serializer
 @Serializable
 sealed class RecruitmentServiceRequest<out TReturn> : ApplicationServiceRequest<RecruitmentService, TReturn>
 {
+    @Required
+    override val apiVersion: ApiVersion = RecruitmentService.API_VERSION
+
     object Serializer : KSerializer<RecruitmentServiceRequest<*>> by ignoreTypeParameters( ::serializer )
 
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceLoggingProxy.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceLoggingProxy.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.studies.infrastructure
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceLoggingProxy
+import dk.cachet.carp.common.infrastructure.services.EventBusLog
 import dk.cachet.carp.common.infrastructure.services.LoggedRequest
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
@@ -22,9 +23,10 @@ class StudyServiceLoggingProxy(
 ) :
     ApplicationServiceLoggingProxy<StudyService, StudyService.Event>(
         service,
-        StudyService::class,
-        StudyService.Event::class,
-        eventBus,
+        EventBusLog(
+            eventBus,
+            EventBusLog.Subscription( StudyService::class, StudyService.Event::class )
+        ),
         log
     ),
     StudyService

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/StudyServiceRequest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.services.ApiVersion
 import dk.cachet.carp.common.infrastructure.serialization.ignoreTypeParameters
 import dk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
 import dk.cachet.carp.deployments.application.users.StudyInvitation
@@ -9,6 +10,7 @@ import dk.cachet.carp.studies.application.StudyService
 import dk.cachet.carp.studies.application.StudyDetails
 import dk.cachet.carp.studies.application.StudyStatus
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
@@ -19,6 +21,9 @@ import kotlinx.serialization.serializer
 @Serializable
 sealed class StudyServiceRequest<out TReturn> : ApplicationServiceRequest<StudyService, TReturn>
 {
+    @Required
+    override val apiVersion: ApiVersion = StudyService.API_VERSION
+
     object Serializer : KSerializer<StudyServiceRequest<*>> by ignoreTypeParameters( ::serializer )
 
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/RecruitmentServiceApiMigrator.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/RecruitmentServiceApiMigrator.kt
@@ -1,0 +1,11 @@
+package dk.cachet.carp.studies.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
+import dk.cachet.carp.studies.application.RecruitmentService
+import dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest
+
+
+val RecruitmentServiceApiMigrator = ApplicationServiceApiMigrator(
+    RecruitmentService.API_VERSION,
+    RecruitmentServiceRequest.Serializer
+)

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/StudyServiceApiMigrator.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/StudyServiceApiMigrator.kt
@@ -1,0 +1,11 @@
+package dk.cachet.carp.studies.infrastructure.versioning
+
+import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
+import dk.cachet.carp.studies.application.StudyService
+import dk.cachet.carp.studies.infrastructure.StudyServiceRequest
+
+
+val StudyServiceApiMigrator = ApplicationServiceApiMigrator(
+    StudyService.API_VERSION,
+    StudyServiceRequest.Serializer
+)

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
@@ -2,12 +2,14 @@ package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
 import dk.cachet.carp.common.application.services.createApplicationServiceAdapter
+import dk.cachet.carp.common.test.infrastructure.TestUUIDFactory
 import dk.cachet.carp.data.infrastructure.InMemoryDataStreamService
 import dk.cachet.carp.deployments.application.DeploymentService
 import dk.cachet.carp.deployments.application.DeploymentServiceHost
 import dk.cachet.carp.deployments.infrastructure.InMemoryDeploymentRepository
 import dk.cachet.carp.studies.infrastructure.InMemoryParticipantRepository
 import dk.cachet.carp.studies.infrastructure.InMemoryStudyRepository
+import dk.cachet.carp.test.TestClock
 
 
 /**
@@ -25,18 +27,26 @@ class RecruitmentServiceHostTest : RecruitmentServiceTest
             val studyRepo = InMemoryStudyRepository()
             val studyService = StudyServiceHost(
                 studyRepo,
-                eventBus.createApplicationServiceAdapter( StudyService::class ) )
+                eventBus.createApplicationServiceAdapter( StudyService::class ),
+                TestUUIDFactory(),
+                TestClock
+            )
 
             // Create dependent deployment service.
             val deploymentService = DeploymentServiceHost(
                 InMemoryDeploymentRepository(),
                 InMemoryDataStreamService(),
-                eventBus.createApplicationServiceAdapter( DeploymentService::class ) )
+                eventBus.createApplicationServiceAdapter( DeploymentService::class ),
+                TestClock
+            )
 
             val recruitmentService = RecruitmentServiceHost(
                 InMemoryParticipantRepository(),
                 deploymentService,
-                eventBus.createApplicationServiceAdapter( RecruitmentService::class ) )
+                eventBus.createApplicationServiceAdapter( RecruitmentService::class ),
+                TestUUIDFactory(),
+                TestClock
+            )
 
             return RecruitmentServiceTest.DependentServices( recruitmentService, studyService, eventBus )
         }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceHostTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/StudyServiceHostTest.kt
@@ -3,7 +3,9 @@ package dk.cachet.carp.studies.application
 import dk.cachet.carp.common.application.services.EventBus
 import dk.cachet.carp.common.application.services.createApplicationServiceAdapter
 import dk.cachet.carp.common.infrastructure.services.SingleThreadedEventBus
+import dk.cachet.carp.common.test.infrastructure.TestUUIDFactory
 import dk.cachet.carp.studies.infrastructure.InMemoryStudyRepository
+import dk.cachet.carp.test.TestClock
 
 
 /**
@@ -18,7 +20,9 @@ class StudyServiceHostTest : StudyServiceTest
             val eventBus = SingleThreadedEventBus()
             val studyService = StudyServiceHost(
                 InMemoryStudyRepository(),
-                eventBus.createApplicationServiceAdapter( StudyService::class )
+                eventBus.createApplicationServiceAdapter( StudyService::class ),
+                TestUUIDFactory(),
+                TestClock
             )
 
             return Pair( studyService, eventBus )

--- a/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/BackwardsCompatibilityTest.kt
+++ b/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/BackwardsCompatibilityTest.kt
@@ -1,0 +1,25 @@
+package dk.cachet.carp.studies.infrastructure.versioning
+
+import dk.cachet.carp.common.test.infrastructure.versioning.BackwardsCompatibilityTest
+import dk.cachet.carp.studies.application.RecruitmentService
+import dk.cachet.carp.studies.application.RecruitmentServiceHostTest
+import dk.cachet.carp.studies.application.StudyService
+import dk.cachet.carp.studies.application.StudyServiceHostTest
+import kotlinx.serialization.ExperimentalSerializationApi
+
+
+@ExperimentalSerializationApi
+class StudyServiceBackwardsCompatibilityTest :
+    BackwardsCompatibilityTest<StudyService>( StudyService::class )
+{
+    override fun createService() = StudyServiceHostTest.createService()
+}
+
+
+@ExperimentalSerializationApi
+class RecruitmentServiceBackwardsCompatibilityTest :
+    BackwardsCompatibilityTest<RecruitmentService>( RecruitmentService::class )
+{
+    override fun createService() = RecruitmentServiceHostTest.createService()
+        .let { Pair( it.recruitmentService, it.eventBus ) }
+}

--- a/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/OutputRecruitmentServiceTestRequests.kt
+++ b/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/OutputRecruitmentServiceTestRequests.kt
@@ -7,19 +7,20 @@ import dk.cachet.carp.studies.application.RecruitmentServiceTest
 import dk.cachet.carp.studies.infrastructure.RecruitmentServiceLoggingProxy
 
 
-private val services = RecruitmentServiceHostTest.createService()
-
-class OutputProtocolServiceTestRequests :
-    OutputTestRequests<RecruitmentService>(
-        RecruitmentService::class,
-        RecruitmentServiceLoggingProxy( services.recruitmentService, services.eventBus )
-    ),
+class OutputRecruitmentServiceTestRequests :
+    OutputTestRequests<RecruitmentService>( RecruitmentService::class ),
     RecruitmentServiceTest
 {
-    override fun createService() =
-        RecruitmentServiceTest.DependentServices(
-            loggedService,
+    override fun createService(): RecruitmentServiceTest.DependentServices
+    {
+        val services = RecruitmentServiceHostTest.createService()
+        val service = RecruitmentServiceLoggingProxy( services.recruitmentService, services.eventBus )
+        loggedService = service
+
+        return RecruitmentServiceTest.DependentServices(
+            service,
             services.studyService,
             services.eventBus
         )
+    }
 }

--- a/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/OutputStudyServiceTestRequests.kt
+++ b/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/OutputStudyServiceTestRequests.kt
@@ -7,14 +7,15 @@ import dk.cachet.carp.studies.application.StudyServiceTest
 import dk.cachet.carp.studies.infrastructure.StudyServiceLoggingProxy
 
 
-private val services = StudyServiceHostTest.createService()
-
 class OutputStudyServiceTestRequests :
-    OutputTestRequests<StudyService>(
-        StudyService::class,
-        StudyServiceLoggingProxy( services.first, services.second )
-    ),
+    OutputTestRequests<StudyService>( StudyService::class ),
     StudyServiceTest
 {
-    override fun createService(): StudyService = loggedService
+    override fun createService(): StudyService
+    {
+        val services = StudyServiceHostTest.createService()
+
+        return StudyServiceLoggingProxy( services.first, services.second )
+            .also { loggedService = it }
+    }
 }

--- a/carp.test/build.gradle
+++ b/carp.test/build.gradle
@@ -19,6 +19,7 @@ kotlin {
                 implementation kotlin('test-common')
                 implementation kotlin('test-annotations-common')
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
+                api "org.jetbrains.kotlinx:kotlinx-datetime:${versions.datetime}"
             }
         }
         jvmMain {

--- a/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/TestClock.kt
+++ b/carp.test/src/commonMain/kotlin/dk/cachet/carp/test/TestClock.kt
@@ -1,0 +1,15 @@
+package dk.cachet.carp.test
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+
+/**
+ * A fixed clock at UNIX epoch for testing with deterministic behavior.
+ */
+object TestClock : Clock
+{
+    private var currentInstant: Instant = Instant.fromEpochSeconds( 0 )
+
+    override fun now(): Instant = currentInstant
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -78,6 +78,7 @@ verify-implementation:
       - 'kotlin.sequences.Sequence'
       - 'kotlinx.serialization.KSerializer'
       - 'kotlinx.serialization.modules.SerializersModuleCollector'
+      - 'kotlinx.datetime.Clock'
   Immutable:
     active: true
     excludes: *verify-implementation-excludes

--- a/rpc/schemas/data/DataStreamService/DataStreamServiceRequest.json
+++ b/rpc/schemas/data/DataStreamService/DataStreamServiceRequest.json
@@ -8,14 +8,16 @@
     { "$ref": "#/$defs/RemoveDataStreams" }
   ],
   "$defs": {
+    "ApiVersion": { "const": "1.0" },
     "OpenDataStreams": {
       "$anchor": "OpenDataStreams",
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.OpenDataStreams" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "configuration": { "$ref": "../DataStreamsConfiguration.json" }
       },
-      "required": [ "$type", "configuration" ],
+      "required": [ "$type", "apiVersion", "configuration" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "OpenDataStreams-Response",
@@ -27,10 +29,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.AppendToDataStreams" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentId": { "type": "string", "format": "uuid" },
         "batch": { "$ref": "../DataStreamBatch.json" }
       },
-      "required": [ "$type", "studyDeploymentId", "batch" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentId", "batch" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "AppendToDataStreams-Response",
@@ -42,11 +45,12 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.GetDataStream" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "dataStream": { "$ref": "../DataStreamId.json" },
         "fromSequenceId": { "type": "integer" },
         "toSequenceIdInclusive": { "type": ["integer", "null"] }
       },
-      "required": [ "$type", "dataStream", "fromSequenceId" ],
+      "required": [ "$type", "apiVersion", "dataStream", "fromSequenceId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetDataStream-Response",
@@ -58,12 +62,13 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.CloseDataStreams" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentIds": {
           "type": "array",
           "items": { "type": "string", "format": "uuid" }
         }
       },
-      "required": [ "$type", "studyDeploymentIds" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentIds" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "CloseDataStreams-Response",
@@ -74,12 +79,13 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.RemoveDataStreams" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentIds": {
           "type": "array",
           "items": { "type": "string", "format": "uuid" }
         }
       },
-      "required": [ "$type", "studyDeploymentIds" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentIds" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "RemoveDataStreams-Response",

--- a/rpc/schemas/deployments/DeploymentService/DeploymentServiceRequest.json
+++ b/rpc/schemas/deployments/DeploymentService/DeploymentServiceRequest.json
@@ -12,11 +12,13 @@
     { "$ref": "#/$defs/Stop" }
   ],
   "$defs": {
+    "ApiVersion": { "const": "1.0" },
     "CreateStudyDeployment": {
       "$anchor": "CreateStudyDeployment",
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "id": { "type": "string", "format": "uuid" },
         "protocol": { "$ref":  "../../protocols/StudyProtocolSnapshot.json" },
         "invitations": {
@@ -28,7 +30,7 @@
           "additionalProperties": { "$ref": "../../common/devices/DeviceRegistration.json" }
         }
       },
-      "required": [ "$type", "id", "protocol", "invitations", "connectedDevicePreregistrations" ],
+      "required": [ "$type", "apiVersion", "id", "protocol", "invitations", "connectedDevicePreregistrations" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "CreateStudyDeployment-Response",
@@ -40,12 +42,13 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RemoveStudyDeployments" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentIds": {
           "type": "array",
           "items": { "type": "string", "format": "uuid" }
         }
       },
-      "required": [ "$type", "studyDeploymentIds" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentIds" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "RemoveStudyDeployments-Response",
@@ -58,9 +61,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyDeploymentId" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetStudyDeploymentStatus-Response",
@@ -72,12 +76,13 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatusList" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentIds": {
           "type": "array",
           "items": { "type": "string", "format": "uuid" }
         }
       },
-      "required": [ "$type", "studyDeploymentIds" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentIds" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetStudyDeploymentStatusList-Response",
@@ -90,11 +95,12 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentId": { "type": "string", "format": "uuid" },
         "deviceRoleName": { "type": "string" },
         "registration": { "$ref": "../../common/devices/DeviceRegistration.json" }
       },
-      "required": [ "$type", "studyDeploymentId", "deviceRoleName", "registration" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentId", "deviceRoleName", "registration" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "RegisterDevice-Response",
@@ -106,10 +112,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.UnregisterDevice" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentId": { "type": "string", "format": "uuid" },
         "deviceRoleName": { "type": "string" }
       },
-      "required": [ "$type", "studyDeploymentId", "deviceRoleName" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentId", "deviceRoleName" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "UnregisterDevice-Response",
@@ -121,10 +128,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentId": { "type": "string", "format": "uuid" },
         "masterDeviceRoleName": { "type": "string" }
       },
-      "required": [ "$type", "studyDeploymentId", "masterDeviceRoleName" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentId", "masterDeviceRoleName" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetDeviceDeploymentFor-Response",
@@ -136,11 +144,12 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.DeviceDeployed" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentId": { "type": "string", "format": "uuid" },
         "masterDeviceRoleName": { "type": "string" },
         "deviceDeploymentLastUpdatedOn": { "type": "string", "format": "date-time" }
       },
-      "required": [ "$type", "studyDeploymentId", "masterDeviceRoleName", "deviceDeploymentLastUpdatedOn" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentId", "masterDeviceRoleName", "deviceDeploymentLastUpdatedOn" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "DeviceDeployed-Response",
@@ -152,9 +161,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.Stop" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyDeploymentId" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "Stop-Response",

--- a/rpc/schemas/deployments/ParticipationService/ParticipationServiceRequest.json
+++ b/rpc/schemas/deployments/ParticipationService/ParticipationServiceRequest.json
@@ -7,14 +7,16 @@
     { "$ref": "#/$defs/SetParticipantData" }
   ],
   "$defs": {
+    "ApiVersion": { "const": "1.0" },
     "GetActiveParticipationInvitations": {
       "$anchor": "GetActiveParticipationInvitations",
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.ParticipationServiceRequest.GetActiveParticipationInvitations" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "accountId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "accountId" ],
+      "required": [ "$type", "apiVersion", "accountId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetActiveParticipationInvitations-Response",
@@ -27,9 +29,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.ParticipationServiceRequest.GetParticipantData" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyDeploymentId" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetParticipantData-Response",
@@ -41,12 +44,13 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.ParticipationServiceRequest.GetParticipantDataList" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentIds": {
           "type": "array",
           "items": { "type": "string", "format": "uuid" }
         }
       },
-      "required": [ "$type", "studyDeploymentIds" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentIds" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetParticipantDataList-Response",
@@ -59,10 +63,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.deployments.infrastructure.ParticipationServiceRequest.SetParticipantData" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyDeploymentId": { "type": "string", "format": "uuid" },
         "data": { "$ref": "../users/ParticipantDataMap.json" }
       },
-      "required": [ "$type", "studyDeploymentId", "data" ],
+      "required": [ "$type", "apiVersion", "studyDeploymentId", "data" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "SetParticipantData-Response",

--- a/rpc/schemas/protocols/ProtocolFactoryService/ProtocolFactoryServiceRequest.json
+++ b/rpc/schemas/protocols/ProtocolFactoryService/ProtocolFactoryServiceRequest.json
@@ -4,17 +4,19 @@
     { "$ref": "#/$defs/CreateCustomProtocol" }
   ],
   "$defs": {
+    "ApiVersion": { "const": "1.0" },
     "CreateCustomProtocol": {
       "$anchor": "CreateCustomProtocol",
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.protocols.infrastructure.ProtocolFactoryServiceRequest.CreateCustomProtocol" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "ownerId": { "type": "string", "format": "uuid" },
         "name": { "type": "string" },
         "customProtocol": { "type": "string" },
         "description": { "type": [ "string", "null" ] }
       },
-      "required": [ "$type", "ownerId", "name", "customProtocol", "description" ],
+      "required": [ "$type", "apiVersion", "ownerId", "name", "customProtocol", "description" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "CreateCustomProtocol-Response",

--- a/rpc/schemas/protocols/ProtocolService/ProtocolServiceRequest.json
+++ b/rpc/schemas/protocols/ProtocolService/ProtocolServiceRequest.json
@@ -9,15 +9,17 @@
     { "$ref": "#/$defs/GetVersionHistoryFor" }
   ],
   "$defs": {
+    "ApiVersion": { "const": "1.0" },
     "Add": {
       "$anchor": "Add",
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest.Add" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "protocol": { "$ref": "../StudyProtocolSnapshot.json" },
         "versionTag": { "type": "string" }
       },
-      "required": [ "$type", "protocol" ],
+      "required": [ "$type", "apiVersion", "protocol" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "Add-Response",
@@ -29,10 +31,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest.AddVersion" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "protocol": { "$ref": "../StudyProtocolSnapshot.json" },
         "versionTag": { "type": "string" }
       },
-      "required": [ "$type", "protocol" ],
+      "required": [ "$type", "apiVersion", "protocol" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "AddVersion-Response",
@@ -44,6 +47,7 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest.UpdateParticipantDataConfiguration" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "protocolId": { "type": "string", "format": "uuid" },
         "versionTag": { "type": "string" },
         "expectedParticipantData": {
@@ -51,7 +55,7 @@
           "items": { "$ref": "../../common/users/ParticipantAttribute.json" }
         }
       },
-      "required": [ "$type", "protocolId", "versionTag", "expectedParticipantData" ],
+      "required": [ "$type", "apiVersion", "protocolId", "versionTag", "expectedParticipantData" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "UpdateParticipantDataConfiguration-Response",
@@ -63,10 +67,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest.GetBy" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "protocolId": { "type": "string", "format": "uuid" },
         "versionTag": { "type": [ "string", "null" ] }
       },
-      "required": [ "$type", "protocolId" ],
+      "required": [ "$type", "apiVersion", "protocolId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetBy-Response",
@@ -78,9 +83,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest.GetAllForOwner" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "ownerId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "ownerId" ],
+      "required": [ "$type", "apiVersion", "ownerId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetAllForOwner-Response",
@@ -93,9 +99,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest.GetVersionHistoryFor" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "protocolId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "protocolId" ],
+      "required": [ "$type", "apiVersion", "protocolId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetVersionHistoryFor-Response",

--- a/rpc/schemas/studies/RecruitmentService/RecruitmentServiceRequest.json
+++ b/rpc/schemas/studies/RecruitmentService/RecruitmentServiceRequest.json
@@ -9,15 +9,17 @@
     { "$ref": "#/$defs/StopParticipantGroup" }
   ],
   "$defs": {
+    "ApiVersion": { "const": "1.0" },
     "AddParticipant": {
       "$anchor": "AddParticipant",
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipant" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" },
         "email": { "type": "string", "format": "email" }
       },
-      "required": [ "$type", "studyId", "email" ],
+      "required": [ "$type", "apiVersion", "studyId", "email" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "AddParticipant-Response",
@@ -29,10 +31,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipant" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" },
         "participantId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyId", "participantId" ],
+      "required": [ "$type", "apiVersion", "studyId", "participantId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetParticipant-Response",
@@ -44,9 +47,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipants" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyId" ],
+      "required": [ "$type", "apiVersion", "studyId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetParticipants-Response",
@@ -59,13 +63,14 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" },
         "group": {
           "type": "array",
           "items": { "$ref": "../users/AssignParticipantDevices.json" }
         }
       },
-      "required": [ "$type", "studyId", "group" ],
+      "required": [ "$type", "apiVersion", "studyId", "group" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "InviteNewParticipantGroup-Response",
@@ -77,9 +82,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyId" ],
+      "required": [ "$type", "apiVersion", "studyId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetParticipantGroupStatusList-Response",
@@ -92,10 +98,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" },
         "groupId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyId", "groupId" ],
+      "required": [ "$type", "apiVersion", "studyId", "groupId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "StopParticipantGroup-Response",

--- a/rpc/schemas/studies/StudyService/StudyServiceRequest.json
+++ b/rpc/schemas/studies/StudyService/StudyServiceRequest.json
@@ -12,11 +12,13 @@
     { "$ref": "#/$defs/Remove" }
   ],
   "$defs": {
+    "ApiVersion": { "const": "1.0" },
     "CreateStudy": {
       "$anchor": "CreateStudy",
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.CreateStudy" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "ownerId": { "type": "string", "format": "uuid" },
         "name": { "type": "string" },
         "description": { "type": [ "string", "null" ] },
@@ -27,7 +29,7 @@
           ]
         }
       },
-      "required": [ "$type", "ownerId", "name" ],
+      "required": [ "$type", "apiVersion", "ownerId", "name" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "CreateStudy-Response",
@@ -39,11 +41,12 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.SetInternalDescription" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" },
         "name": { "type": "string" },
         "description": { "type": "string" }
       },
-      "required": [ "$type", "studyId", "name", "description" ],
+      "required": [ "$type", "apiVersion", "studyId", "name", "description" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "SetInternalDescription-Response",
@@ -55,9 +58,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.GetStudyDetails" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyId" ],
+      "required": [ "$type", "apiVersion", "studyId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetStudyDetails-Response",
@@ -69,9 +73,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.GetStudyStatus" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyId" ],
+      "required": [ "$type", "apiVersion", "studyId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetStudyStatus-Response",
@@ -83,9 +88,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.GetStudiesOverview" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "ownerId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "ownerId" ],
+      "required": [ "$type", "apiVersion", "ownerId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GetStudiesOverview-Response",
@@ -98,10 +104,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.SetInvitation" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" },
         "invitation": { "$ref": "../../deployments/users/StudyInvitation.json" }
       },
-      "required": [ "$type", "studyId", "invitation" ],
+      "required": [ "$type", "apiVersion", "studyId", "invitation" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "SetInvitation-Response",
@@ -113,10 +120,11 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.SetProtocol" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" },
         "protocol": { "$ref": "../../protocols/StudyProtocolSnapshot.json" }
       },
-      "required": [ "$type", "studyId", "protocol" ],
+      "required": [ "$type", "apiVersion", "studyId", "protocol" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "SetProtocol-Response",
@@ -128,9 +136,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.GoLive" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyId" ],
+      "required": [ "$type", "apiVersion", "studyId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "GoLive-Response",
@@ -142,9 +151,10 @@
       "type": "object",
   	  "properties": {
         "$type": { "const": "dk.cachet.carp.studies.infrastructure.StudyServiceRequest.Remove" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
         "studyId": { "type": "string", "format": "uuid" }
       },
-      "required": [ "$type", "studyId" ],
+      "required": [ "$type", "apiVersion", "studyId" ],
       "additionalProperties": false,
       "Response": {
         "$anchor": "Remove-Response",

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -249,7 +249,7 @@ private val phoneDataStreamBatch = MutableDataStreamBatch().apply {
 fun <TService : ApplicationService<TService, *>, TResponse> example(
     request: ApplicationServiceRequest<TService, TResponse>,
     response: Any? = Unit
-) = LoggedRequest.Succeeded( request, emptyList(), response )
+) = LoggedRequest.Succeeded( request, emptyList(), emptyList(), response )
 
 private val exampleRequests: Map<KFunction<*>, LoggedRequest.Succeeded<*, *>> = mapOf(
     // ProtocolService

--- a/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.common/index.d.ts
@@ -296,4 +296,26 @@ declare module 'carp.core-kotlin-carp.common'
     {
         function createDefaultJSON_18xi4u$(): Json
     }
+
+
+    namespace dk.cachet.carp.common.application.services
+    {
+        class ApiVersion
+        {
+            constructor( major: Number, minor: Number )
+
+            readonly major: Number
+            readonly minor: Number
+        }
+    }
+
+    namespace dk.cachet.carp.common.infrastructure.services
+    {
+        import ApiVersion = dk.cachet.carp.common.application.services.ApiVersion
+
+        interface ApplicationServiceRequest
+        {
+            readonly apiVersion: ApiVersion
+        }
+    }
 }

--- a/typescript-declarations/@types/carp.core-kotlin-carp.deployments.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.deployments.core/index.d.ts
@@ -13,6 +13,8 @@ declare module 'carp.core-kotlin-carp.deployments.core'
     import UUID = cdk.cachet.carp.common.application.UUID
     import DeviceRegistration = cdk.cachet.carp.common.application.devices.DeviceRegistration
     import AccountIdentity = cdk.cachet.carp.common.application.users.AccountIdentity
+    import ApplicationServiceRequest = cdk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
+    import ApiVersion = cdk.cachet.carp.common.application.services.ApiVersion
 
     import { dk as pdk } from 'carp.core-kotlin-carp.protocols.core'
     import StudyProtocolSnapshot = pdk.cachet.carp.protocols.application.StudyProtocolSnapshot
@@ -227,8 +229,10 @@ declare module 'carp.core-kotlin-carp.deployments.core'
         import ParticipantInvitation = dk.cachet.carp.deployments.application.users.ParticipantInvitation
 
 
-        abstract class DeploymentServiceRequest
+        abstract class DeploymentServiceRequest implements ApplicationServiceRequest
         {
+            readonly apiVersion: ApiVersion
+
             static get Serializer(): any
         }
 
@@ -269,8 +273,10 @@ declare module 'carp.core-kotlin-carp.deployments.core'
         }
 
 
-        abstract class ParticipationServiceRequest
+        abstract class ParticipationServiceRequest implements ApplicationServiceRequest
         {
+            readonly apiVersion: ApiVersion
+
             static get Serializer(): any
         }
 

--- a/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.protocols.core/index.d.ts
@@ -14,6 +14,8 @@ declare module 'carp.core-kotlin-carp.protocols.core'
     import TaskDescriptor = cdk.cachet.carp.common.application.tasks.TaskDescriptor
     import TaskControl = cdk.cachet.carp.common.application.triggers.TaskControl
     import Trigger = cdk.cachet.carp.common.application.triggers.Trigger
+    import ApplicationServiceRequest = cdk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
+    import ApiVersion = cdk.cachet.carp.common.application.services.ApiVersion
 
 
     namespace dk.cachet.carp.protocols.application
@@ -57,8 +59,10 @@ declare module 'carp.core-kotlin-carp.protocols.core'
         import StudyProtocolSnapshot = dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 
         
-        abstract class ProtocolServiceRequest
+        abstract class ProtocolServiceRequest implements ApplicationServiceRequest
         {
+            readonly apiVersion: ApiVersion
+
             static get Serializer(): any
         }
 
@@ -91,8 +95,10 @@ declare module 'carp.core-kotlin-carp.protocols.core'
         }
 
 
-        abstract class ProtocolFactoryServiceRequest
+        abstract class ProtocolFactoryServiceRequest implements ApplicationServiceRequest
         {
+            readonly apiVersion: ApiVersion
+
             static get Serializer(): any
         }
 

--- a/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
+++ b/typescript-declarations/@types/carp.core-kotlin-carp.studies.core/index.d.ts
@@ -11,6 +11,8 @@ declare module 'carp.core-kotlin-carp.studies.core'
     import EmailAddress = cdk.cachet.carp.common.application.EmailAddress
     import UUID = cdk.cachet.carp.common.application.UUID
     import AccountIdentity = cdk.cachet.carp.common.application.users.AccountIdentity
+    import ApplicationServiceRequest = cdk.cachet.carp.common.infrastructure.services.ApplicationServiceRequest
+    import ApiVersion = cdk.cachet.carp.common.application.services.ApiVersion
 
     import { dk as ddk } from 'carp.core-kotlin-carp.deployments.core'
     import StudyDeploymentStatus = ddk.cachet.carp.deployments.application.StudyDeploymentStatus
@@ -170,8 +172,10 @@ declare module 'carp.core-kotlin-carp.studies.core'
         import AssignParticipantDevices = dk.cachet.carp.studies.application.users.AssignParticipantDevices
 
 
-        abstract class StudyServiceRequest
+        abstract class StudyServiceRequest implements ApplicationServiceRequest
         {
+            readonly apiVersion: ApiVersion
+
             static get Serializer(): any
         }
 
@@ -216,8 +220,10 @@ declare module 'carp.core-kotlin-carp.studies.core'
         }
 
 
-        abstract class RecruitmentServiceRequest
+        abstract class RecruitmentServiceRequest implements ApplicationServiceRequest
         {
+            readonly apiVersion: ApiVersion
+
             static get Serializer(): any
         }
 

--- a/typescript-declarations/tests/carp.common.ts
+++ b/typescript-declarations/tests/carp.common.ts
@@ -30,6 +30,10 @@ import ParticipantAttribute = dk.cachet.carp.common.application.users.Participan
 import Username = dk.cachet.carp.common.application.users.Username;
 import UsernameAccountIdentity = dk.cachet.carp.common.application.users.UsernameAccountIdentity;
 import emailAccountIdentityFromString = dk.cachet.carp.common.application.users.EmailAccountIdentity_init_61zpoe$;
+import ApiVersion = dk.cachet.carp.common.application.services.ApiVersion
+
+import { dk as ddk } from 'carp.core-kotlin-carp.deployments.core'
+import DeploymentServiceRequest = ddk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest
 
 
 describe( "carp.common", () => {
@@ -74,7 +78,9 @@ describe( "carp.common", () => {
             new UsernameAccountIdentity( username ),
             UsernameAccountIdentity.Companion,
             [ "ParticipantAttribute", new ParticipantAttribute.DefaultParticipantAttribute( new NamespacedId( "namespace", "type" ) ) ],
-            ParticipantAttribute.Companion
+            ParticipantAttribute.Companion,
+            new ApiVersion( 1, 0 ),
+            [ "ApplicationServiceRequest", new DeploymentServiceRequest.GetStudyDeploymentStatus( UUID.Companion.randomUUID() ) ]
         ]
 
         const moduleVerifier = new VerifyModule( 'carp.core-kotlin-carp.common', instances )

--- a/typescript-declarations/tests/carp.protocols.core.ts
+++ b/typescript-declarations/tests/carp.protocols.core.ts
@@ -28,7 +28,9 @@ describe( "carp.protocols.core", () => {
             new ProtocolVersion( "Version" ),
             ProtocolVersion.Companion,
             studyProtocolSnapshot,
-            StudyProtocolSnapshot.Companion
+            StudyProtocolSnapshot.Companion,
+            [ "ProtocolServiceRequest", new ProtocolServiceRequest.GetAllForOwner( UUID.Companion.randomUUID() ) ],
+            [ "ProtocolFactoryServiceRequest", new ProtocolFactoryServiceRequest.CreateCustomProtocol( UUID.Companion.randomUUID(), "", "" ) ]
         ]
 
         const moduleVerifier = new VerifyModule( 'carp.core-kotlin-carp.protocols.core', instances )

--- a/typescript-declarations/tests/carp.studies.core.ts
+++ b/typescript-declarations/tests/carp.studies.core.ts
@@ -62,7 +62,9 @@ describe( "carp.studies.core", () => {
             new ParticipantGroupStatus.Invited( deploymentId, new HashSet<Participant>(), now, invitedDeploymentStatus ),
             new ParticipantGroupStatus.Running( deploymentId, new HashSet<Participant>(), now, invitedDeploymentStatus, now ),
             new ParticipantGroupStatus.Stopped( deploymentId, new HashSet<Participant>(), now, invitedDeploymentStatus, null, now ),
-            ParticipantGroupStatus.Companion
+            ParticipantGroupStatus.Companion,
+            [ "StudyServiceRequest", new StudyServiceRequest.Remove( UUID.Companion.randomUUID() ) ],
+            [ "RecruitmentServiceRequest", new RecruitmentServiceRequest.GetParticipants( UUID.Companion.randomUUID() ) ]
         ]
 
         const moduleVerifier = new VerifyModule( 'carp.core-kotlin-carp.studies.core', instances )


### PR DESCRIPTION
Adds infrastructure support to transform old application service request objects to newer versions, and transform the returned responses to those expected by the caller.

The current state of this PR can generate test resources which when copied to the correct location can all be successfully replayed when `@Ignore` is removed for the tests in the base `BackwardsCompatibilityTest` class. I only intend to commit test resources once the 1.0 API stabilizes; otherwise they will cause tests to fail during intermediate updates, and we'd have to constantly update them as the API is still in flux.

Similarly, we will need transformation helpers to migrate integration events, but I consider this out of scope in this PR for now. This may need further discussion before proceeding.

