### PR TITLE
Add WebServer as a device

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/WebServer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/WebServer.kt
@@ -1,0 +1,45 @@
+@file:Suppress("NON_EXPORTABLE_TYPE")
+
+package dk.cachet.carp.common.application.devices
+
+import dk.cachet.carp.common.application.Trilean
+import dk.cachet.carp.common.application.data.DataType
+import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
+import dk.cachet.carp.common.application.sampling.SamplingConfiguration
+import dk.cachet.carp.common.application.tasks.TaskConfigurationList
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+import kotlin.reflect.KClass
+
+typealias WebServerDeviceRegistration = DefaultDeviceRegistration
+typealias WebServerDeviceRegistrationBuilder = DefaultDeviceRegistrationBuilder
+
+@Serializable
+@JsExport
+data class WebServer(
+        val url: String,
+        override val roleName: String,
+        override val isOptional: Boolean = false
+) : PrimaryDeviceConfiguration<WebServerDeviceRegistration, WebServerDeviceRegistrationBuilder>()
+{
+    companion object
+    {
+        fun create( url: String, roleName: String ): WebServer = WebServer( url, roleName )
+    }
+
+    object Sensors : DataTypeSamplingSchemeMap()
+    object Tasks : TaskConfigurationList()
+
+    override fun getSupportedDataTypes(): Set<DataType> = Sensors.keys
+
+    override val defaultSamplingConfiguration: Map<DataType, SamplingConfiguration> = emptyMap()
+
+    override fun getDataTypeSamplingSchemes(): DataTypeSamplingSchemeMap = Sensors
+
+    override fun createDeviceRegistrationBuilder(): WebServerDeviceRegistrationBuilder =
+            WebServerDeviceRegistrationBuilder()
+
+    override fun getRegistrationClass(): KClass<WebServerDeviceRegistration> = WebServerDeviceRegistration::class
+
+    override fun isValidRegistration( registration: WebServerDeviceRegistration ): Trilean = Trilean.TRUE
+}

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/Serialization.kt
@@ -63,6 +63,7 @@ val COMMON_SERIAL_MODULE = SerializersModule {
     {
         subclass( CustomProtocolDevice::class )
         subclass( Smartphone::class )
+        subclass( WebServer::class )
 
         subclass( CustomPrimaryDeviceConfiguration::class )
     }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/TestInstances.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/TestInstances.kt
@@ -48,6 +48,7 @@ val commonInstances = listOf(
     BLESerialNumberDeviceRegistration( "123456789" ),
     CustomProtocolDevice( "User's phone" ),
     Smartphone( "User's phone" ),
+    WebServer( "https://example.com", "Example server" ),
 
     // Shared device registrations in `devices` namespace.
     DefaultDeviceRegistration(),

--- a/docs/carp-common.md
+++ b/docs/carp-common.md
@@ -70,13 +70,13 @@ _Primary_ devices ([`PrimaryDeviceConfiguration`](../carp.common/src/commonMain/
 in addition to supporting data collection from internal sensors,
 act as a hub to aggregate, synchronize, and upload incoming data received from one or more connected devices. 
 
-| Class                                                                                                                          | Primary | Description                                                                                              |
-|--------------------------------------------------------------------------------------------------------------------------------|:-------:|----------------------------------------------------------------------------------------------------------|
-| [Smartphone](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt)                     |   Yes   | An internet-connected phone with built-in sensors.                                                       |
-| [AltBeacon](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt)                       |         | A beacon meeting the open AltBeacon standard.                                                            |
-| [BLEHeartRateDevice](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLEHeartRateDevice.kt)     |         | A Bluetooth device which implements a Heart Rate service.                                                |
-| [CustomProtocolDevice](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/CustomProtocolDevice.kt) |   Yes   | A primary device which uses a single `CustomProtocolTask` to determine how to run a study on the device. |
-
+| Class                                                                                                                          | Primary | Description                                                                                               |
+|--------------------------------------------------------------------------------------------------------------------------------|:-------:|-----------------------------------------------------------------------------------------------------------|
+| [Smartphone](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Smartphone.kt)                     |   Yes   | An internet-connected phone with built-in sensors.                                                        |
+| [AltBeacon](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt)                       |         | A beacon meeting the open AltBeacon standard.                                                             |
+| [BLEHeartRateDevice](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLEHeartRateDevice.kt)     |         | A Bluetooth device which implements a Heart Rate service.                                                 |
+| [CustomProtocolDevice](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/CustomProtocolDevice.kt) |   Yes   | A primary device which uses a single `CustomProtocolTask` to determine how to run a study on the device.  |
+| [WebServer](../carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/WebServer.kt)                       |   Yes   | A primary device that has an associated URL where the study is hosted.                                    |
 ## Sampling schemes and configurations
 
 Supports specifying the sampling scheme for a [`DataType`](#data-types), including possible options, defaults, and constraints.


### PR DESCRIPTION
A little background information:
We are trying to add a feature in @cph-cachet/carp-webservcies-spring, which would allow for a study to be hosted in an anonymous mode, meaning that participants would only receive a link in their inbox, and they wouldn't have to bother with the onboarding process. 

When we are generating the links with the help of our authorization service, we need to have a url that we can redirect users. At the time of creating the accounts and links we don't have any deployed groups and devices so I can really only rely on the protocol to contain some sort of information about where the study is hosted.

Do you think this is the right way to approach this @Whathecode? Or do you have any other ideas? Right now we would only be using anonymous invitations for ICAT, but in the future there may be other studies where we want to avoid using accounts and I also don't want to hardcode it on the CAWS level.