### PR TITLE
Upgrade to Kotlin 1.9.21 and matching serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
 
         versions = [
             // Kotlin multiplatform versions.
-            kotlin:'1.9.10',
-            serialization:'1.6.0',
+            kotlin:'1.9.21',
+            serialization:'1.6.1',
             coroutines:'1.7.3',
             datetime:'0.4.1',
 
@@ -107,6 +107,7 @@ configure( subprojects - devOpsModules ) {
                     {
                         it.optIn.add('kotlinx.coroutines.ExperimentalCoroutinesApi')
                     }
+                    it.freeCompilerArgs.add('-Xexpect-actual-classes') // https://youtrack.jetbrains.com/issue/KT-61573
                 } )
             }
         }

--- a/publish-npm-packages/src/commonMain/kotlin/KotlinExport.kt
+++ b/publish-npm-packages/src/commonMain/kotlin/KotlinExport.kt
@@ -47,7 +47,7 @@ class KotlinExport
         val second = pair.second
     }
 
-    val mapOf = mapOf( 42 to "answer" )
+    val mapOf = mapOf( 42 to "answer", 13 to "unlucky" )
 
     fun duration( duration: Duration )
     {

--- a/publish-npm-packages/src/forced-exports/kotlin-kotlin-stdlib
+++ b/publish-npm-packages/src/forced-exports/kotlin-kotlin-stdlib
@@ -7,9 +7,9 @@ EmptySet
 HashMap
 Pair
 to
-listOf
-setOf
-mapOf
-Companion_getInstance_7
+listOf_0
+setOf_0
+mapOf_0
+Companion_getInstance_13
 _Duration___get_inWholeMilliseconds__impl__msfiry
 _Duration___get_inWholeMicroseconds__impl__8oe8vv

--- a/typescript-declarations/carp-kotlin/index.ts
+++ b/typescript-declarations/carp-kotlin/index.ts
@@ -1,4 +1,4 @@
-import * as kotlinStdLib from "@cachet/kotlin-kotlin-stdlib-js-ir"
+import * as kotlinStdLib from "@cachet/kotlin-kotlin-stdlib"
 
 
 // Facade with better method names and type conversions for internal types.
@@ -14,8 +14,8 @@ export namespace kotlin
     {
         constructor( first: K, second: V ) {
             let kotlinPair = new kotlinStdLib.$_$.Pair( first, second );
-            kotlinPair.first = kotlinPair.b3_1;
-            kotlinPair.second = kotlinPair.c3_1;
+            kotlinPair.first = kotlinPair.md_1;
+            kotlinPair.second = kotlinPair.nd_1;
             return kotlinPair;
         }
         get first(): K { return this.first; }
@@ -38,12 +38,12 @@ export namespace kotlin.collections
         keys: Set<K>
         values: Collection<V>
     }
-    export const listOf: <T>(array: T[]) => List<T> = kotlinStdLib.$_$.listOf
-    export const setOf: <T>(array: T[]) => Set<T> = kotlinStdLib.$_$.setOf
+    export const listOf: <T>(array: T[]) => List<T> = kotlinStdLib.$_$.listOf_0
+    export const setOf: <T>(array: T[]) => Set<T> = kotlinStdLib.$_$.setOf_0
     export const mapOf =
         function<K, V>( pairs: kotlin.Pair<K, V>[] ): Map<K, V>
         {
-            return kotlinStdLib.$_$.mapOf( pairs as any )
+            return kotlinStdLib.$_$.mapOf_0( pairs as any )
         }
 }
 export namespace kotlin.time
@@ -55,16 +55,16 @@ export namespace kotlin.time
     }
     export namespace Duration
     {
-        export const Companion: any = kotlinStdLib.$_$.Companion_getInstance_7()
-        export const parseIsoString: (isoDuration: string) => Duration = Companion.n6
-        export const ZERO: Duration = Companion.k6_1
-        export const INFINITE: Duration = Companion.l6_1
+        export const Companion: any = kotlinStdLib.$_$.Companion_getInstance_13()
+        export const parseIsoString: (isoDuration: string) => Duration = Companion.zf
+        export const ZERO: Duration = Companion.wf_1
+        export const INFINITE: Duration = Companion.xf_1
     }
 }
 
 
 // Augment internal types to implement facade.
