### PR TITLE
Add custom participant attribute API backwards compatibilty test

### DIFF
--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/ProtocolServiceTest.kt
@@ -1,7 +1,10 @@
 package dk.cachet.carp.protocols.application
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.application.data.input.InputDataType
+import dk.cachet.carp.common.application.data.input.elements.SelectOne
+import dk.cachet.carp.common.application.data.input.elements.Text
 import dk.cachet.carp.common.application.triggers.TaskControl
 import dk.cachet.carp.common.application.users.ExpectedParticipantData
 import dk.cachet.carp.common.application.users.ParticipantAttribute
@@ -31,6 +34,28 @@ interface ProtocolServiceTest
 
         service.add( snapshot, "Initial" )
         val retrieved = service.getBy( protocol.id, "Initial" )
+        assertEquals( snapshot, retrieved )
+    }
+
+    @Test
+    fun add_protocol_with_expected_participant_data_succeeds() = runTest {
+        val service = createService()
+        val protocol = createEmptyProtocol()
+
+        val sex = ParticipantAttribute.DefaultParticipantAttribute( CarpInputDataTypes.SEX )
+        protocol.addExpectedParticipantData( ExpectedParticipantData( sex ) )
+
+        val ssn = Text("Social Security Number" )
+        val customText = ParticipantAttribute.CustomParticipantAttribute( ssn )
+        protocol.addExpectedParticipantData( ExpectedParticipantData( customText ) )
+
+        val os = SelectOne( "Favorite OS", setOf( "Windows", "Linux", "Mac" ) )
+        val customSelectOne = ParticipantAttribute.CustomParticipantAttribute( os )
+        protocol.addExpectedParticipantData( ExpectedParticipantData( customSelectOne ) )
+
+        val snapshot = protocol.getSnapshot()
+        service.add( snapshot )
+        val retrieved = service.getBy( protocol.id )
         assertEquals( snapshot, retrieved )
     }
 

--- a/carp.protocols.core/src/commonTest/resources/test-requests/ProtocolService/1.1/ProtocolServiceTest/add_protocol_with_expected_participant_data_succeeds.json
+++ b/carp.protocols.core/src/commonTest/resources/test-requests/ProtocolService/1.1/ProtocolServiceTest/add_protocol_with_expected_participant_data_succeeds.json
@@ -1,0 +1,109 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest.Add",
+            "apiVersion": "1.1",
+            "protocol": {
+                "id": "0d57f923-955e-4693-a606-cca9651aab4a",
+                "createdOn": "2023-12-10T18:51:39.511538600Z",
+                "version": 0,
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "expectedParticipantData": [
+                    {
+                        "attribute": {
+                            "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                            "inputDataType": "dk.cachet.carp.input.sex"
+                        }
+                    },
+                    {
+                        "attribute": {
+                            "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.CustomParticipantAttribute",
+                            "input": {
+                                "__type": "dk.cachet.carp.common.application.data.input.elements.Text",
+                                "prompt": "Social Security Number"
+                            },
+                            "inputDataType": "dk.cachet.carp.input.custom.a1eda4bcd0d84ca0ba446cabfa4e84c8"
+                        }
+                    },
+                    {
+                        "attribute": {
+                            "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.CustomParticipantAttribute",
+                            "input": {
+                                "__type": "dk.cachet.carp.common.application.data.input.elements.SelectOne",
+                                "prompt": "Favorite OS",
+                                "options": [
+                                    "Windows",
+                                    "Linux",
+                                    "Mac"
+                                ]
+                            },
+                            "inputDataType": "dk.cachet.carp.input.custom.4ee5a0cc0ce5462b94baee4e59415f9b"
+                        }
+                    }
+                ]
+            }
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.protocols.infrastructure.ProtocolServiceRequest.GetBy",
+            "apiVersion": "1.1",
+            "protocolId": "0d57f923-955e-4693-a606-cca9651aab4a"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "id": "0d57f923-955e-4693-a606-cca9651aab4a",
+            "createdOn": "2023-12-10T18:51:39.511538600Z",
+            "version": 0,
+            "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+            "name": "Test protocol",
+            "description": "Test description",
+            "expectedParticipantData": [
+                {
+                    "attribute": {
+                        "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                        "inputDataType": "dk.cachet.carp.input.sex"
+                    }
+                },
+                {
+                    "attribute": {
+                        "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.CustomParticipantAttribute",
+                        "input": {
+                            "__type": "dk.cachet.carp.common.application.data.input.elements.Text",
+                            "prompt": "Social Security Number"
+                        },
+                        "inputDataType": "dk.cachet.carp.input.custom.a1eda4bcd0d84ca0ba446cabfa4e84c8"
+                    }
+                },
+                {
+                    "attribute": {
+                        "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.CustomParticipantAttribute",
+                        "input": {
+                            "__type": "dk.cachet.carp.common.application.data.input.elements.SelectOne",
+                            "prompt": "Favorite OS",
+                            "options": [
+                                "Windows",
+                                "Linux",
+                                "Mac"
+                            ]
+                        },
+                        "inputDataType": "dk.cachet.carp.input.custom.4ee5a0cc0ce5462b94baee4e59415f9b"
+                    }
+                }
+            ]
+        }
+    }
+]


### PR DESCRIPTION
Currently, there was no coverage for adding custom participant attributes to protocols in the backwards compatibility tests. The test resource also serves as an example on how such a JSON request looks like, which was a request in #451 .

Example of a protocol with both a default attribute (the server is expected to have the type information available at compile time), and a custom attributes (the type information is provided by the client in the form of an "input element").

```
{
    "id": "0d57f923-955e-4693-a606-cca9651aab4a",
    "createdOn": "2023-12-10T18:51:39.511538600Z",
    "version": 0,
    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
    "name": "Test protocol",
    "description": "Test description",
    "expectedParticipantData": [
        {
            "attribute": {
                "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
                "inputDataType": "dk.cachet.carp.input.sex"
            }
        },
        {
            "attribute": {
                "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.CustomParticipantAttribute",
                "input": {
                    "__type": "dk.cachet.carp.common.application.data.input.elements.Text",
                    "prompt": "Social Security Number"
                },
                "inputDataType": "dk.cachet.carp.input.custom.a1eda4bcd0d84ca0ba446cabfa4e84c8"
            }
        },
        {
            "attribute": {
                "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.CustomParticipantAttribute",
                "input": {
                    "__type": "dk.cachet.carp.common.application.data.input.elements.SelectOne",
                    "prompt": "Favorite OS",
                    "options": [
                        "Windows",
                        "Linux",
                        "Mac"
                    ]
                },
                "inputDataType": "dk.cachet.carp.input.custom.4ee5a0cc0ce5462b94baee4e59415f9b"
            }
        }
    ]
}
```

The protocol service does not validate `inputDataType`. Only when _setting_ the participant data on `ParticipationService`, errors will occur if no type information is available for the provided `inputDataType`. In the Kotlin APIs, the `inputDataType` for custom participant attributes is generated under the namespace `dk.cachet.carp.input.custom` with a GUID appended, but, this is currently no requirement for the API.