### PR TITLE
Add ApplicationData datatype

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/ApplicationData.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/ApplicationData.kt
@@ -1,0 +1,18 @@
+package dk.cachet.carp.common.application
+
+import dk.cachet.carp.common.infrastructure.serialization.ApplicationDataSerializer
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+
+/**
+ * Holds extra [data] which is specific to concrete applications, sensors, or infrastructure, and isn't statically
+ * known to the base infrastructure.
+ *
+ * While the [data] can be formatted in any way, when JSON serialization is applied and [data] contains a JSON element,
+ * the data will be formatted as JSON (without escaping special characters). If the JSON contained in the string is
+ * malformed, it will be serialized as a normal, escaped string.
+ */
+@Serializable( ApplicationDataSerializer::class )
+@JsExport
+data class ApplicationData( val data: String )

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/ApplicationDataSerializerTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/ApplicationDataSerializerTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.infrastructure.serialization
 
+import dk.cachet.carp.common.application.ApplicationData
 import kotlinx.serialization.*
 import kotlin.test.*
 
@@ -12,8 +13,7 @@ class ApplicationDataSerializerTest
     @Serializable
     data class ContainsApplicationData(
         val normalData: String,
-        @Serializable( ApplicationDataSerializer::class )
-        val applicationData: String?
+        val applicationData: ApplicationData?
     )
 
     private val json = createDefaultJSON()
