### PR TITLE
Add additionalSpecifications field to DeviceRegistration

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
@@ -2,6 +2,7 @@
 
 package dk.cachet.carp.common.application.devices
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.Trilean
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.CarpDataTypes
@@ -78,7 +79,8 @@ data class AltBeaconDeviceRegistration(
      */
     val referenceRssi: Short,
     @Required
-    override val deviceDisplayName: String? = null // TODO: We could map known manufacturerId's to display names.
+    override val deviceDisplayName: String? = null, // TODO: We could map known manufacturerId's to display names.
+    override val additionalSpecifications: ApplicationData? = null
 ) : DeviceRegistration()
 {
     companion object
@@ -134,6 +136,7 @@ class AltBeaconDeviceRegistrationBuilder : DeviceRegistrationBuilder<AltBeaconDe
         majorId,
         minorId,
         referenceRssi,
-        deviceDisplayName
+        deviceDisplayName,
+        additionalSpecifications
     )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLESerialNumberDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLESerialNumberDeviceRegistration.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.application.devices
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
 import kotlinx.serialization.*
 import kotlin.js.JsExport
@@ -15,7 +16,8 @@ import kotlin.js.JsExport
 data class BLESerialNumberDeviceRegistration(
     val serialNumber: String,
     @Required
-    override val deviceDisplayName: String? = null
+    override val deviceDisplayName: String? = null,
+    override val additionalSpecifications: ApplicationData? = null
 ) : DeviceRegistration()
 {
     init
@@ -41,5 +43,5 @@ class BLESerialNumberDeviceRegistrationBuilder : DeviceRegistrationBuilder<BLESe
     var serialNumber: String = ""
 
     override fun build(): BLESerialNumberDeviceRegistration =
-        BLESerialNumberDeviceRegistration( serialNumber, deviceDisplayName )
+        BLESerialNumberDeviceRegistration( serialNumber, deviceDisplayName, additionalSpecifications )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.application.devices
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
 import kotlinx.serialization.*
@@ -16,6 +17,7 @@ import kotlin.js.JsExport
 data class DefaultDeviceRegistration(
     @Required
     override val deviceDisplayName: String? = null,
+    override val additionalSpecifications: ApplicationData? = null,
     @Required
     override val deviceId: String = UUID.randomUUID().toString()
 ) : DeviceRegistration()
@@ -36,5 +38,6 @@ class DefaultDeviceRegistrationBuilder : DeviceRegistrationBuilder<DefaultDevice
      */
     var deviceId: String = UUID.randomUUID().toString()
 
-    override fun build(): DefaultDeviceRegistration = DefaultDeviceRegistration( deviceDisplayName, deviceId )
+    override fun build(): DefaultDeviceRegistration =
+        DefaultDeviceRegistration( deviceDisplayName, additionalSpecifications, deviceId )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceRegistration.kt
@@ -2,6 +2,7 @@
 
 package dk.cachet.carp.common.application.devices
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.Immutable
 import dk.cachet.carp.common.application.ImplementAsDataClass
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
@@ -42,6 +43,12 @@ abstract class DeviceRegistration
 
     @Required
     val registrationCreatedOn: Instant = Clock.System.now()
+
+    /**
+     * Additional device specifications which may be relevant to the researcher when interpreting collected data.
+     * E.g., brand/model name, operating system version, or any other relevant information.
+     */
+    abstract val additionalSpecifications: ApplicationData?
 }
 
 
@@ -64,6 +71,12 @@ abstract class DeviceRegistrationBuilder<T : DeviceRegistration>
      * In case this is not set, the builder may derive a default name based on the other registration properties.
      */
     var deviceDisplayName: String? = null
+
+    /**
+     * Additional device specifications which may be relevant to the researcher when interpreting collected data.
+     * E.g., brand/model name, operating system version, or any other relevant information.
+     */
+    var additionalSpecifications: ApplicationData? = null
 
     /**
      * Build the immutable [DeviceRegistration] using the current configuration of this [DeviceRegistrationBuilder].

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistration.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.application.devices
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.MACAddress
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
 import kotlinx.serialization.*
@@ -14,7 +15,8 @@ import kotlin.js.JsExport
 data class MACAddressDeviceRegistration(
     val macAddress: MACAddress,
     @Required
-    override val deviceDisplayName: String? = null
+    override val deviceDisplayName: String? = null,
+    override val additionalSpecifications: ApplicationData? = null
 ) : DeviceRegistration()
 {
     @Required
@@ -30,5 +32,5 @@ class MACAddressDeviceRegistrationBuilder : DeviceRegistrationBuilder<MACAddress
     var macAddress: String = ""
 
     override fun build(): MACAddressDeviceRegistration =
-        MACAddressDeviceRegistration( MACAddress.parse( macAddress ), deviceDisplayName )
+        MACAddressDeviceRegistration( MACAddress.parse( macAddress ), deviceDisplayName, additionalSpecifications )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Website.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Website.kt
@@ -2,6 +2,7 @@
 
 package dk.cachet.carp.common.application.devices
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.Trilean
 import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
@@ -51,7 +52,8 @@ data class WebsiteDeviceRegistration(
      */
     val userAgent: String,
     @Required
