### PR TITLE
Let `removeDataStreams` return IDs of affected study deployments.

### DIFF
--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
@@ -69,7 +69,8 @@ interface DataStreamService : ApplicationService<DataStreamService, DataStreamSe
     /**
      * Close data streams and remove all data for each of the [studyDeploymentIds].
      *
-     * @return True when any data streams have been removed, or false when there were no data streams to remove.
+     * @return The IDs of the study deployments for which data streams were configured.
+     * IDs for which no study deployment exists are ignored.
      */
-    suspend fun removeDataStreams( studyDeploymentIds: Set<UUID> ): Boolean
+    suspend fun removeDataStreams( studyDeploymentIds: Set<UUID> ): Set<UUID>
 }

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceLoggingProxy.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceLoggingProxy.kt
@@ -46,6 +46,6 @@ class DataStreamServiceLoggingProxy(
     override suspend fun closeDataStreams( studyDeploymentIds: Set<UUID> ) =
         log( DataStreamServiceRequest.CloseDataStreams( studyDeploymentIds ) )
 
-    override suspend fun removeDataStreams( studyDeploymentIds: Set<UUID> ): Boolean =
+    override suspend fun removeDataStreams( studyDeploymentIds: Set<UUID> ) =
         log( DataStreamServiceRequest.RemoveDataStreams( studyDeploymentIds ) )
 }

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceRequest.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceRequest.kt
@@ -68,9 +68,9 @@ sealed class DataStreamServiceRequest<out TReturn> : ApplicationServiceRequest<D
 
     @Serializable
     data class RemoveDataStreams( val studyDeploymentIds: Set<UUID> ) :
-        DataStreamServiceRequest<Boolean>()
+        DataStreamServiceRequest<Set<UUID>>()
     {
-        override fun getResponseSerializer() = serializer<Boolean>()
+        override fun getResponseSerializer() = serializer<Set<UUID>>()
         override suspend fun invokeOn( service: DataStreamService ) = service.removeDataStreams( studyDeploymentIds )
     }
 }

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/InMemoryDataStreamService.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/InMemoryDataStreamService.kt
@@ -120,14 +120,16 @@ class InMemoryDataStreamService : DataStreamService
     /**
      * Close data streams and remove all data for each of the [studyDeploymentIds].
      *
-     * @return True when any data streams have been removed, or false when there were no data streams to remove.
+     * @return The IDs of the study deployments for which data streams were configured.
+     * IDs for which no study deployment exists are ignored.
      */
-    override suspend fun removeDataStreams( studyDeploymentIds: Set<UUID> ): Boolean
+    override suspend fun removeDataStreams( studyDeploymentIds: Set<UUID> ): Set<UUID>
     {
         stoppedStudyDeploymentIds.removeAll( studyDeploymentIds )
 
-        return studyDeploymentIds.fold( false ) {
-            removedAny, toRemove -> configuredDataStreams.removeKey( toRemove ) || removedAny
-        }
+        return studyDeploymentIds.mapNotNull { toRemove ->
+            if ( configuredDataStreams.removeKey( toRemove ) ) toRemove
+            else null
+        }.toSet()
     }
 }

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/DataStreamServiceTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/DataStreamServiceTest.kt
@@ -137,18 +137,21 @@ interface DataStreamServiceTest
         }
         service.appendToDataStreams( stubDeploymentId, batch )
 
-        service.removeDataStreams( setOf( stubDeploymentId ) )
+        val removed = service.removeDataStreams( setOf( stubDeploymentId ) )
+        assertEquals( setOf( stubDeploymentId ), removed )
 
         val dataStreamId = dataStreamId<StubData>( stubDeploymentId, stubSequenceDeviceRoleName )
         assertFailsWith<IllegalArgumentException> { service.getDataStream( dataStreamId, 0 ) }
     }
 
     @Test
-    fun removeDataStreams_returns_false_when_nothing_removed() = runTest {
-        val service = createService()
+    fun removeDataStream_ignores_unknown_ids() = runTest {
+        val service = createServiceWithOpenStubDataStream()
 
-        val unknownDeploymentId = UUID.randomUUID()
-        assertFalse( service.removeDataStreams( setOf( unknownDeploymentId ) ) )
+        val unknownDeploymentid = UUID.randomUUID()
+        val removed = service.removeDataStreams( setOf( stubDeploymentId, unknownDeploymentid ) )
+
+        assertEquals( setOf( stubDeploymentId ), removed )
     }
 
 

--- a/rpc/schemas/data/DataStreamService/DataStreamServiceRequest.json
+++ b/rpc/schemas/data/DataStreamService/DataStreamServiceRequest.json
@@ -89,7 +89,8 @@
       "additionalProperties": false,
       "Response": {
         "$anchor": "RemoveDataStreams-Response",
-        "type": "boolean"
+        "type": "array",
+        "items": { "type": "string", "format": "uuid" }
       }
     }
   }

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -457,6 +457,6 @@ private val exampleRequests: Map<KFunction<*>, LoggedRequest.Succeeded<*, *>> = 
     ),
     DataStreamService::removeDataStreams to example(
         request = DataStreamServiceRequest.RemoveDataStreams( deploymentIds ),
-        response = true
+        response = deploymentIds
     )
 )


### PR DESCRIPTION
Closes #352 

For consistency with `DeploymentService.removeStudyDeployments`, and simply because it provides additional functionality.