@@ -22,7 +22,7 @@ class ApplicationDataSerializerTest
     @Test
     fun can_serialize_and_deserialize_non_json_application_data()
     {
-        val toSerialize = ContainsApplicationData( "normal", "some application data" )
+        val toSerialize = ContainsApplicationData( "normal", ApplicationData( "some application data" ) )
 
         val serialized = json.encodeToString( toSerialize )
         val parsed: ContainsApplicationData = json.decodeFromString( serialized )
@@ -43,7 +43,7 @@ class ApplicationDataSerializerTest
             }
             """
         )
-        val toSerialize = ContainsApplicationData( "normal", applicationData.toString() )
+        val toSerialize = ContainsApplicationData( "normal", ApplicationData( applicationData.toString() ) )
 
         val serialized = json.encodeToString( toSerialize )
         val parsed: ContainsApplicationData = json.decodeFromString( serialized )
@@ -63,7 +63,7 @@ class ApplicationDataSerializerTest
     @Test
     fun json_serializer_serializes_as_json_element()
     {
-        val toSerialize = ContainsApplicationData( "normal", """{"json":"data"}""" )
+        val toSerialize = ContainsApplicationData( "normal", ApplicationData( """{"json":"data"}""" ) )
 
         val serialized = json.encodeToString( toSerialize )
 
@@ -75,7 +75,7 @@ class ApplicationDataSerializerTest
     fun can_serialize_malformed_json()
     {
         val malformedJson = """{"json object":"or not?"""
-        val toSerialize = ContainsApplicationData( "normal", malformedJson )
+        val toSerialize = ContainsApplicationData( "normal", ApplicationData( malformedJson ) )
 
         val serialized = json.encodeToString( toSerialize )
 

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/PrimaryDeviceDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/PrimaryDeviceDeployment.kt
@@ -2,6 +2,7 @@
 
 package dk.cachet.carp.deployments.application
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.data.DataType
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
@@ -13,7 +14,6 @@ import dk.cachet.carp.common.application.triggers.TaskControl
 import dk.cachet.carp.common.application.triggers.TriggerConfiguration
 import dk.cachet.carp.common.application.users.ExpectedParticipantData
 import dk.cachet.carp.common.application.users.hasNoConflicts
-import dk.cachet.carp.common.infrastructure.serialization.ApplicationDataSerializer
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.*
@@ -64,8 +64,7 @@ data class PrimaryDeviceDeployment(
      * This can be used by infrastructures or concrete applications which require exchanging additional data
      * between the protocols and clients subsystems, outside of scope or not yet supported by CARP core.
      */
-    @Serializable( ApplicationDataSerializer::class )
-    val applicationData: String? = null
+    val applicationData: ApplicationData? = null
 )
 {
     init { expectedParticipantData.hasNoConflicts( exceptionOnConflict = true ) }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/StudyInvitation.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/StudyInvitation.kt
@@ -1,6 +1,6 @@
 package dk.cachet.carp.deployments.application.users
 
-import dk.cachet.carp.common.infrastructure.serialization.ApplicationDataSerializer
+import dk.cachet.carp.common.application.ApplicationData
 import kotlinx.serialization.*
 import kotlin.js.JsExport
 
@@ -25,6 +25,5 @@ data class StudyInvitation(
      * This can be used by infrastructures or concrete applications which require exchanging additional data
      * between the studies and clients subsystems, outside of scope or not yet supported by CARP core.
      */
-    @Serializable( ApplicationDataSerializer::class )
-    val applicationData: String? = null
+    val applicationData: ApplicationData? = null
 )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployments.application
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.application.data.input.Sex
@@ -56,7 +57,7 @@ interface ParticipationServiceTest
         val (participationService, deploymentService, accountService) = createSUT()
         val protocol = createSinglePrimaryDeviceProtocol()
         val identity = AccountIdentity.fromEmailAddress( "test@test.com" )
-        val invitation = StudyInvitation( "Test study", "description", "Custom data" )
+        val invitation = StudyInvitation( "Test study", "description", ApplicationData( "Custom data" ) )
         val participantInvitation = ParticipantInvitation(
             participantId = UUID.randomUUID(),
             AssignedTo.All,

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/StudyDeploymentTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/domain/StudyDeploymentTest.kt
@@ -2,6 +2,7 @@
 
 package dk.cachet.carp.deployments.domain
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.CarpDataTypes
 import dk.cachet.carp.common.application.data.DataType
@@ -577,7 +578,7 @@ class StudyDeploymentTest
     fun getDeviceDeploymentFor_succeeds()
     {
         val (protocol, primary, connected) = createSinglePrimaryWithConnectedDeviceProtocol()
-        protocol.applicationData = "some data"
+        protocol.applicationData = ApplicationData( "some data" )
         val primaryTask = StubTaskConfiguration( "Primary task" )
         val connectedTask = StubTaskConfiguration( "Connected task" )
         protocol.addTaskControl( primary.atStartOfStudy().start( primaryTask, primary ) )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/PrimaryDeviceDeploymentTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/PrimaryDeviceDeploymentTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployments.infrastructure
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.triggers.TaskControl
 import dk.cachet.carp.common.application.users.ExpectedParticipantData
@@ -46,7 +47,7 @@ class PrimaryDeviceDeploymentTest
             mapOf( 0 to trigger ),
             setOf( TaskControl( 0, task.name, connected.roleName, TaskControl.Control.Start ) ),
             setOf( expectedData ),
-            "some data"
+            ApplicationData( "some data" )
         )
 
         val json = JSON.encodeToString( deployment )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyInvitationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyInvitationTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.deployments.infrastructure
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import kotlinx.serialization.*
@@ -14,7 +15,7 @@ class StudyInvitationTest
     @Test
     fun can_serialize_and_deserialize_study_invitation_using_JSON()
     {
-        val applicationData = """{"extraData":"42"}"""
+        val applicationData = ApplicationData( """{"extraData":"42"}""" )
         val invitation = StudyInvitation( "Test", "Description", applicationData )
 
         val serialized = JSON.encodeToString( invitation )

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshot.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshot.kt
@@ -2,6 +2,7 @@
 
 package dk.cachet.carp.protocols.application
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
@@ -13,7 +14,6 @@ import dk.cachet.carp.common.application.users.AssignedTo
 import dk.cachet.carp.common.application.users.ExpectedParticipantData
 import dk.cachet.carp.common.application.users.ParticipantRole
 import dk.cachet.carp.common.domain.Snapshot
-import dk.cachet.carp.common.infrastructure.serialization.ApplicationDataSerializer
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import kotlinx.datetime.Instant
 import kotlinx.serialization.*
@@ -45,8 +45,7 @@ data class StudyProtocolSnapshot(
      */
     val assignedDevices: Map<String, Set<String>> = emptyMap(),
     val expectedParticipantData: Set<ExpectedParticipantData> = emptySet(),
-    @Serializable( ApplicationDataSerializer::class )
-    val applicationData: String? = null
+    val applicationData: ApplicationData? = null
 ) : Snapshot<StudyProtocol>
 {
     @Serializable

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/StudyProtocol.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.protocols.domain
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
 import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
@@ -482,7 +483,7 @@ class StudyProtocol(
      * This can be used by infrastructures or concrete applications which require exchanging additional data
      * between the protocols and clients subsystems, outside of scope or not yet supported by CARP core.
      */
-    var applicationData: String? = null
+    var applicationData: ApplicationData? = null
 
 
     /**

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshotTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/application/StudyProtocolSnapshotTest.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.protocols.application
 
+import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
@@ -130,7 +131,7 @@ class StudyProtocolSnapshotTest
             description,
             primaryDevices.toSet(), connectedDevices.toSet(), connections.toSet(),
             tasks.toSet(), triggers, triggeredTasks.toSet(),
-            participantRoles.toSet(), assignedDevices, expectedParticipantData.toSet(), ""
+            participantRoles.toSet(), assignedDevices, expectedParticipantData.toSet(), ApplicationData( "" )
         )
         val reorganizedSnapshot = StudyProtocolSnapshot(
             protocolId,
@@ -141,7 +142,7 @@ class StudyProtocolSnapshotTest
             description,
             primaryDevices.reversed().toSet(), connectedDevices.reversed().toSet(), connections.reversed().toSet(),
             tasks.reversed().toSet(), triggers, triggeredTasks.reversed().toSet(),
-            participantRoles.reversed().toSet(), assignedDevices, expectedParticipantData.reversed().toSet(), ""
+            participantRoles.reversed().toSet(), assignedDevices, expectedParticipantData.reversed().toSet(), ApplicationData( "" )
         )
 
         assertEquals( snapshot, reorganizedSnapshot )

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -125,7 +125,7 @@ private val phoneProtocol = StudyProtocol(
     addConnectedDevice( bikeBeacon, phone )
     addTaskControl( startOfStudyTrigger.start( measurePhoneMovement, phone ) )
     addTaskControl( startOfStudyTrigger.start( measureBikeProximity, bikeBeacon ) )
-    applicationData = "{\"uiTheme\": \"black\"}"
+    applicationData = ApplicationData( "{\"uiTheme\": \"black\"}" )
 }.getSnapshot()
 private val startOfStudyTriggerId = phoneProtocol.triggers.entries.first { it.value == startOfStudyTrigger }.key
 private val expectedParticipantData = setOf(
@@ -163,7 +163,7 @@ private val participantAccountId = UUID( "ca60cb7f-de18-44b6-baf9-3c8e6a73005a" 
 private val studyInvitation = StudyInvitation(
     studyName,
     "Participate in this study, which keeps track of how much you walk and bike!",
-    "{\"trialGroup\", \"A\"}"
+    ApplicationData( "{\"trialGroup\", \"A\"}" )
 )
 private val participantAssignedRoles = AssignedTo.Roles( setOf( participantRole.role ) )
 private val participantInvitation = ParticipantInvitation(

--- a/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime.d.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime.d.ts
@@ -5,14 +5,14 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime"
         interface System
         {
             // now
-            q13(): Instant_0
+            p13(): Instant_0
         }
         function System_getInstance(): System
 
         interface Instant_0
         {
             // toEpochMilliseconds
-            d14(): number
+            c14(): number
         }
     }
 }

--- a/typescript-declarations/carp-kotlinx-datetime/index.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/index.ts
@@ -34,8 +34,8 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime"
 
 
 // Implement base interfaces in internal types.
-extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.q13(); };
-extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.d14(); };
+extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.p13(); };
+extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.c14(); };
 
 
 // Export facade.

--- a/typescript-declarations/carp-kotlinx-serialization/index.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/index.ts
@@ -7,7 +7,7 @@ import extendJson from "@cachet/kotlinx-serialization-kotlinx-serialization-json
 // Facade with better method names and type conversions for internal types.
 export namespace kotlinx.serialization
 {
-    export function getSerializer( type: any ) { return type.Companion.m16() }
+    export function getSerializer( type: any ) { return type.Companion.i16() }
 }
 export namespace kotlinx.serialization.json
 {
@@ -44,12 +44,12 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
 extendJson.$_$.JsonImpl.prototype.encodeToString =
     function( serializer: any, value: any ): string
     {
-        return this.i14( serializer, value );
+        return this.h14( serializer, value );
     };
 extendJson.$_$.JsonImpl.prototype.decodeFromString =
     function( serializer: any, string: string ): any
     {
-        return this.j14( serializer, string );
+        return this.i14( serializer, string );
     };
 
 

--- a/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
@@ -5,10 +5,10 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
         interface JsonImpl
         {
             // encodeToString
-            i14( serializer: any, instance: any ): string
+            h14( serializer: any, instance: any ): string
 
             // decodeFromString
-            j14( serializer: any, string: string ): string
+            i14( serializer: any, string: string ): string
         }
         function Default_getInstance(): JsonImpl
     }


### PR DESCRIPTION
As discussed in #484, introducing a new datatype to hold `applicationData`and set default serializer to `ApplicationDataSerializer`. This way we don't need to specify the serializer used everytime we use `applicationData`.

Changes:
1. New type `ApplicationData` holds a `String` field `data`.
2. In `ApplicationDataSerializer`, a _not null_ String value is expected for field `data`
3. All `applicationData` are now type of `ApplicationData?`
4. Update TypeScript wrapper