-    override val deviceDisplayName: String? = userAgent
+    override val deviceDisplayName: String? = userAgent,
+    override val additionalSpecifications: ApplicationData? = null
 ) : DeviceRegistration()
 {
     @Required
@@ -74,5 +76,6 @@ class WebsiteDeviceRegistrationBuilder : DeviceRegistrationBuilder<WebsiteDevice
      */
     var userAgent: String = ""
 
-    override fun build(): WebsiteDeviceRegistration = WebsiteDeviceRegistration( url, userAgent, deviceDisplayName )
+    override fun build(): WebsiteDeviceRegistration =
+        WebsiteDeviceRegistration( url, userAgent, deviceDisplayName, additionalSpecifications )
 }

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.Trilean
 import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
@@ -178,11 +179,13 @@ data class CustomDeviceRegistration internal constructor(
     @Serializable
     private data class BaseMembers(
         override val deviceId: String,
-        override val deviceDisplayName: String?
+        override val deviceDisplayName: String?,
+        override val additionalSpecifications: ApplicationData? = null
     ) : DeviceRegistration()
 
     override val deviceId: String
     override val deviceDisplayName: String?
+    override val additionalSpecifications: ApplicationData?
 
     init
     {
@@ -190,6 +193,7 @@ data class CustomDeviceRegistration internal constructor(
         val baseMembers = json.decodeFromString( BaseMembers.serializer(), jsonSource )
         deviceId = baseMembers.deviceId
         deviceDisplayName = baseMembers.deviceDisplayName
+        additionalSpecifications = baseMembers.additionalSpecifications
     }
 }
 

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/PrimaryDeviceDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/PrimaryDeviceDeployment.kt
@@ -14,7 +14,6 @@ import dk.cachet.carp.common.application.triggers.TaskControl
 import dk.cachet.carp.common.application.triggers.TriggerConfiguration
 import dk.cachet.carp.common.application.users.ExpectedParticipantData
 import dk.cachet.carp.common.application.users.hasNoConflicts
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlin.js.JsExport
@@ -97,14 +96,7 @@ data class PrimaryDeviceDeployment(
      * The time when this device deployment was last updated.
      * This corresponds to the most recent device registration as part of this device deployment.
      */
-    val lastUpdatedOn: Instant =
-        // TODO: Remove this workaround once JS serialization bug is fixed:
-        //  https://github.com/Kotlin/kotlinx.serialization/issues/716
-        @Suppress( "SENSELESS_COMPARISON" )
-        if ( connectedDeviceRegistrations == null || registration == null ) Clock.System.now()
-        else connectedDeviceRegistrations.values.plus( registration )
-            .maxOf { it.registrationCreatedOn }
-
+    val lastUpdatedOn: Instant = (connectedDeviceRegistrations.values + registration).maxOf { it.registrationCreatedOn }
 
     /**
      * Get info on the primary device and each of the devices this device needs to connect to relevant at study runtime.

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployments.application
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.DefaultDeviceRegistration
 import dk.cachet.carp.common.application.devices.DeviceRegistration
@@ -158,6 +159,7 @@ class ValidationTest
             {
                 override val deviceId: String = "Invalid"
                 override val deviceDisplayName: String? = null
+                override val additionalSpecifications: ApplicationData? = null
             }
         val preregistrations = mapOf( connectedRoleName to invalidRegistration )
 

--- a/rpc/schemas/common/devices/DeviceRegistration.json
+++ b/rpc/schemas/common/devices/DeviceRegistration.json
@@ -31,7 +31,8 @@
         "__type": true,
         "deviceId": { "type": "string" },
         "deviceDisplayName": { "type": [ "string", "null" ] },
-        "registrationCreatedOn": { "type": "string", "format": "date-time" }
+        "registrationCreatedOn": { "type": "string", "format": "date-time" },
+        "additionalSpecifications": { "$ref":  "../../common/ApplicationData.json" }
       },
       "required": [ "__type", "deviceId", "deviceDisplayName", "registrationCreatedOn" ]
     }

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -187,6 +187,7 @@ private val bikeBeaconPreregistration = bikeBeacon.createRegistration {
     organizationId = UUID( "4e990957-0838-414c-bf25-2d391e2990b5" )
     majorId = 42
     minorId = 42
+    additionalSpecifications = ApplicationData( """{"Model": "AnyBeacon B42"}""" )
 }.setRegistrationCreatedOn( deploymentCreatedOn )
 private val phoneRegistration = phone.createRegistration {
     deviceId = UUID( "fc7b41b0-e9e2-4b5d-8c3d-5119b556a3f0" ).toString()


### PR DESCRIPTION
As discussed in #431, adding a `additionalSpecifications` field to `DeviceRegistration`. This allows to keep additional specification data when register device and access them later on in `StudyDeploymentStatus.deviceStatusList`