-declare module "@cachet/kotlin-kotlin-stdlib-js-ir"
+declare module "@cachet/kotlin-kotlin-stdlib"
 {
     namespace $_$
     {
@@ -97,7 +97,7 @@ declare module "@cachet/kotlin-kotlin-stdlib-js-ir"
 
 
 // Implement base interfaces in internal types.
-kotlinStdLib.$_$.Long.prototype.toNumber = function(): number { return this.c1(); };
+kotlinStdLib.$_$.Long.prototype.toNumber = function(): number { return this.da(); };
 Object.defineProperty( kotlinStdLib.$_$.Long.prototype, "inWholeMilliseconds", {
     get: function inWholeMilliseconds()
     {
@@ -113,21 +113,21 @@ Object.defineProperty( kotlinStdLib.$_$.Long.prototype, "inWholeMicroseconds", {
 kotlinStdLib.$_$.EmptyList.prototype.contains = function<T>( value: T ): boolean { return false; }
 kotlinStdLib.$_$.EmptyList.prototype.size = function<T>(): number { return 0; }
 kotlinStdLib.$_$.EmptyList.prototype.toArray = function<T>(): T[] { return []; }
-kotlinStdLib.$_$.AbstractMutableList.prototype.contains = function<T>( value: T ): boolean { return this.e1( value ); }
-kotlinStdLib.$_$.AbstractMutableList.prototype.size = function<T>(): number { return this.i(); }
+kotlinStdLib.$_$.AbstractMutableList.prototype.contains = function<T>( value: T ): boolean { return this.p( value ); }
+kotlinStdLib.$_$.AbstractMutableList.prototype.size = function<T>(): number { return this.n(); }
 kotlinStdLib.$_$.EmptySet.prototype.contains = function<T>( value: T ): boolean { return false; }
 kotlinStdLib.$_$.EmptySet.prototype.size = function<T>(): number { return 0; }
 kotlinStdLib.$_$.EmptySet.prototype.toArray = function<T>(): T[] { return []; }
-kotlinStdLib.$_$.HashSet.prototype.contains = function<T>( value: T ): boolean { return this.e1( value ); }
-kotlinStdLib.$_$.HashSet.prototype.size = function<T>(): number { return this.i(); }
-kotlinStdLib.$_$.HashMap.prototype.get = function<K, V>( key: K ): V { return this.f2( key ); }
+kotlinStdLib.$_$.HashSet.prototype.contains = function<T>( value: T ): boolean { return this.p( value ); }
+kotlinStdLib.$_$.HashSet.prototype.size = function<T>(): number { return this.n(); }
+kotlinStdLib.$_$.HashMap.prototype.get = function<K, V>( key: K ): V { return this.x2( key ); }
 Object.defineProperty( kotlinStdLib.$_$.HashMap.prototype, "keys", {
-    get: function keys() { return this.g2(); }
+    get: function keys() { return this.l2(); }
 } );
 Object.defineProperty( kotlinStdLib.$_$.HashMap.prototype, "values", {
-    get: function values() { return this.h2(); }
+    get: function values() { return this.m2(); }
 } );
 
 
 // Re-export augmented types.
-export * from "@cachet/kotlin-kotlin-stdlib-js-ir";
+export * from "@cachet/kotlin-kotlin-stdlib";

--- a/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
+++ b/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
@@ -1,11 +1,11 @@
-declare module "@cachet/kotlin-kotlin-stdlib-js-ir"
+declare module "@cachet/kotlin-kotlin-stdlib"
 {
     namespace $_$
     {
         interface Long
         {
             // toNumber
-            c1(): number
+            da(): number
         }
         function toLong_0( number: number ): Long
 
@@ -14,19 +14,19 @@ declare module "@cachet/kotlin-kotlin-stdlib-js-ir"
             constructor( first: K, second: V )
 
             // first
-            b3_1: K
+            md_1: K
 
             // second
-            c3_1: V
+            nd_1: V
         }
 
         interface Collection<T>
         {
             // contains
-            e1( value: T ): boolean
+            p( value: T ): boolean
 
             // size
-            i(): number
+            n(): number
 
             toArray(): Array<T>
         }
@@ -34,40 +34,40 @@ declare module "@cachet/kotlin-kotlin-stdlib-js-ir"
         interface List<T> extends Collection<T> {}
         interface EmptyList<T> extends List<T> {}
         interface AbstractMutableList<T> extends List<T> {}
-        function listOf<T>( elements: T[] ): List<T>
+        function listOf_0<T>( elements: T[] ): List<T>
 
         interface Set<T> extends Collection<T> {}
         interface EmptySet<T> extends Set<T> {}
         interface HashSet<T> extends Set<T> {}
-        function setOf<T>( elements: T[] ): Set<T>
+        function setOf_0<T>( elements: T[] ): Set<T>
 
         interface Map<K, V>
         {
             // get
-            f2( key: K ): V
+            x2( key: K ): V
 
             // keys
-            g2(): Set<K>
+            l2(): Set<K>
 
             // values
-            h2(): Collection<V>
+            m2(): Collection<V>
         }
         interface HashMap<K, V> extends Map<K, V> {}
-        function mapOf<K, V>( pairs: Pair<K, V>[] ): Map<K, V>
+        function mapOf_0<K, V>( pairs: Pair<K, V>[] ): Map<K, V>
 
         interface Duration extends Long {}
         interface DurationCompanion
         {
             // parseIsoString
-            n6(): Duration
+            zf(): Duration
 
             // ZERO
-            k6_1: Duration
+            wf_1: Duration
 
             // INFINITE
-            l6_1: Duration
+            xf_1: Duration
         }
-        function Companion_getInstance_7(): DurationCompanion
+        function Companion_getInstance_13(): DurationCompanion
         function _Duration___get_inWholeMilliseconds__impl__msfiry(duration: Duration): Long
         function _Duration___get_inWholeMicroseconds__impl__8oe8vv(duration: Duration): Long
     }

--- a/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime-js-ir.d.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime-js-ir.d.ts
@@ -5,14 +5,14 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime-js-ir"
         interface System
         {
             // now
-            w1c(): Instant_0
+            l1e(): Instant_0
         }
         function System_getInstance(): System
 
         interface Instant_0
         {
             // toEpochMilliseconds
-            j1d(): number
+            y1e(): number
         }
     }
 }

--- a/typescript-declarations/carp-kotlinx-datetime/index.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/index.ts
@@ -33,8 +33,8 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime-js-ir"
 
 
 // Implement base interfaces in internal types.
-extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.w1c(); };
-extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.j1d(); };
+extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.l1e(); };
+extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.y1e(); };
 
 
 // Re-export augmented types.

--- a/typescript-declarations/carp-kotlinx-serialization/index.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/index.ts
@@ -5,7 +5,7 @@ import * as extendJson from "@cachet/kotlinx-serialization-kotlinx-serialization
 // Facade with better method names and type conversions for internal types.
 export namespace kotlinx.serialization
 {
-    export function getSerializer( type: any ) { return type.Companion.o14() }
+    export function getSerializer( type: any ) { return type.Companion.c16() }
 }
 export namespace kotlinx.serialization.json
 {
@@ -42,12 +42,12 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
 extendJson.$_$.JsonImpl.prototype.encodeToString =
     function( serializer: any, value: any ): string
     {
-        return this.h12( serializer, value );
+        return this.t13( serializer, value );
     };
 extendJson.$_$.JsonImpl.prototype.decodeFromString =
     function( serializer: any, string: string ): any
     {
-        return this.i12( serializer, string );
+        return this.u13( serializer, string );
     };
 
 

--- a/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
@@ -5,10 +5,10 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
         interface JsonImpl
         {
             // encodeToString
-            h12( serializer: any, instance: any ): string
+            t13( serializer: any, instance: any ): string
 
             // decodeFromString
-            i12( serializer: any, string: string ): string
+            u13( serializer: any, string: string ): string
         }
         function Default_getInstance(): JsonImpl
     }

--- a/typescript-declarations/tests/carp-kotlin-test.ts
+++ b/typescript-declarations/tests/carp-kotlin-test.ts
@@ -32,8 +32,8 @@ describe( "kotlin", () => {
         ]
 
         const moduleVerifier = new VerifyModule(
-            '@cachet/kotlin-kotlin-stdlib-js-ir',
-            './carp-kotlin/kotlin-kotlin-stdlib-js-ir.d.ts',
+            '@cachet/kotlin-kotlin-stdlib',
+            './carp-kotlin/kotlin-kotlin-stdlib.d.ts',
             instances
         )
         await moduleVerifier.verify()


### PR DESCRIPTION
The [bug in TypeScript generation for Kotlin 1.9.20](https://github.com/cph-cachet/carp.core-kotlin/pull/447#issuecomment-1793777046) has been fixed.

This PR updates to Kotlin 1.9.21. The kotlin stdlib now also drops the `-js-ir` suffix. And, as usual, the JS facades had to be updated.