### PR TITLE
Fix: JS/TS access to snapshot properties

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/domain/Snapshot.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/domain/Snapshot.kt
@@ -4,6 +4,7 @@ import dk.cachet.carp.common.application.Immutable
 import dk.cachet.carp.common.application.ImplementAsDataClass
 import dk.cachet.carp.common.application.UUID
 import kotlinx.datetime.Instant
+import kotlin.js.JsExport
 
 
 /**
@@ -11,6 +12,7 @@ import kotlinx.datetime.Instant
  */
 @Immutable
 @ImplementAsDataClass
+@JsExport
 interface Snapshot<TAggregateRoot>
 {
     val id: UUID
@@ -18,6 +20,7 @@ interface Snapshot<TAggregateRoot>
     /**
      * The date when the object represented by this snapshot was created.
      */
+    @Suppress( "NON_EXPORTABLE_TYPE" )
     val createdOn: Instant
 
     /**

--- a/typescript-declarations/tests/carp-protocols-test.ts
+++ b/typescript-declarations/tests/carp-protocols-test.ts
@@ -2,9 +2,13 @@ import { expect } from 'chai'
 
 import { dk as cdk } from '@cachet/carp-common'
 import JSON = cdk.cachet.carp.common.infrastructure.serialization.JSON
+import UUID = cdk.cachet.carp.common.application.UUID
 
 import { kotlinx } from '@cachet/carp-kotlinx-serialization'
 import getSerializer = kotlinx.serialization.getSerializer
+
+import { kotlinx as datetime } from '@cachet/carp-kotlinx-datetime'
+import Clock = datetime.datetime.Clock
 
 import { dk } from '@cachet/carp-protocols-core'
 import StudyProtocolSnapshot = dk.cachet.carp.protocols.application.StudyProtocolSnapshot
@@ -19,6 +23,17 @@ describe( "carp-protocols-core", () => {
             const serializer = getSerializer( StudyProtocolSnapshot )
             const parsed = JSON.decodeFromString( serializer, serializedSnapshot )
             expect( parsed ).is.instanceOf( StudyProtocolSnapshot )
+        } )
+
+        it( "can access snapshot properties", () => {
+            const id = UUID.Companion.randomUUID()
+            const now = Clock.System.now()
+            const version = 42
+            const snapshot = new StudyProtocolSnapshot( id, now, version, UUID.Companion.randomUUID(), "Stub" )
+
+            expect( snapshot.id ).equals( id )
+            expect( snapshot.createdOn ).equals( now )
+            expect( snapshot.version ).equals( version )
         } )
     } )
 


### PR DESCRIPTION
The properties `id`, `createdOn`, and `version` of snapshots couldn't be accessed through JS/TypeScript since they were defined on a base `Snapshot` interface which couldn't be JS exported from Kotlin due to an unsupported `Instant` type.

But, by suppressing a warning the base `Snapshot` interface can in fact be exported, and the resulting TypeScript code compiles since the custom build pipeline already modifies generated TypeScript sources to support `Instant`.

Closes #454