### PR TITLE
488 include `deviceregistration` in `devicedeploymentstatus`

### DIFF
--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/ClientRepositoryTest.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/ClientRepositoryTest.kt
@@ -97,7 +97,7 @@ interface ClientRepositoryTest
                 Clock.System.now(),
                 deploymentId,
                 listOf(
-                    DeviceDeploymentStatus.Registered( primaryDevice, true, emptySet(), emptySet() )
+                    DeviceDeploymentStatus.Registered( primaryDevice, registration, true, emptySet(), emptySet() )
                 ),
                 emptyList(),
                 null

--- a/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/study/StudyTest.kt
+++ b/carp.clients.core/src/commonTest/kotlin/dk/cachet/carp/clients/domain/study/StudyTest.kt
@@ -311,6 +311,7 @@ class StudyTest
                 listOf(
                     DeviceDeploymentStatus.Registered(
                         smartphone,
+                        primaryDeviceDeployment.registration,
                         true,
                         emptySet(),
                         connectedDevices.map { it.roleName }.toSet()

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHost.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceHost.kt
@@ -214,7 +214,7 @@ class DeploymentServiceHost(
         val deployment: StudyDeployment = repository.getStudyDeploymentOrThrowBy( studyDeploymentId )
         val device = getRegisteredPrimaryDevice( deployment, primaryDeviceRoleName )
 
-        deployment.deviceDeployed( device, deviceDeploymentLastUpdatedOn )
+        deployment.deviceDeployed( device, deviceDeploymentLastUpdatedOn, clock.now() )
         repository.update( deployment )
 
         // Open the required data streams.

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeviceDeploymentStatus.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/DeviceDeploymentStatus.kt
@@ -3,6 +3,7 @@
 package dk.cachet.carp.deployments.application
 
 import dk.cachet.carp.common.application.devices.AnyDeviceConfiguration
+import dk.cachet.carp.common.application.devices.DeviceRegistration
 import kotlinx.serialization.*
 import kotlin.js.JsExport
 
@@ -56,6 +57,16 @@ sealed class DeviceDeploymentStatus
         abstract val remainingDevicesToRegisterBeforeDeployment: Set<String>
     }
 
+    /**
+     * A device deployment status which indicates the device has been registered.
+     */
+    sealed interface HasDeviceRegistration
+    {
+        /**
+         * The last [DeviceRegistration] for this device.
+         */
+        val deviceRegistration: DeviceRegistration
+    }
 
     /**
      * Device deployment status for when a device has not been registered.
@@ -74,18 +85,20 @@ sealed class DeviceDeploymentStatus
     @Serializable
     data class Registered(
         override val device: AnyDeviceConfiguration,
+        override val deviceRegistration: DeviceRegistration,
         override val canBeDeployed: Boolean,
         override val remainingDevicesToRegisterToObtainDeployment: Set<String>,
         override val remainingDevicesToRegisterBeforeDeployment: Set<String>
-    ) : NotDeployed()
+    ) : NotDeployed(), HasDeviceRegistration
 
     /**
      * Device deployment status when the device has retrieved its [PrimaryDeviceDeployment] and was able to load all the necessary plugins to execute the study.
      */
     @Serializable
     data class Deployed(
-        override val device: AnyDeviceConfiguration
-    ) : DeviceDeploymentStatus()
+        override val device: AnyDeviceConfiguration,
+        override val deviceRegistration: DeviceRegistration
+    ) : DeviceDeploymentStatus(), HasDeviceRegistration
     {
         // All devices that have been deployed necessarily can be deployed.
         override val canBeDeployed = true
@@ -97,9 +110,10 @@ sealed class DeviceDeploymentStatus
     @Serializable
     data class NeedsRedeployment(
         override val device: AnyDeviceConfiguration,
+        override val deviceRegistration: DeviceRegistration,
         override val remainingDevicesToRegisterToObtainDeployment: Set<String>,
         override val remainingDevicesToRegisterBeforeDeployment: Set<String>
-    ) : NotDeployed()
+    ) : NotDeployed(), HasDeviceRegistration
     {
         // All devices that have been deployed necessarily can be deployed.
         override val canBeDeployed = true

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
@@ -287,11 +287,25 @@ class StudyDeployment private constructor(
         return when
         {
             needsRedeployment ->
-                DeviceDeploymentStatus.NeedsRedeployment( device, toObtainDeployment, beforeDeployment )
+                DeviceDeploymentStatus.NeedsRedeployment(
+                    device,
+                    _registeredDevices.getValue( device ),
+                    toObtainDeployment,
+                    beforeDeployment
+                )
             isDeployed ->
-                DeviceDeploymentStatus.Deployed( device )
+                DeviceDeploymentStatus.Deployed(
+                    device,
+                    _registeredDevices.getValue( device )
+                )
             isRegistered ->
-                DeviceDeploymentStatus.Registered( device, canBeDeployed, toObtainDeployment, beforeDeployment )
+                DeviceDeploymentStatus.Registered(
+                    device,
+                    _registeredDevices.getValue( device ),
+                    canBeDeployed,
+                    toObtainDeployment,
+                    beforeDeployment
+                )
             else ->
                 DeviceDeploymentStatus.Unregistered( device, canBeDeployed, toObtainDeployment, beforeDeployment )
         }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/domain/StudyDeployment.kt
@@ -470,7 +470,11 @@ class StudyDeployment private constructor(
      * - the [deviceDeploymentLastUpdatedOn] does not match the expected timestamp. The deployment might be outdated.
      * @throws IllegalStateException when the passed [device] cannot be deployed yet, or the deployment has stopped.
      */
-    fun deviceDeployed( device: AnyPrimaryDeviceConfiguration, deviceDeploymentLastUpdatedOn: Instant )
+    fun deviceDeployed(
+        device: AnyPrimaryDeviceConfiguration,
+        deviceDeploymentLastUpdatedOn: Instant,
+        now: Instant = Clock.System.now()
+    )
     {
         // Verify whether the specified device is part of the protocol of this deployment.
         require( device in protocolSnapshot.primaryDevices )
@@ -501,7 +505,6 @@ class StudyDeployment private constructor(
             .all { it is DeviceDeploymentStatus.Deployed }
         if ( startedOn == null && allRequiredDeviceDeployed )
         {
-            val now = Clock.System.now()
             startedOn = now
             event( Event.Started( now ) )
         }

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/DeploymentServiceTest.kt
@@ -128,6 +128,55 @@ interface DeploymentServiceTest
     }
 
     @Test
+    fun getStudyDeploymentStatusList_full_flow_succeeds() = runTest {
+        val (service, _) = createSUT()
+        val deviceRoleName = "Primary"
+        val protocol = createSinglePrimaryDeviceProtocol( deviceRoleName )
+        val protocolSnapshot = protocol.getSnapshot()
+
+        val invitation = createParticipantInvitation( AccountIdentity.fromUsername( "User" ) )
+        val deploymentId = UUID.randomUUID()
+        service.createStudyDeployment( deploymentId, protocolSnapshot, listOf( invitation ) )
+
+        val status = service.getStudyDeploymentStatus( deploymentId )
+        val primary = status.getRemainingDevicesToRegister().first { it.roleName == deviceRoleName }
+        val registration = primary.createRegistration()
+        service.registerDevice( deploymentId, primary.roleName, registration )
+        val deviceDeployment = service.getDeviceDeploymentFor( deploymentId, primary.roleName )
+        service.deviceDeployed( deploymentId, primary.roleName, deviceDeployment.lastUpdatedOn )
+        service.unregisterDevice( deploymentId, primary.roleName )
+        service.stop( deploymentId )
+        service.removeStudyDeployments( setOf( deploymentId ) )
+    }
+
+    @Test
+    fun getStudyDeploymentStatusList_with_multiple_deployments_succeeds() = runTest {
+        val (service, _) = createSUT()
+        val deviceRoleName = "Primary"
+        val (protocol, _, _) = createSinglePrimaryWithConnectedDeviceProtocol( deviceRoleName )
+        val protocolSnapshot = protocol.getSnapshot()
+
+        val invitation1 = createParticipantInvitation( AccountIdentity.fromUsername( "User 1" ) )
+        val deploymentId1 = UUID.randomUUID()
+        service.createStudyDeployment( deploymentId1, protocolSnapshot, listOf( invitation1 ) )
+        val invitation2 = createParticipantInvitation( AccountIdentity.fromUsername( "User 2" ) )
+        val deploymentId2 = UUID.randomUUID()
+        service.createStudyDeployment( deploymentId2, protocolSnapshot, listOf( invitation2 ) )
+
+        val status = service.getStudyDeploymentStatus( deploymentId1 )
+        val primary = status.getRemainingDevicesToRegister().first { it.roleName == deviceRoleName }
+        val registration = primary.createRegistration()
+        service.registerDevice( deploymentId1, primary.roleName, registration )
+        service.getStudyDeploymentStatusList(
+            setOf(
+                deploymentId1,
+                deploymentId2
+            )
+        )
+        service.stop( deploymentId1 )
+    }
+
+    @Test
     fun getStudyDeploymentStatusList_fails_when_containing_an_unknown_studyDeploymentId() = runTest {
         val (service, _) = createSUT()
         val studyDeploymentId = addTestDeployment( service, "Test device" )

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.0/DeploymentServiceTest/getStudyDeploymentStatusList_full_flow_succeeds.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.0/DeploymentServiceTest/getStudyDeploymentStatusList_full_flow_succeeds.json
@@ -1,0 +1,430 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.0",
+            "id": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "protocol": {
+                "id": "bc5f9e5a-c6ef-464e-8edc-aa4eddc20bcc",
+                "createdOn": "2025-07-21T09:21:12.991416Z",
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "18e73cb9-026e-4b6f-b9a1-92dbf31e03af",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "User"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+                "apiVersion": "1.0",
+                "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+                "protocol": {
+                    "id": "bc5f9e5a-c6ef-464e-8edc-aa4eddc20bcc",
+                    "createdOn": "2025-07-21T09:21:12.991416Z",
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "18e73cb9-026e-4b6f-b9a1-92dbf31e03af",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "User"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "18e73cb9-026e-4b6f-b9a1-92dbf31e03af",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
+            "apiVersion": "1.0",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "18e73cb9-026e-4b6f-b9a1-92dbf31e03af",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
+            "apiVersion": "1.0",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "deviceRoleName": "Primary",
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "deviceDisplayName": null,
+                "deviceId": "75289ff2-4cee-4647-b79c-7dc0497a860d",
+                "registrationCreatedOn": "1970-01-01T00:00:00Z"
+            }
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+                "apiVersion": "1.0",
+                "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Primary"
+                },
+                "registration": {
+                    "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                    "deviceDisplayName": null,
+                    "deviceId": "75289ff2-4cee-4647-b79c-7dc0497a860d",
+                    "registrationCreatedOn": "1970-01-01T00:00:00Z"
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "18e73cb9-026e-4b6f-b9a1-92dbf31e03af",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
+            "apiVersion": "1.0",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "primaryDeviceRoleName": "Primary"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "deviceConfiguration": {
+                "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                "isPrimaryDevice": true,
+                "roleName": "Primary"
+            },
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "deviceDisplayName": null,
+                "deviceId": "75289ff2-4cee-4647-b79c-7dc0497a860d",
+                "registrationCreatedOn": "1970-01-01T00:00:00Z"
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.DeviceDeployed",
+            "apiVersion": "1.0",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "primaryDeviceRoleName": "Primary",
+            "deviceDeploymentLastUpdatedOn": "1970-01-01T00:00:00Z"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Running",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Deployed",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "18e73cb9-026e-4b6f-b9a1-92dbf31e03af",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.UnregisterDevice",
+            "apiVersion": "1.0",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "deviceRoleName": "Primary"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+                "apiVersion": "1.0",
+                "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Primary"
+                },
+                "registration": null
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "18e73cb9-026e-4b6f-b9a1-92dbf31e03af",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.Stop",
+            "apiVersion": "1.0",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentStopped",
+                "aggregateId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+                "apiVersion": "1.0",
+                "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf"
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "18e73cb9-026e-4b6f-b9a1-92dbf31e03af",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": "1970-01-01T00:00:00Z",
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RemoveStudyDeployments",
+            "apiVersion": "1.0",
+            "studyDeploymentIds": [
+                "9a6fc6d6-c973-439f-a711-f6f1ede398bf"
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentRemoved",
+                "aggregateId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf",
+                "apiVersion": "1.0",
+                "studyDeploymentId": "9a6fc6d6-c973-439f-a711-f6f1ede398bf"
+            }
+        ],
+        "response": [
+            "9a6fc6d6-c973-439f-a711-f6f1ede398bf"
+        ]
+    }
+]

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.0/DeploymentServiceTest/getStudyDeploymentStatusList_with_multiple_deployments_succeeds.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.0/DeploymentServiceTest/getStudyDeploymentStatusList_with_multiple_deployments_succeeds.json
@@ -1,0 +1,627 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.0",
+            "id": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+            "protocol": {
+                "id": "bdac258e-13f3-498d-a876-ad65ba39f83a",
+                "createdOn": "2025-07-21T14:31:40.056232Z",
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                ],
+                "connectedDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    }
+                ],
+                "connections": [
+                    {
+                        "roleName": "Connected",
+                        "connectedToRoleName": "Primary"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "508c9f17-e275-49bc-b1d6-ef4eeb6a8a00",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "User 1"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+                "apiVersion": "1.0",
+                "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+                "protocol": {
+                    "id": "bdac258e-13f3-498d-a876-ad65ba39f83a",
+                    "createdOn": "2025-07-21T14:31:40.056232Z",
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        }
+                    ],
+                    "connectedDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        }
+                    ],
+                    "connections": [
+                        {
+                            "roleName": "Connected",
+                            "connectedToRoleName": "Primary"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "508c9f17-e275-49bc-b1d6-ef4eeb6a8a00",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "User 1"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary",
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "508c9f17-e275-49bc-b1d6-ef4eeb6a8a00",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.0",
+            "id": "fe56c49a-696b-45c3-9e7a-e1be2e8aab8f",
+            "protocol": {
+                "id": "bdac258e-13f3-498d-a876-ad65ba39f83a",
+                "createdOn": "2025-07-21T14:31:40.056232Z",
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                ],
+                "connectedDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    }
+                ],
+                "connections": [
+                    {
+                        "roleName": "Connected",
+                        "connectedToRoleName": "Primary"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "cdc50d8b-1a39-4214-909e-3f3ee7fbc7e5",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "User 2"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "fe56c49a-696b-45c3-9e7a-e1be2e8aab8f",
+                "apiVersion": "1.0",
+                "studyDeploymentId": "fe56c49a-696b-45c3-9e7a-e1be2e8aab8f",
+                "protocol": {
+                    "id": "bdac258e-13f3-498d-a876-ad65ba39f83a",
+                    "createdOn": "2025-07-21T14:31:40.056232Z",
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        }
+                    ],
+                    "connectedDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        }
+                    ],
+                    "connections": [
+                        {
+                            "roleName": "Connected",
+                            "connectedToRoleName": "Primary"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "cdc50d8b-1a39-4214-909e-3f3ee7fbc7e5",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "User 2"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "fe56c49a-696b-45c3-9e7a-e1be2e8aab8f",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary",
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "cdc50d8b-1a39-4214-909e-3f3ee7fbc7e5",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
+            "apiVersion": "1.0",
+            "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary",
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "508c9f17-e275-49bc-b1d6-ef4eeb6a8a00",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
+            "apiVersion": "1.0",
+            "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+            "deviceRoleName": "Primary",
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "deviceDisplayName": null,
+                "deviceId": "5804a5d5-7118-41d6-8412-ee2920325555",
+                "registrationCreatedOn": "1970-01-01T00:00:00Z"
+            }
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+                "apiVersion": "1.0",
+                "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Primary"
+                },
+                "registration": {
+                    "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                    "deviceDisplayName": null,
+                    "deviceId": "5804a5d5-7118-41d6-8412-ee2920325555",
+                    "registrationCreatedOn": "1970-01-01T00:00:00Z"
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "508c9f17-e275-49bc-b1d6-ef4eeb6a8a00",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatusList",
+            "apiVersion": "1.0",
+            "studyDeploymentIds": [
+                "b728cfc0-75ad-4e96-bebe-c1825704501a",
+                "fe56c49a-696b-45c3-9e7a-e1be2e8aab8f"
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Connected"
+                        ]
+                    },
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        },
+                        "canBeDeployed": false,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "Connected"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Connected"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "508c9f17-e275-49bc-b1d6-ef4eeb6a8a00",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "Primary"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            },
+            {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "fe56c49a-696b-45c3-9e7a-e1be2e8aab8f",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "Primary"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Primary",
+                            "Connected"
+                        ]
+                    },
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        },
+                        "canBeDeployed": false,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "Connected"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Connected"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "cdc50d8b-1a39-4214-909e-3f3ee7fbc7e5",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "Primary"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.Stop",
+            "apiVersion": "1.0",
+            "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentStopped",
+                "aggregateId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+                "apiVersion": "1.0",
+                "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a"
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "b728cfc0-75ad-4e96-bebe-c1825704501a",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "508c9f17-e275-49bc-b1d6-ef4eeb6a8a00",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null,
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    }
+]

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.1/DeploymentServiceTest/getStudyDeploymentStatusList_full_flow_succeeds.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.1/DeploymentServiceTest/getStudyDeploymentStatusList_full_flow_succeeds.json
@@ -1,0 +1,432 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.1",
+            "id": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "protocol": {
+                "id": "e88e6ce0-d78e-4445-bd71-40a486e351e4",
+                "createdOn": "2025-07-22T10:55:32.545189Z",
+                "version": 0,
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "9dc2d57a-d4fa-44a0-939d-5d9efc41308a",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "User"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+                "protocol": {
+                    "id": "e88e6ce0-d78e-4445-bd71-40a486e351e4",
+                    "createdOn": "2025-07-22T10:55:32.545189Z",
+                    "version": 0,
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "9dc2d57a-d4fa-44a0-939d-5d9efc41308a",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "User"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "9dc2d57a-d4fa-44a0-939d-5d9efc41308a",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "9dc2d57a-d4fa-44a0-939d-5d9efc41308a",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "deviceRoleName": "Primary",
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "deviceDisplayName": null,
+                "deviceId": "6b638fb6-072c-4347-aac8-d59edd27cb3d",
+                "registrationCreatedOn": "1970-01-01T00:00:00Z"
+            }
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Primary"
+                },
+                "registration": {
+                    "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                    "deviceDisplayName": null,
+                    "deviceId": "6b638fb6-072c-4347-aac8-d59edd27cb3d",
+                    "registrationCreatedOn": "1970-01-01T00:00:00Z"
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "9dc2d57a-d4fa-44a0-939d-5d9efc41308a",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "primaryDeviceRoleName": "Primary"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "deviceConfiguration": {
+                "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                "isPrimaryDevice": true,
+                "roleName": "Primary"
+            },
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "deviceDisplayName": null,
+                "deviceId": "6b638fb6-072c-4347-aac8-d59edd27cb3d",
+                "registrationCreatedOn": "1970-01-01T00:00:00Z"
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.DeviceDeployed",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "primaryDeviceRoleName": "Primary",
+            "deviceDeploymentLastUpdatedOn": "1970-01-01T00:00:00Z"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Running",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Deployed",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "9dc2d57a-d4fa-44a0-939d-5d9efc41308a",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.UnregisterDevice",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "deviceRoleName": "Primary"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Primary"
+                },
+                "registration": null
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "9dc2d57a-d4fa-44a0-939d-5d9efc41308a",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.Stop",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentStopped",
+                "aggregateId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81"
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "9dc2d57a-d4fa-44a0-939d-5d9efc41308a",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": "1970-01-01T00:00:00Z",
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RemoveStudyDeployments",
+            "apiVersion": "1.1",
+            "studyDeploymentIds": [
+                "67822e97-abeb-4a22-bb43-e90e5cdd9b81"
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentRemoved",
+                "aggregateId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "67822e97-abeb-4a22-bb43-e90e5cdd9b81"
+            }
+        ],
+        "response": [
+            "67822e97-abeb-4a22-bb43-e90e5cdd9b81"
+        ]
+    }
+]

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.1/DeploymentServiceTest/getStudyDeploymentStatusList_with_multiple_deployments_succeeds.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.1/DeploymentServiceTest/getStudyDeploymentStatusList_with_multiple_deployments_succeeds.json
@@ -1,0 +1,631 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.1",
+            "id": "26f89691-3352-4789-8c69-20c988f25908",
+            "protocol": {
+                "id": "76d012e9-0d2d-498d-8929-d1ba2d3e7d5b",
+                "createdOn": "2025-07-22T10:55:32.561037Z",
+                "version": 0,
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                ],
+                "connectedDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    }
+                ],
+                "connections": [
+                    {
+                        "roleName": "Connected",
+                        "connectedToRoleName": "Primary"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "8cc06214-f5b1-455d-b195-5a0769443edb",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "User 1"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "26f89691-3352-4789-8c69-20c988f25908",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908",
+                "protocol": {
+                    "id": "76d012e9-0d2d-498d-8929-d1ba2d3e7d5b",
+                    "createdOn": "2025-07-22T10:55:32.561037Z",
+                    "version": 0,
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        }
+                    ],
+                    "connectedDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        }
+                    ],
+                    "connections": [
+                        {
+                            "roleName": "Connected",
+                            "connectedToRoleName": "Primary"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "8cc06214-f5b1-455d-b195-5a0769443edb",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "User 1"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary",
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "8cc06214-f5b1-455d-b195-5a0769443edb",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.1",
+            "id": "f1857b84-25b0-4c11-94e5-0605de3d947a",
+            "protocol": {
+                "id": "76d012e9-0d2d-498d-8929-d1ba2d3e7d5b",
+                "createdOn": "2025-07-22T10:55:32.561037Z",
+                "version": 0,
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                ],
+                "connectedDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    }
+                ],
+                "connections": [
+                    {
+                        "roleName": "Connected",
+                        "connectedToRoleName": "Primary"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "bcd819ad-be8c-41a3-a0e5-875abd7be1b7",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "User 2"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "f1857b84-25b0-4c11-94e5-0605de3d947a",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "f1857b84-25b0-4c11-94e5-0605de3d947a",
+                "protocol": {
+                    "id": "76d012e9-0d2d-498d-8929-d1ba2d3e7d5b",
+                    "createdOn": "2025-07-22T10:55:32.561037Z",
+                    "version": 0,
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        }
+                    ],
+                    "connectedDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        }
+                    ],
+                    "connections": [
+                        {
+                            "roleName": "Connected",
+                            "connectedToRoleName": "Primary"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "bcd819ad-be8c-41a3-a0e5-875abd7be1b7",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "User 2"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "f1857b84-25b0-4c11-94e5-0605de3d947a",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary",
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "bcd819ad-be8c-41a3-a0e5-875abd7be1b7",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary",
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "8cc06214-f5b1-455d-b195-5a0769443edb",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908",
+            "deviceRoleName": "Primary",
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "deviceDisplayName": null,
+                "deviceId": "e4f12f2b-3489-41e8-aab1-4b3c5962a787",
+                "registrationCreatedOn": "1970-01-01T00:00:00Z"
+            }
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "26f89691-3352-4789-8c69-20c988f25908",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Primary"
+                },
+                "registration": {
+                    "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                    "deviceDisplayName": null,
+                    "deviceId": "e4f12f2b-3489-41e8-aab1-4b3c5962a787",
+                    "registrationCreatedOn": "1970-01-01T00:00:00Z"
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "8cc06214-f5b1-455d-b195-5a0769443edb",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatusList",
+            "apiVersion": "1.1",
+            "studyDeploymentIds": [
+                "26f89691-3352-4789-8c69-20c988f25908",
+                "f1857b84-25b0-4c11-94e5-0605de3d947a"
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Connected"
+                        ]
+                    },
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        },
+                        "canBeDeployed": false,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "Connected"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Connected"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "8cc06214-f5b1-455d-b195-5a0769443edb",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "Primary"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            },
+            {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "f1857b84-25b0-4c11-94e5-0605de3d947a",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "Primary"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Primary",
+                            "Connected"
+                        ]
+                    },
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        },
+                        "canBeDeployed": false,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "Connected"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Connected"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "bcd819ad-be8c-41a3-a0e5-875abd7be1b7",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "Primary"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.Stop",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentStopped",
+                "aggregateId": "26f89691-3352-4789-8c69-20c988f25908",
+                "apiVersion": "1.1",
+                "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908"
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "26f89691-3352-4789-8c69-20c988f25908",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "8cc06214-f5b1-455d-b195-5a0769443edb",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null,
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    }
+]

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/createStudyDeployment_registers_preregistered_devices.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/createStudyDeployment_registers_preregistered_devices.json
@@ -4,10 +4,10 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
             "apiVersion": "1.3",
-            "id": "bd9f4116-7c3c-4653-9285-38710660a8af",
+            "id": "5f8b35d8-2d9e-45ae-87d4-62274b0fe325",
             "protocol": {
-                "id": "cc251597-c835-4120-b238-eca1df37eb9e",
-                "createdOn": "2024-10-09T08:17:33.754071Z",
+                "id": "0ef899d4-389b-4001-af50-bc7b50d28419",
+                "createdOn": "2024-10-23T13:28:04.937081Z",
                 "version": 0,
                 "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                 "name": "Test protocol",
@@ -34,7 +34,7 @@
             },
             "invitations": [
                 {
-                    "participantId": "5511bab5-4f93-458a-b51e-d468d9624468",
+                    "participantId": "d79806b7-c100-4617-ac26-75a958765d15",
                     "assignedRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -50,8 +50,8 @@
             "connectedDevicePreregistrations": {
                 "Connected": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.754108Z",
-                    "deviceId": "03baa630-74f7-4f7b-ab89-aea7b1fa5e2a"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.937108Z",
+                    "deviceId": "11ce9129-4d16-4c29-93e4-2e0ae1cb9a76"
                 }
             }
         },
@@ -59,12 +59,12 @@
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
-                "aggregateId": "bd9f4116-7c3c-4653-9285-38710660a8af",
+                "aggregateId": "5f8b35d8-2d9e-45ae-87d4-62274b0fe325",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "bd9f4116-7c3c-4653-9285-38710660a8af",
+                "studyDeploymentId": "5f8b35d8-2d9e-45ae-87d4-62274b0fe325",
                 "protocol": {
-                    "id": "cc251597-c835-4120-b238-eca1df37eb9e",
-                    "createdOn": "2024-10-09T08:17:33.754071Z",
+                    "id": "0ef899d4-389b-4001-af50-bc7b50d28419",
+                    "createdOn": "2024-10-23T13:28:04.937081Z",
                     "version": 0,
                     "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                     "name": "Test protocol",
@@ -91,7 +91,7 @@
                 },
                 "invitations": [
                     {
-                        "participantId": "5511bab5-4f93-458a-b51e-d468d9624468",
+                        "participantId": "d79806b7-c100-4617-ac26-75a958765d15",
                         "assignedRoles": {
                             "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                         },
@@ -107,8 +107,8 @@
                 "connectedDevicePreregistrations": {
                     "Connected": {
                         "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                        "registrationCreatedOn": "2024-10-09T08:17:33.754108Z",
-                        "deviceId": "03baa630-74f7-4f7b-ab89-aea7b1fa5e2a"
+                        "registrationCreatedOn": "2024-10-23T13:28:04.937108Z",
+                        "deviceId": "11ce9129-4d16-4c29-93e4-2e0ae1cb9a76"
                     }
                 }
             }
@@ -116,7 +116,7 @@
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "bd9f4116-7c3c-4653-9285-38710660a8af",
+            "studyDeploymentId": "5f8b35d8-2d9e-45ae-87d4-62274b0fe325",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -139,6 +139,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
                         "roleName": "Connected"
                     },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.937108Z",
+                        "deviceId": "11ce9129-4d16-4c29-93e4-2e0ae1cb9a76"
+                    },
                     "canBeDeployed": false,
                     "remainingDevicesToRegisterToObtainDeployment": [],
                     "remainingDevicesToRegisterBeforeDeployment": []
@@ -146,7 +151,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "5511bab5-4f93-458a-b51e-d468d9624468",
+                    "participantId": "d79806b7-c100-4617-ac26-75a958765d15",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -163,21 +168,21 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "bd9f4116-7c3c-4653-9285-38710660a8af",
+            "studyDeploymentId": "5f8b35d8-2d9e-45ae-87d4-62274b0fe325",
             "deviceRoleName": "Primary",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.754227Z",
-                "deviceId": "a7b167cb-77d6-4db3-8fc3-cc3d612c82de"
+                "registrationCreatedOn": "2024-10-23T13:28:04.937259Z",
+                "deviceId": "199d05be-5e67-4c68-8ec9-c55290841c9a"
             }
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "bd9f4116-7c3c-4653-9285-38710660a8af",
+                "aggregateId": "5f8b35d8-2d9e-45ae-87d4-62274b0fe325",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "bd9f4116-7c3c-4653-9285-38710660a8af",
+                "studyDeploymentId": "5f8b35d8-2d9e-45ae-87d4-62274b0fe325",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                     "isPrimaryDevice": true,
@@ -185,15 +190,15 @@
                 },
                 "registration": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.754227Z",
-                    "deviceId": "a7b167cb-77d6-4db3-8fc3-cc3d612c82de"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.937259Z",
+                    "deviceId": "199d05be-5e67-4c68-8ec9-c55290841c9a"
                 }
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "bd9f4116-7c3c-4653-9285-38710660a8af",
+            "studyDeploymentId": "5f8b35d8-2d9e-45ae-87d4-62274b0fe325",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -201,6 +206,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                         "isPrimaryDevice": true,
                         "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.937259Z",
+                        "deviceId": "199d05be-5e67-4c68-8ec9-c55290841c9a"
                     },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
@@ -212,6 +222,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
                         "roleName": "Connected"
                     },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.937108Z",
+                        "deviceId": "11ce9129-4d16-4c29-93e4-2e0ae1cb9a76"
+                    },
                     "canBeDeployed": false,
                     "remainingDevicesToRegisterToObtainDeployment": [],
                     "remainingDevicesToRegisterBeforeDeployment": []
@@ -219,7 +234,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "5511bab5-4f93-458a-b51e-d468d9624468",
+                    "participantId": "d79806b7-c100-4617-ac26-75a958765d15",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -236,7 +251,7 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
             "apiVersion": "1.3",
-            "studyDeploymentId": "bd9f4116-7c3c-4653-9285-38710660a8af",
+            "studyDeploymentId": "5f8b35d8-2d9e-45ae-87d4-62274b0fe325",
             "primaryDeviceRoleName": "Primary"
         },
         "precedingEvents": [],
@@ -249,8 +264,8 @@
             },
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.754227Z",
-                "deviceId": "a7b167cb-77d6-4db3-8fc3-cc3d612c82de"
+                "registrationCreatedOn": "2024-10-23T13:28:04.937259Z",
+                "deviceId": "199d05be-5e67-4c68-8ec9-c55290841c9a"
             },
             "connectedDevices": [
                 {
@@ -261,8 +276,8 @@
             "connectedDeviceRegistrations": {
                 "Connected": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.754108Z",
-                    "deviceId": "03baa630-74f7-4f7b-ab89-aea7b1fa5e2a"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.937108Z",
+                    "deviceId": "11ce9129-4d16-4c29-93e4-2e0ae1cb9a76"
                 }
             }
         }

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/getDeviceDeploymentFor_during_device_reregistrations.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/getDeviceDeploymentFor_during_device_reregistrations.json
@@ -4,10 +4,10 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
             "apiVersion": "1.3",
-            "id": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "id": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "protocol": {
-                "id": "5205551a-37a8-4a87-adfc-b246304a6c1a",
-                "createdOn": "2024-10-09T08:17:33.782260Z",
+                "id": "8ff57fa2-4a43-44fa-b540-cd5ef8d0faca",
+                "createdOn": "2024-10-23T13:28:04.973958Z",
                 "version": 0,
                 "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                 "name": "Test protocol",
@@ -22,7 +22,7 @@
             },
             "invitations": [
                 {
-                    "participantId": "8ba6c597-f2d2-4fc6-98e7-bce34e18ce8a",
+                    "participantId": "ee7b08a8-4aa2-4f4d-8800-e9e35e212fe4",
                     "assignedRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -40,12 +40,12 @@
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
-                "aggregateId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+                "aggregateId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+                "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
                 "protocol": {
-                    "id": "5205551a-37a8-4a87-adfc-b246304a6c1a",
-                    "createdOn": "2024-10-09T08:17:33.782260Z",
+                    "id": "8ff57fa2-4a43-44fa-b540-cd5ef8d0faca",
+                    "createdOn": "2024-10-23T13:28:04.973958Z",
                     "version": 0,
                     "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                     "name": "Test protocol",
@@ -60,7 +60,7 @@
                 },
                 "invitations": [
                     {
-                        "participantId": "8ba6c597-f2d2-4fc6-98e7-bce34e18ce8a",
+                        "participantId": "ee7b08a8-4aa2-4f4d-8800-e9e35e212fe4",
                         "assignedRoles": {
                             "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                         },
@@ -79,7 +79,7 @@
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -99,7 +99,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "8ba6c597-f2d2-4fc6-98e7-bce34e18ce8a",
+                    "participantId": "ee7b08a8-4aa2-4f4d-8800-e9e35e212fe4",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -116,21 +116,21 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "deviceRoleName": "Test device",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.783526Z",
-                "deviceId": "c5cf6146-d748-46ce-9354-660d37a2c6eb"
+                "registrationCreatedOn": "2024-10-23T13:28:04.974525Z",
+                "deviceId": "9357517d-7d91-426b-97fb-a558a1e67814"
             }
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+                "aggregateId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+                "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                     "isPrimaryDevice": true,
@@ -138,15 +138,15 @@
                 },
                 "registration": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.783526Z",
-                    "deviceId": "c5cf6146-d748-46ce-9354-660d37a2c6eb"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.974525Z",
+                    "deviceId": "9357517d-7d91-426b-97fb-a558a1e67814"
                 }
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -155,6 +155,11 @@
                         "isPrimaryDevice": true,
                         "roleName": "Test device"
                     },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.974525Z",
+                        "deviceId": "9357517d-7d91-426b-97fb-a558a1e67814"
+                    },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
                     "remainingDevicesToRegisterBeforeDeployment": []
@@ -162,7 +167,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "8ba6c597-f2d2-4fc6-98e7-bce34e18ce8a",
+                    "participantId": "ee7b08a8-4aa2-4f4d-8800-e9e35e212fe4",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -179,7 +184,7 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
             "apiVersion": "1.3",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "primaryDeviceRoleName": "Test device"
         },
         "precedingEvents": [],
@@ -192,8 +197,8 @@
             },
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.783526Z",
-                "deviceId": "c5cf6146-d748-46ce-9354-660d37a2c6eb"
+                "registrationCreatedOn": "2024-10-23T13:28:04.974525Z",
+                "deviceId": "9357517d-7d91-426b-97fb-a558a1e67814"
             }
         }
     },
@@ -202,16 +207,16 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.UnregisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "deviceRoleName": "Test device"
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+                "aggregateId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+                "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                     "isPrimaryDevice": true,
@@ -223,7 +228,7 @@
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -243,7 +248,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "8ba6c597-f2d2-4fc6-98e7-bce34e18ce8a",
+                    "participantId": "ee7b08a8-4aa2-4f4d-8800-e9e35e212fe4",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -260,7 +265,7 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
             "apiVersion": "1.3",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "primaryDeviceRoleName": "Test device"
         },
         "precedingEvents": [],
@@ -272,21 +277,21 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "deviceRoleName": "Test device",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.784020Z",
-                "deviceId": "7aa81293-dec8-4816-a1a8-2c687c01042c"
+                "registrationCreatedOn": "2024-10-23T13:28:04.974960Z",
+                "deviceId": "89b4ad43-071d-4b4f-8ad0-cda4fa40334d"
             }
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+                "aggregateId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+                "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                     "isPrimaryDevice": true,
@@ -294,15 +299,15 @@
                 },
                 "registration": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.784020Z",
-                    "deviceId": "7aa81293-dec8-4816-a1a8-2c687c01042c"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.974960Z",
+                    "deviceId": "89b4ad43-071d-4b4f-8ad0-cda4fa40334d"
                 }
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -311,6 +316,11 @@
                         "isPrimaryDevice": true,
                         "roleName": "Test device"
                     },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.974960Z",
+                        "deviceId": "89b4ad43-071d-4b4f-8ad0-cda4fa40334d"
+                    },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
                     "remainingDevicesToRegisterBeforeDeployment": []
@@ -318,7 +328,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "8ba6c597-f2d2-4fc6-98e7-bce34e18ce8a",
+                    "participantId": "ee7b08a8-4aa2-4f4d-8800-e9e35e212fe4",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -335,7 +345,7 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
             "apiVersion": "1.3",
-            "studyDeploymentId": "c58edc1e-c451-483b-9552-7b455ed2e0a6",
+            "studyDeploymentId": "5e25307a-98c1-44df-ac6b-338dd70ba0c0",
             "primaryDeviceRoleName": "Test device"
         },
         "precedingEvents": [],
@@ -348,8 +358,8 @@
             },
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.784020Z",
-                "deviceId": "7aa81293-dec8-4816-a1a8-2c687c01042c"
+                "registrationCreatedOn": "2024-10-23T13:28:04.974960Z",
+                "deviceId": "89b4ad43-071d-4b4f-8ad0-cda4fa40334d"
             }
         }
     }

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/getStudyDeploymentStatusList_full_flow_succeeds.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/getStudyDeploymentStatusList_full_flow_succeeds.json
@@ -1,0 +1,425 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.3",
+            "id": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "protocol": {
+                "id": "5863e233-d0cf-498d-8b68-9bd2f0d111ff",
+                "createdOn": "2025-07-22T10:38:00.053808Z",
+                "version": 0,
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "c4ba2ada-dbc6-42fe-8c7a-69d85a13179d",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "User"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+                "apiVersion": "1.3",
+                "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+                "protocol": {
+                    "id": "5863e233-d0cf-498d-8b68-9bd2f0d111ff",
+                    "createdOn": "2025-07-22T10:38:00.053808Z",
+                    "version": 0,
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "c4ba2ada-dbc6-42fe-8c7a-69d85a13179d",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "User"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {}
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "c4ba2ada-dbc6-42fe-8c7a-69d85a13179d",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
+            "apiVersion": "1.3",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "c4ba2ada-dbc6-42fe-8c7a-69d85a13179d",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
+            "apiVersion": "1.3",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "deviceRoleName": "Primary",
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "registrationCreatedOn": "2025-07-22T10:38:00.053935Z",
+                "deviceId": "17fb190b-caba-4edc-a865-a465c1f76504"
+            }
+        },
+        "precedingEvents": [],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+                "apiVersion": "1.3",
+                "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Primary"
+                },
+                "registration": {
+                    "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                    "registrationCreatedOn": "2025-07-22T10:38:00.053935Z",
+                    "deviceId": "17fb190b-caba-4edc-a865-a465c1f76504"
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2025-07-22T10:38:00.053935Z",
+                        "deviceId": "17fb190b-caba-4edc-a865-a465c1f76504"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [],
+                    "remainingDevicesToRegisterBeforeDeployment": []
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "c4ba2ada-dbc6-42fe-8c7a-69d85a13179d",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
+            "apiVersion": "1.3",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "primaryDeviceRoleName": "Primary"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "deviceConfiguration": {
+                "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                "isPrimaryDevice": true,
+                "roleName": "Primary"
+            },
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "registrationCreatedOn": "2025-07-22T10:38:00.053935Z",
+                "deviceId": "17fb190b-caba-4edc-a865-a465c1f76504"
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.DeviceDeployed",
+            "apiVersion": "1.3",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "primaryDeviceRoleName": "Primary",
+            "deviceDeploymentLastUpdatedOn": "2025-07-22T10:38:00.053935Z"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Running",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Deployed",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2025-07-22T10:38:00.053935Z",
+                        "deviceId": "17fb190b-caba-4edc-a865-a465c1f76504"
+                    }
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "c4ba2ada-dbc6-42fe-8c7a-69d85a13179d",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.UnregisterDevice",
+            "apiVersion": "1.3",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "deviceRoleName": "Primary"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+                "apiVersion": "1.3",
+                "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Primary"
+                },
+                "registration": null
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "c4ba2ada-dbc6-42fe-8c7a-69d85a13179d",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.Stop",
+            "apiVersion": "1.3",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentStopped",
+                "aggregateId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+                "apiVersion": "1.3",
+                "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5"
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "c4ba2ada-dbc6-42fe-8c7a-69d85a13179d",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": "1970-01-01T00:00:00Z",
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RemoveStudyDeployments",
+            "apiVersion": "1.3",
+            "studyDeploymentIds": [
+                "4292a086-0158-4dc9-96c6-269d1f4301a5"
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentRemoved",
+                "aggregateId": "4292a086-0158-4dc9-96c6-269d1f4301a5",
+                "apiVersion": "1.3",
+                "studyDeploymentId": "4292a086-0158-4dc9-96c6-269d1f4301a5"
+            }
+        ],
+        "response": [
+            "4292a086-0158-4dc9-96c6-269d1f4301a5"
+        ]
+    }
+]

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/getStudyDeploymentStatusList_with_multiple_deployments_succeeds.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/getStudyDeploymentStatusList_with_multiple_deployments_succeeds.json
@@ -1,0 +1,631 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.3",
+            "id": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+            "protocol": {
+                "id": "b1169f80-ec6e-46db-a4ef-f89533770a01",
+                "createdOn": "2025-07-22T10:38:00.067457Z",
+                "version": 0,
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                ],
+                "connectedDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    }
+                ],
+                "connections": [
+                    {
+                        "roleName": "Connected",
+                        "connectedToRoleName": "Primary"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "ebe10676-582f-41ec-a0ef-05dcf2b4d4df",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "User 1"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+                "apiVersion": "1.3",
+                "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+                "protocol": {
+                    "id": "b1169f80-ec6e-46db-a4ef-f89533770a01",
+                    "createdOn": "2025-07-22T10:38:00.067457Z",
+                    "version": 0,
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        }
+                    ],
+                    "connectedDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        }
+                    ],
+                    "connections": [
+                        {
+                            "roleName": "Connected",
+                            "connectedToRoleName": "Primary"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "ebe10676-582f-41ec-a0ef-05dcf2b4d4df",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "User 1"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {}
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary",
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "ebe10676-582f-41ec-a0ef-05dcf2b4d4df",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
+            "apiVersion": "1.3",
+            "id": "ee55a7de-69f8-45b3-a7f5-1d46cfc568c5",
+            "protocol": {
+                "id": "b1169f80-ec6e-46db-a4ef-f89533770a01",
+                "createdOn": "2025-07-22T10:38:00.067457Z",
+                "version": 0,
+                "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                "name": "Test protocol",
+                "description": "Test description",
+                "primaryDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    }
+                ],
+                "connectedDevices": [
+                    {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    }
+                ],
+                "connections": [
+                    {
+                        "roleName": "Connected",
+                        "connectedToRoleName": "Primary"
+                    }
+                ]
+            },
+            "invitations": [
+                {
+                    "participantId": "0db21a6c-268f-40d5-b040-1d6a603c1351",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "identity": {
+                        "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                        "username": "User 2"
+                    },
+                    "invitation": {
+                        "name": "Some study"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
+                "aggregateId": "ee55a7de-69f8-45b3-a7f5-1d46cfc568c5",
+                "apiVersion": "1.3",
+                "studyDeploymentId": "ee55a7de-69f8-45b3-a7f5-1d46cfc568c5",
+                "protocol": {
+                    "id": "b1169f80-ec6e-46db-a4ef-f89533770a01",
+                    "createdOn": "2025-07-22T10:38:00.067457Z",
+                    "version": 0,
+                    "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
+                    "name": "Test protocol",
+                    "description": "Test description",
+                    "primaryDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        }
+                    ],
+                    "connectedDevices": [
+                        {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        }
+                    ],
+                    "connections": [
+                        {
+                            "roleName": "Connected",
+                            "connectedToRoleName": "Primary"
+                        }
+                    ]
+                },
+                "invitations": [
+                    {
+                        "participantId": "0db21a6c-268f-40d5-b040-1d6a603c1351",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "identity": {
+                            "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                            "username": "User 2"
+                        },
+                        "invitation": {
+                            "name": "Some study"
+                        }
+                    }
+                ],
+                "connectedDevicePreregistrations": {}
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "ee55a7de-69f8-45b3-a7f5-1d46cfc568c5",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary",
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "0db21a6c-268f-40d5-b040-1d6a603c1351",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
+            "apiVersion": "1.3",
+            "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Primary"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Primary",
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "ebe10676-582f-41ec-a0ef-05dcf2b4d4df",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
+            "apiVersion": "1.3",
+            "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+            "deviceRoleName": "Primary",
+            "registration": {
+                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                "registrationCreatedOn": "2025-07-22T10:38:00.072743Z",
+                "deviceId": "ca38e257-454c-48a3-8bf1-7eec1a4711ad"
+            }
+        },
+        "precedingEvents": [],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
+                "aggregateId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+                "apiVersion": "1.3",
+                "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+                "device": {
+                    "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                    "isPrimaryDevice": true,
+                    "roleName": "Primary"
+                },
+                "registration": {
+                    "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                    "registrationCreatedOn": "2025-07-22T10:38:00.072743Z",
+                    "deviceId": "ca38e257-454c-48a3-8bf1-7eec1a4711ad"
+                }
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2025-07-22T10:38:00.072743Z",
+                        "deviceId": "ca38e257-454c-48a3-8bf1-7eec1a4711ad"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "ebe10676-582f-41ec-a0ef-05dcf2b4d4df",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatusList",
+            "apiVersion": "1.3",
+            "studyDeploymentIds": [
+                "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+                "ee55a7de-69f8-45b3-a7f5-1d46cfc568c5"
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        },
+                        "deviceRegistration": {
+                            "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                            "registrationCreatedOn": "2025-07-22T10:38:00.072743Z",
+                            "deviceId": "ca38e257-454c-48a3-8bf1-7eec1a4711ad"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Connected"
+                        ]
+                    },
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        },
+                        "canBeDeployed": false,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "Connected"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Connected"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "ebe10676-582f-41ec-a0ef-05dcf2b4d4df",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "Primary"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            },
+            {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "ee55a7de-69f8-45b3-a7f5-1d46cfc568c5",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                            "isPrimaryDevice": true,
+                            "roleName": "Primary"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "Primary"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Primary",
+                            "Connected"
+                        ]
+                    },
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                            "roleName": "Connected"
+                        },
+                        "canBeDeployed": false,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "Connected"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "Connected"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "0db21a6c-268f-40d5-b040-1d6a603c1351",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "Primary"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.Stop",
+            "apiVersion": "1.3",
+            "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [
+            {
+                "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentStopped",
+                "aggregateId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+                "apiVersion": "1.3",
+                "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928"
+            }
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+            "createdOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentId": "40cf0c6c-8034-4fd0-b985-1d0ee7e0c928",
+            "deviceStatusList": [
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
+                        "isPrimaryDevice": true,
+                        "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2025-07-22T10:38:00.072743Z",
+                        "deviceId": "ca38e257-454c-48a3-8bf1-7eec1a4711ad"
+                    },
+                    "canBeDeployed": true,
+                    "remainingDevicesToRegisterToObtainDeployment": [],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                },
+                {
+                    "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                    "device": {
+                        "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
+                        "roleName": "Connected"
+                    },
+                    "canBeDeployed": false,
+                    "remainingDevicesToRegisterToObtainDeployment": [
+                        "Connected"
+                    ],
+                    "remainingDevicesToRegisterBeforeDeployment": [
+                        "Connected"
+                    ]
+                }
+            ],
+            "participantStatusList": [
+                {
+                    "participantId": "ebe10676-582f-41ec-a0ef-05dcf2b4d4df",
+                    "assignedParticipantRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    },
+                    "assignedPrimaryDeviceRoleNames": [
+                        "Primary"
+                    ]
+                }
+            ],
+            "startedOn": null,
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    }
+]

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/modifications_after_stop_not_allowed.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/modifications_after_stop_not_allowed.json
@@ -4,10 +4,10 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
             "apiVersion": "1.3",
-            "id": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "id": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "protocol": {
-                "id": "c5724080-e5ec-4366-a9e4-281203369ab5",
-                "createdOn": "2024-10-09T08:17:33.804237Z",
+                "id": "f8077775-b1a2-411f-943c-66269ce2f569",
+                "createdOn": "2024-10-23T13:28:04.991855Z",
                 "version": 0,
                 "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                 "name": "Test protocol",
@@ -34,7 +34,7 @@
             },
             "invitations": [
                 {
-                    "participantId": "08ea7dca-bb45-446d-b464-4f92d9408e55",
+                    "participantId": "28b5e14f-67d0-4cf3-b901-8ba1a3165f69",
                     "assignedRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -52,12 +52,12 @@
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
-                "aggregateId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+                "aggregateId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+                "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
                 "protocol": {
-                    "id": "c5724080-e5ec-4366-a9e4-281203369ab5",
-                    "createdOn": "2024-10-09T08:17:33.804237Z",
+                    "id": "f8077775-b1a2-411f-943c-66269ce2f569",
+                    "createdOn": "2024-10-23T13:28:04.991855Z",
                     "version": 0,
                     "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                     "name": "Test protocol",
@@ -84,7 +84,7 @@
                 },
                 "invitations": [
                     {
-                        "participantId": "08ea7dca-bb45-446d-b464-4f92d9408e55",
+                        "participantId": "28b5e14f-67d0-4cf3-b901-8ba1a3165f69",
                         "assignedRoles": {
                             "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                         },
@@ -103,7 +103,7 @@
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -138,7 +138,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "08ea7dca-bb45-446d-b464-4f92d9408e55",
+                    "participantId": "28b5e14f-67d0-4cf3-b901-8ba1a3165f69",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -155,14 +155,14 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
             "apiVersion": "1.3",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14"
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7"
         },
         "precedingEvents": [],
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -197,7 +197,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "08ea7dca-bb45-446d-b464-4f92d9408e55",
+                    "participantId": "28b5e14f-67d0-4cf3-b901-8ba1a3165f69",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -214,21 +214,21 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "deviceRoleName": "Primary",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.804445Z",
-                "deviceId": "01c6bda0-9c68-45e9-a924-687df9a27f4c"
+                "registrationCreatedOn": "2024-10-23T13:28:04.992045Z",
+                "deviceId": "495cfa02-72d4-451c-974a-c53268ebb7a9"
             }
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+                "aggregateId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+                "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                     "isPrimaryDevice": true,
@@ -236,15 +236,15 @@
                 },
                 "registration": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.804445Z",
-                    "deviceId": "01c6bda0-9c68-45e9-a924-687df9a27f4c"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.992045Z",
+                    "deviceId": "495cfa02-72d4-451c-974a-c53268ebb7a9"
                 }
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -252,6 +252,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                         "isPrimaryDevice": true,
                         "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.992045Z",
+                        "deviceId": "495cfa02-72d4-451c-974a-c53268ebb7a9"
                     },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
@@ -276,7 +281,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "08ea7dca-bb45-446d-b464-4f92d9408e55",
+                    "participantId": "28b5e14f-67d0-4cf3-b901-8ba1a3165f69",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -293,36 +298,36 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "deviceRoleName": "Connected",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.804598Z",
-                "deviceId": "38bb9e8b-2303-46bb-aa33-3a8cb1cd03bb"
+                "registrationCreatedOn": "2024-10-23T13:28:04.992104Z",
+                "deviceId": "cabea3df-845e-43e4-926b-be8d32792815"
             }
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+                "aggregateId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+                "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
                     "roleName": "Connected"
                 },
                 "registration": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.804598Z",
-                    "deviceId": "38bb9e8b-2303-46bb-aa33-3a8cb1cd03bb"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.992104Z",
+                    "deviceId": "cabea3df-845e-43e4-926b-be8d32792815"
                 }
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -330,6 +335,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                         "isPrimaryDevice": true,
                         "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.992045Z",
+                        "deviceId": "495cfa02-72d4-451c-974a-c53268ebb7a9"
                     },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
@@ -341,6 +351,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
                         "roleName": "Connected"
                     },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.992104Z",
+                        "deviceId": "cabea3df-845e-43e4-926b-be8d32792815"
+                    },
                     "canBeDeployed": false,
                     "remainingDevicesToRegisterToObtainDeployment": [],
                     "remainingDevicesToRegisterBeforeDeployment": []
@@ -348,7 +363,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "08ea7dca-bb45-446d-b464-4f92d9408e55",
+                    "participantId": "28b5e14f-67d0-4cf3-b901-8ba1a3165f69",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -365,21 +380,21 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.Stop",
             "apiVersion": "1.3",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14"
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7"
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentStopped",
-                "aggregateId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+                "aggregateId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14"
+                "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7"
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -387,6 +402,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                         "isPrimaryDevice": true,
                         "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.992045Z",
+                        "deviceId": "495cfa02-72d4-451c-974a-c53268ebb7a9"
                     },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
@@ -398,6 +418,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration",
                         "roleName": "Connected"
                     },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.992104Z",
+                        "deviceId": "cabea3df-845e-43e4-926b-be8d32792815"
+                    },
                     "canBeDeployed": false,
                     "remainingDevicesToRegisterToObtainDeployment": [],
                     "remainingDevicesToRegisterBeforeDeployment": []
@@ -405,7 +430,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "08ea7dca-bb45-446d-b464-4f92d9408e55",
+                    "participantId": "28b5e14f-67d0-4cf3-b901-8ba1a3165f69",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -423,12 +448,12 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "deviceRoleName": "Connected",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.804735Z",
-                "deviceId": "b3736803-d27e-42a3-8c91-10175b76abb4"
+                "registrationCreatedOn": "2024-10-23T13:28:04.992191Z",
+                "deviceId": "4b9cd54e-e1e1-4443-859c-fe6855919d95"
             }
         },
         "precedingEvents": [],
@@ -440,7 +465,7 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.UnregisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "deviceRoleName": "Primary"
         },
         "precedingEvents": [],
@@ -452,7 +477,7 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetDeviceDeploymentFor",
             "apiVersion": "1.3",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "primaryDeviceRoleName": "Primary"
         },
         "precedingEvents": [],
@@ -465,8 +490,8 @@
             },
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.804445Z",
-                "deviceId": "01c6bda0-9c68-45e9-a924-687df9a27f4c"
+                "registrationCreatedOn": "2024-10-23T13:28:04.992045Z",
+                "deviceId": "495cfa02-72d4-451c-974a-c53268ebb7a9"
             },
             "connectedDevices": [
                 {
@@ -477,8 +502,8 @@
             "connectedDeviceRegistrations": {
                 "Connected": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.804598Z",
-                    "deviceId": "38bb9e8b-2303-46bb-aa33-3a8cb1cd03bb"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.992104Z",
+                    "deviceId": "cabea3df-845e-43e4-926b-be8d32792815"
                 }
             }
         }
@@ -488,9 +513,9 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.DeviceDeployed",
             "apiVersion": "1.3",
-            "studyDeploymentId": "fa0ae217-904a-4a9f-b28a-ae9c9dd68f14",
+            "studyDeploymentId": "c92146bf-fd35-4b9b-86d1-72d9cec344e7",
             "primaryDeviceRoleName": "Primary",
-            "deviceDeploymentLastUpdatedOn": "2024-10-09T08:17:33.804598Z"
+            "deviceDeploymentLastUpdatedOn": "2024-10-23T13:28:04.992104Z"
         },
         "precedingEvents": [],
         "publishedEvents": [],

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/registerDevice_can_be_called_multiple_times.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/registerDevice_can_be_called_multiple_times.json
@@ -4,10 +4,10 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
             "apiVersion": "1.3",
-            "id": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+            "id": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
             "protocol": {
-                "id": "0d8f8e63-63c5-45af-b83f-3d75d5807eeb",
-                "createdOn": "2024-10-09T08:17:33.814534Z",
+                "id": "4a379a94-5063-425b-baec-e25959031131",
+                "createdOn": "2024-10-23T13:28:05.000594Z",
                 "version": 0,
                 "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                 "name": "Test protocol",
@@ -34,7 +34,7 @@
             },
             "invitations": [
                 {
-                    "participantId": "bb31c185-6b47-4a81-92a0-ea802ead5032",
+                    "participantId": "331b8f8d-0e87-46f9-8683-e66462dfa41d",
                     "assignedRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -52,12 +52,12 @@
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
-                "aggregateId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+                "aggregateId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+                "studyDeploymentId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
                 "protocol": {
-                    "id": "0d8f8e63-63c5-45af-b83f-3d75d5807eeb",
-                    "createdOn": "2024-10-09T08:17:33.814534Z",
+                    "id": "4a379a94-5063-425b-baec-e25959031131",
+                    "createdOn": "2024-10-23T13:28:05.000594Z",
                     "version": 0,
                     "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                     "name": "Test protocol",
@@ -84,7 +84,7 @@
                 },
                 "invitations": [
                     {
-                        "participantId": "bb31c185-6b47-4a81-92a0-ea802ead5032",
+                        "participantId": "331b8f8d-0e87-46f9-8683-e66462dfa41d",
                         "assignedRoles": {
                             "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                         },
@@ -103,7 +103,7 @@
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+            "studyDeploymentId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -138,7 +138,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "bb31c185-6b47-4a81-92a0-ea802ead5032",
+                    "participantId": "331b8f8d-0e87-46f9-8683-e66462dfa41d",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -155,14 +155,14 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
             "apiVersion": "1.3",
-            "studyDeploymentId": "f235ad9c-66f2-4245-bcb3-8b2985eae777"
+            "studyDeploymentId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a"
         },
         "precedingEvents": [],
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+            "studyDeploymentId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -197,7 +197,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "bb31c185-6b47-4a81-92a0-ea802ead5032",
+                    "participantId": "331b8f8d-0e87-46f9-8683-e66462dfa41d",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -214,21 +214,21 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+            "studyDeploymentId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
             "deviceRoleName": "Primary",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.814753Z",
-                "deviceId": "115ada23-3643-4a81-b2c5-20c53b70af32"
+                "registrationCreatedOn": "2024-10-23T13:28:05.000734Z",
+                "deviceId": "9edb801b-a09a-46f4-9517-654b3c6dc163"
             }
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+                "aggregateId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+                "studyDeploymentId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                     "isPrimaryDevice": true,
@@ -236,15 +236,15 @@
                 },
                 "registration": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.814753Z",
-                    "deviceId": "115ada23-3643-4a81-b2c5-20c53b70af32"
+                    "registrationCreatedOn": "2024-10-23T13:28:05.000734Z",
+                    "deviceId": "9edb801b-a09a-46f4-9517-654b3c6dc163"
                 }
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+            "studyDeploymentId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -252,6 +252,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                         "isPrimaryDevice": true,
                         "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:05.000734Z",
+                        "deviceId": "9edb801b-a09a-46f4-9517-654b3c6dc163"
                     },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
@@ -276,7 +281,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "bb31c185-6b47-4a81-92a0-ea802ead5032",
+                    "participantId": "331b8f8d-0e87-46f9-8683-e66462dfa41d",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -293,12 +298,12 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+            "studyDeploymentId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
             "deviceRoleName": "Primary",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.814753Z",
-                "deviceId": "115ada23-3643-4a81-b2c5-20c53b70af32"
+                "registrationCreatedOn": "2024-10-23T13:28:05.000734Z",
+                "deviceId": "9edb801b-a09a-46f4-9517-654b3c6dc163"
             }
         },
         "precedingEvents": [],
@@ -306,7 +311,7 @@
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "f235ad9c-66f2-4245-bcb3-8b2985eae777",
+            "studyDeploymentId": "8510e14f-c6f3-4ac8-84da-8e1f5290cc1a",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -314,6 +319,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                         "isPrimaryDevice": true,
                         "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:05.000734Z",
+                        "deviceId": "9edb801b-a09a-46f4-9517-654b3c6dc163"
                     },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
@@ -338,7 +348,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "bb31c185-6b47-4a81-92a0-ea802ead5032",
+                    "participantId": "331b8f8d-0e87-46f9-8683-e66462dfa41d",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/registerDevice_cannot_be_called_with_same_registration_when_stopped.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/registerDevice_cannot_be_called_with_same_registration_when_stopped.json
@@ -4,10 +4,10 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
             "apiVersion": "1.3",
-            "id": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+            "id": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
             "protocol": {
-                "id": "9e062dc6-1dcc-4a9e-b6c2-0ce9bd019302",
-                "createdOn": "2024-10-09T08:17:33.769601Z",
+                "id": "ae2e7cc1-2e9f-4fb0-a6ca-36033eff7af4",
+                "createdOn": "2024-10-23T13:28:04.953112Z",
                 "version": 0,
                 "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                 "name": "Test protocol",
@@ -34,7 +34,7 @@
             },
             "invitations": [
                 {
-                    "participantId": "e600986f-bca0-43c3-b59d-5c1c66adcd62",
+                    "participantId": "094908ed-aa9e-4c01-956f-34bd303d9e9e",
                     "assignedRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -52,12 +52,12 @@
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
-                "aggregateId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+                "aggregateId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+                "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
                 "protocol": {
-                    "id": "9e062dc6-1dcc-4a9e-b6c2-0ce9bd019302",
-                    "createdOn": "2024-10-09T08:17:33.769601Z",
+                    "id": "ae2e7cc1-2e9f-4fb0-a6ca-36033eff7af4",
+                    "createdOn": "2024-10-23T13:28:04.953112Z",
                     "version": 0,
                     "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                     "name": "Test protocol",
@@ -84,7 +84,7 @@
                 },
                 "invitations": [
                     {
-                        "participantId": "e600986f-bca0-43c3-b59d-5c1c66adcd62",
+                        "participantId": "094908ed-aa9e-4c01-956f-34bd303d9e9e",
                         "assignedRoles": {
                             "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                         },
@@ -103,7 +103,7 @@
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+            "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -138,7 +138,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "e600986f-bca0-43c3-b59d-5c1c66adcd62",
+                    "participantId": "094908ed-aa9e-4c01-956f-34bd303d9e9e",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -155,14 +155,14 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
             "apiVersion": "1.3",
-            "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b"
+            "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd"
         },
         "precedingEvents": [],
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+            "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -197,7 +197,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "e600986f-bca0-43c3-b59d-5c1c66adcd62",
+                    "participantId": "094908ed-aa9e-4c01-956f-34bd303d9e9e",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -214,21 +214,21 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+            "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
             "deviceRoleName": "Primary",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.769796Z",
-                "deviceId": "4ad851e6-550e-4b45-92d1-ed8bb6cc3025"
+                "registrationCreatedOn": "2024-10-23T13:28:04.953329Z",
+                "deviceId": "fce7c813-4103-4ac8-974d-df6acda867df"
             }
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+                "aggregateId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+                "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                     "isPrimaryDevice": true,
@@ -236,15 +236,15 @@
                 },
                 "registration": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.769796Z",
-                    "deviceId": "4ad851e6-550e-4b45-92d1-ed8bb6cc3025"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.953329Z",
+                    "deviceId": "fce7c813-4103-4ac8-974d-df6acda867df"
                 }
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+            "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -252,6 +252,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                         "isPrimaryDevice": true,
                         "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.953329Z",
+                        "deviceId": "fce7c813-4103-4ac8-974d-df6acda867df"
                     },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
@@ -276,7 +281,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "e600986f-bca0-43c3-b59d-5c1c66adcd62",
+                    "participantId": "094908ed-aa9e-4c01-956f-34bd303d9e9e",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -293,21 +298,21 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.Stop",
             "apiVersion": "1.3",
-            "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b"
+            "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd"
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentStopped",
-                "aggregateId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+                "aggregateId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b"
+                "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd"
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+            "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -315,6 +320,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                         "isPrimaryDevice": true,
                         "roleName": "Primary"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.953329Z",
+                        "deviceId": "fce7c813-4103-4ac8-974d-df6acda867df"
                     },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
@@ -339,7 +349,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "e600986f-bca0-43c3-b59d-5c1c66adcd62",
+                    "participantId": "094908ed-aa9e-4c01-956f-34bd303d9e9e",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -357,12 +367,12 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "371dbdd3-3913-4ee3-a300-e7e7639a7d0b",
+            "studyDeploymentId": "c2e773a1-bb22-4340-bd39-2fcef2cceebd",
             "deviceRoleName": "Primary",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.769796Z",
-                "deviceId": "4ad851e6-550e-4b45-92d1-ed8bb6cc3025"
+                "registrationCreatedOn": "2024-10-23T13:28:04.953329Z",
+                "deviceId": "fce7c813-4103-4ac8-974d-df6acda867df"
             }
         },
         "precedingEvents": [],

--- a/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/unregisterDevice_succeeds.json
+++ b/carp.deployments.core/src/commonTest/resources/test-requests/DeploymentService/1.3/DeploymentServiceTest/unregisterDevice_succeeds.json
@@ -4,10 +4,10 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.CreateStudyDeployment",
             "apiVersion": "1.3",
-            "id": "911fd544-135f-49f0-8998-377b1307b70f",
+            "id": "d70a1936-9230-4537-a849-4b6cf9c6f279",
             "protocol": {
-                "id": "1721c856-0087-433b-a719-a8ada7641802",
-                "createdOn": "2024-10-09T08:17:33.778003Z",
+                "id": "c8bafd50-7ea2-4a73-998d-ca1b80cd5e8d",
+                "createdOn": "2024-10-23T13:28:04.968044Z",
                 "version": 0,
                 "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                 "name": "Test protocol",
@@ -34,7 +34,7 @@
             },
             "invitations": [
                 {
-                    "participantId": "c8b447cf-a7ca-4b6c-bdd2-61ada806f849",
+                    "participantId": "d3e49de4-e760-4c70-b9f6-27aaaf7a6246",
                     "assignedRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -52,12 +52,12 @@
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.StudyDeploymentCreated",
-                "aggregateId": "911fd544-135f-49f0-8998-377b1307b70f",
+                "aggregateId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f",
+                "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
                 "protocol": {
-                    "id": "1721c856-0087-433b-a719-a8ada7641802",
-                    "createdOn": "2024-10-09T08:17:33.778003Z",
+                    "id": "c8bafd50-7ea2-4a73-998d-ca1b80cd5e8d",
+                    "createdOn": "2024-10-23T13:28:04.968044Z",
                     "version": 0,
                     "ownerId": "27879e75-ccc1-4866-9ab3-4ece1b735052",
                     "name": "Test protocol",
@@ -84,7 +84,7 @@
                 },
                 "invitations": [
                     {
-                        "participantId": "c8b447cf-a7ca-4b6c-bdd2-61ada806f849",
+                        "participantId": "d3e49de4-e760-4c70-b9f6-27aaaf7a6246",
                         "assignedRoles": {
                             "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                         },
@@ -103,7 +103,7 @@
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f",
+            "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -138,7 +138,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "c8b447cf-a7ca-4b6c-bdd2-61ada806f849",
+                    "participantId": "d3e49de4-e760-4c70-b9f6-27aaaf7a6246",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -155,14 +155,14 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.GetStudyDeploymentStatus",
             "apiVersion": "1.3",
-            "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f"
+            "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279"
         },
         "precedingEvents": [],
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f",
+            "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -197,7 +197,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "c8b447cf-a7ca-4b6c-bdd2-61ada806f849",
+                    "participantId": "d3e49de4-e760-4c70-b9f6-27aaaf7a6246",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -214,21 +214,21 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.RegisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f",
+            "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
             "deviceRoleName": "Test device",
             "registration": {
                 "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                "registrationCreatedOn": "2024-10-09T08:17:33.778267Z",
-                "deviceId": "a43533e7-58fb-4b5b-bed1-312ec0cc0d49"
+                "registrationCreatedOn": "2024-10-23T13:28:04.968882Z",
+                "deviceId": "42bc556e-e337-47de-8b6a-3e5ed76c63f1"
             }
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "911fd544-135f-49f0-8998-377b1307b70f",
+                "aggregateId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f",
+                "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                     "isPrimaryDevice": true,
@@ -236,15 +236,15 @@
                 },
                 "registration": {
                     "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
-                    "registrationCreatedOn": "2024-10-09T08:17:33.778267Z",
-                    "deviceId": "a43533e7-58fb-4b5b-bed1-312ec0cc0d49"
+                    "registrationCreatedOn": "2024-10-23T13:28:04.968882Z",
+                    "deviceId": "42bc556e-e337-47de-8b6a-3e5ed76c63f1"
                 }
             }
         ],
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f",
+            "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
@@ -252,6 +252,11 @@
                         "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                         "isPrimaryDevice": true,
                         "roleName": "Test device"
+                    },
+                    "deviceRegistration": {
+                        "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                        "registrationCreatedOn": "2024-10-23T13:28:04.968882Z",
+                        "deviceId": "42bc556e-e337-47de-8b6a-3e5ed76c63f1"
                     },
                     "canBeDeployed": true,
                     "remainingDevicesToRegisterToObtainDeployment": [],
@@ -276,7 +281,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "c8b447cf-a7ca-4b6c-bdd2-61ada806f849",
+                    "participantId": "d3e49de4-e760-4c70-b9f6-27aaaf7a6246",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },
@@ -293,16 +298,16 @@
         "request": {
             "__type": "dk.cachet.carp.deployments.infrastructure.DeploymentServiceRequest.UnregisterDevice",
             "apiVersion": "1.3",
-            "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f",
+            "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
             "deviceRoleName": "Test device"
         },
         "precedingEvents": [],
         "publishedEvents": [
             {
                 "__type": "dk.cachet.carp.deployments.application.DeploymentService.Event.DeviceRegistrationChanged",
-                "aggregateId": "911fd544-135f-49f0-8998-377b1307b70f",
+                "aggregateId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
                 "apiVersion": "1.3",
-                "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f",
+                "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
                 "device": {
                     "__type": "dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration",
                     "isPrimaryDevice": true,
@@ -314,7 +319,7 @@
         "response": {
             "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
             "createdOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentId": "911fd544-135f-49f0-8998-377b1307b70f",
+            "studyDeploymentId": "d70a1936-9230-4537-a849-4b6cf9c6f279",
             "deviceStatusList": [
                 {
                     "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -349,7 +354,7 @@
             ],
             "participantStatusList": [
                 {
-                    "participantId": "c8b447cf-a7ca-4b6c-bdd2-61ada806f849",
+                    "participantId": "d3e49de4-e760-4c70-b9f6-27aaaf7a6246",
                     "assignedParticipantRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     },

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.*
 @DependentServices( StudyService::class )
 interface RecruitmentService : ApplicationService<RecruitmentService, RecruitmentService.Event>
 {
-    companion object { val API_VERSION = ApiVersion( 1, 2 ) }
+    companion object { val API_VERSION = ApiVersion( 1, 3 ) }
 
     @Serializable
     sealed class Event : IntegrationEvent<RecruitmentService>

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/RecruitmentServiceApiMigrator.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/RecruitmentServiceApiMigrator.kt
@@ -1,13 +1,13 @@
 package dk.cachet.carp.studies.infrastructure.versioning
 
 import dk.cachet.carp.common.application.services.ApiVersion
-import dk.cachet.carp.common.infrastructure.versioning.ApiMigration
-import dk.cachet.carp.common.infrastructure.versioning.ApiResponse
-import dk.cachet.carp.common.infrastructure.versioning.ApplicationServiceApiMigrator
+import dk.cachet.carp.common.infrastructure.versioning.*
 import dk.cachet.carp.studies.application.RecruitmentService
 import dk.cachet.carp.studies.infrastructure.RecruitmentServiceInvoker
 import dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 
 
 const val recruitmentRequest = "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest"
@@ -31,10 +31,53 @@ private val major1Minor0To2Migration =
        override fun migrateEvent( event: JsonObject ): JsonObject = event
    }
 
+
+private val major1Minor2To3Migration =
+    @Suppress( "MagicNumber" )
+    object : ApiMigration( 2, 3 )
+    {
+        override fun migrateRequest( request: JsonObject ) = request
+
+        override fun migrateResponse( request: JsonObject, response: ApiResponse, targetVersion: ApiVersion ) =
+            when ( request.getType( ) )
+            {
+                "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+                "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup" ->
+                {
+                    val responseObject = response.response?.jsonObject?.migrate {
+                        removeDeviceRegistration()
+                    }
+                    ApiResponse( responseObject, response.ex )
+                }
+                "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList" ->
+                {
+                    val responseObject = response.response?.jsonArray?.migrate {
+                        objects { removeDeviceRegistration() }
+                    }
+                    ApiResponse( responseObject, response.ex )
+                }
+                else -> response
+            }
+
+        /**
+         * Remove the newly added `deviceRegistration` field from `DeviceDeploymentStatus` objects contained within
+         * `StudyDeploymentStatus`.
+         */
+        private fun ApiJsonObjectMigrationBuilder.removeDeviceRegistration() =
+            updateObject( "studyDeploymentStatus" ) {
+                updateArray( "deviceStatusList" ) {
+                    objects { json.remove( "deviceRegistration" ) }
+                }
+            }
+
+        override fun migrateEvent( event: JsonObject ) = event
+    }
+
+
 val RecruitmentServiceApiMigrator = ApplicationServiceApiMigrator(
     RecruitmentService.API_VERSION,
     RecruitmentServiceInvoker,
     RecruitmentServiceRequest.Serializer,
     RecruitmentService.Event.serializer(),
-    listOf( major1Minor0To2Migration )
+    listOf( major1Minor0To2Migration, major1Minor2To3Migration )
 )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
@@ -48,7 +48,7 @@ class RecruitmentServiceHostTest : RecruitmentServiceTest
                 TestClock
             )
 
-            return RecruitmentServiceTest.SUT( recruitmentService, studyService, eventBus )
+            return RecruitmentServiceTest.SUT( recruitmentService, studyService, deploymentService, eventBus )
         }
     }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
@@ -5,11 +5,8 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.application.devices.Smartphone
 import dk.cachet.carp.common.application.services.EventBus
-import dk.cachet.carp.common.application.users.AssignedTo
-import dk.cachet.carp.common.application.users.ExpectedParticipantData
-import dk.cachet.carp.common.application.users.ParticipantAttribute
-import dk.cachet.carp.common.application.users.ParticipantRole
-import dk.cachet.carp.common.application.users.Username
+import dk.cachet.carp.common.application.users.*
+import dk.cachet.carp.deployments.application.DeploymentService
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
@@ -32,6 +29,7 @@ interface RecruitmentServiceTest
     data class SUT(
         val recruitmentService: RecruitmentService,
         val studyService: StudyService,
+        val deploymentService: DeploymentService,
         val eventBus: EventBus
     )
 
@@ -254,12 +252,41 @@ interface RecruitmentServiceTest
         assertFailsWith<IllegalArgumentException> { recruitmentService.stopParticipantGroup( studyId, unknownId ) }
     }
 
+    @Test
+    fun getParticipantGroupStatusList_full_flow_succeeds() = runTest {
+        val (recruitmentService, studyService, deploymentService) = createSUT()
+        val roleName = "User's phone"
+        val (studyId, _) = createLiveStudy( studyService, roleName )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
 
-    private suspend fun createLiveStudy( service: StudyService ): Pair<UUID, StudyProtocolSnapshot>
+        val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
+
+        val groupStatus = recruitmentService.inviteNewParticipantGroup( studyId, setOf( assignParticipant ) )
+        val deploymentId = groupStatus.id
+
+        val status = deploymentService.getStudyDeploymentStatus( deploymentId )
+        val primary = status.getRemainingDevicesToRegister().first { it.roleName == roleName }
+        val registration = primary.createRegistration()
+
+        recruitmentService.getParticipantGroupStatusList( studyId )
+        deploymentService.registerDevice( deploymentId, primary.roleName, registration )
+        recruitmentService.getParticipantGroupStatusList( studyId )
+        val deviceDeployment = deploymentService.getDeviceDeploymentFor( deploymentId, primary.roleName )
+        deploymentService.deviceDeployed( deploymentId, primary.roleName, deviceDeployment.lastUpdatedOn )
+        recruitmentService.getParticipantGroupStatusList( studyId )
+        deploymentService.unregisterDevice( deploymentId, primary.roleName )
+        recruitmentService.getParticipantGroupStatusList( studyId )
+        recruitmentService.stopParticipantGroup( studyId, deploymentId )
+    }
+
+    private suspend fun createLiveStudy(
+        service: StudyService,
+        roleName: String = "User's phone"
+    ): Pair<UUID, StudyProtocolSnapshot>
     {
         // Create deployable protocol.
         val protocol = StudyProtocol( UUID.randomUUID(), "Test protocol" )
-        protocol.addPrimaryDevice( Smartphone( "User's phone" ) )
+        protocol.addPrimaryDevice( Smartphone( roleName ) )
         val expectedData = ExpectedParticipantData(
             ParticipantAttribute.DefaultParticipantAttribute( CarpInputDataTypes.SEX )
         )

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.0/RecruitmentServiceTest/getParticipantGroupStatusList_full_flow_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.0/RecruitmentServiceTest/getParticipantGroupStatusList_full_flow_succeeds.json
@@ -1,0 +1,457 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipant",
+            "apiVersion": "1.0",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.0",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "42f95b7f-c5e8-44dd-9344-d10f6c9a7b8c",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.0",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "42f95b7f-c5e8-44dd-9344-d10f6c9a7b8c",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "35dcc10a-1dd2-431b-9175-4ff7d44c428c",
+                        "createdOn": "2025-07-22T14:50:49.485453Z",
+                        "ownerId": "fc553fba-8f5d-4555-a190-e427b3fbf78d",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.0",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.0",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            },
+                            "canBeDeployed": true,
+                            "remainingDevicesToRegisterToObtainDeployment": [
+                                "User's phone"
+                            ],
+                            "remainingDevicesToRegisterBeforeDeployment": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": null
+                }
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.0",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            },
+                            "canBeDeployed": true,
+                            "remainingDevicesToRegisterToObtainDeployment": [
+                            ],
+                            "remainingDevicesToRegisterBeforeDeployment": [
+                            ]
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": null
+                }
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.0",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Running",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Running",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Deployed",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": "1970-01-01T00:00:00Z"
+                },
+                "startedOn": "1970-01-01T00:00:00Z"
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.0",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Running",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            },
+                            "canBeDeployed": true,
+                            "remainingDevicesToRegisterToObtainDeployment": [
+                                "User's phone"
+                            ],
+                            "remainingDevicesToRegisterBeforeDeployment": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": "1970-01-01T00:00:00Z"
+                },
+                "startedOn": "1970-01-01T00:00:00Z"
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup",
+            "apiVersion": "1.0",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "00000000-0000-0000-0000-000000000003"
+        },
+        "precedingEvents": [
+        ],
+        "publishedEvents": [
+        ],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Stopped",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": "1970-01-01T00:00:00Z",
+                "stoppedOn": "1970-01-01T00:00:00Z"
+            },
+            "startedOn": "1970-01-01T00:00:00Z",
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.2/RecruitmentServiceTest/getParticipantGroupStatusList_full_flow_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.2/RecruitmentServiceTest/getParticipantGroupStatusList_full_flow_succeeds.json
@@ -1,0 +1,443 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.2",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "24439a3d-933f-40a4-b02c-ec974653a172",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "24439a3d-933f-40a4-b02c-ec974653a172",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "5d0ab43e-bdf0-4702-9c94-91da023f1959",
+                        "createdOn": "2025-07-22T16:54:41.393117Z",
+                        "version": 0,
+                        "ownerId": "1643a416-c402-4b6d-982c-a243914b6bc5",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.2",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.2",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            },
+                            "canBeDeployed": true,
+                            "remainingDevicesToRegisterToObtainDeployment": [
+                                "User's phone"
+                            ],
+                            "remainingDevicesToRegisterBeforeDeployment": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": null
+                }
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.2",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            },
+                            "canBeDeployed": true,
+                            "remainingDevicesToRegisterToObtainDeployment": [],
+                            "remainingDevicesToRegisterBeforeDeployment": []
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": null
+                }
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.2",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Running",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Running",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Deployed",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": "2025-07-22T16:54:41.394749Z"
+                },
+                "startedOn": "2025-07-22T16:54:41.394749Z"
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.2",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Running",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.DeployingDevices",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            },
+                            "canBeDeployed": true,
+                            "remainingDevicesToRegisterToObtainDeployment": [
+                                "User's phone"
+                            ],
+                            "remainingDevicesToRegisterBeforeDeployment": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": "2025-07-22T16:54:41.394749Z"
+                },
+                "startedOn": "2025-07-22T16:54:41.394749Z"
+            }
+        ]
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup",
+            "apiVersion": "1.2",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "00000000-0000-0000-0000-000000000003"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Stopped",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": "2025-07-22T16:54:41.394749Z",
+                "stoppedOn": "1970-01-01T00:00:00Z"
+            },
+            "startedOn": "2025-07-22T16:54:41.394749Z",
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/addParticipant_fails_for_unknown_studyId.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/addParticipant_fails_for_unknown_studyId.json
@@ -1,0 +1,14 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "df573012-8d1c-487d-8788-f643491d50c9",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/addParticipant_twice_returns_same_participant.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/addParticipant_twice_returns_same_participant.json
@@ -1,0 +1,55 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "64f4a056-33de-4be3-a2e3-80ebbeff1c5e",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/adding_and_retrieving_participants_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/adding_and_retrieving_participants_succeeds.json
@@ -1,0 +1,117 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "6e8bb0fe-6a81-4e92-bd12-b6b1d8f6a739",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByUsername",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "username": "test"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                "username": "test"
+            },
+            "id": "00000000-0000-0000-0000-000000000003"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipant",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "participantId": "00000000-0000-0000-0000-000000000002"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipant",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "participantId": "00000000-0000-0000-0000-000000000003"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                "username": "test"
+            },
+            "id": "00000000-0000-0000-0000-000000000003"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipants",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "accountIdentity": {
+                    "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                    "emailAddress": "test@test.com"
+                },
+                "id": "00000000-0000-0000-0000-000000000002"
+            },
+            {
+                "accountIdentity": {
+                    "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                    "username": "test"
+                },
+                "id": "00000000-0000-0000-0000-000000000003"
+            }
+        ]
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipantGroupStatusList_full_flow_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipantGroupStatusList_full_flow_succeeds.json
@@ -2,8 +2,8 @@
     {
         "outcome": "Succeeded",
         "request": {
-            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipant",
-            "apiVersion": "1.0",
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
             "studyId": "00000000-0000-0000-0000-000000000001",
             "email": "test@test.com"
         },
@@ -11,10 +11,10 @@
             {
                 "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
                 "aggregateId": "00000000-0000-0000-0000-000000000001",
-                "apiVersion": "1.0",
+                "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "660a2e3e-2e99-40a9-a754-54c3b177dd8e",
+                    "ownerId": "c356e5a4-e990-474d-892b-952e38a0b247",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -27,10 +27,10 @@
             {
                 "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
                 "aggregateId": "00000000-0000-0000-0000-000000000001",
-                "apiVersion": "1.0",
+                "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "660a2e3e-2e99-40a9-a754-54c3b177dd8e",
+                    "ownerId": "c356e5a4-e990-474d-892b-952e38a0b247",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,9 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "2eb83384-772e-46cb-b6dc-997fe6e6a4d9",
-                        "createdOn": "2025-07-29T16:04:52.015551Z",
-                        "ownerId": "0b30174b-912c-41c1-92dd-b9f70ecba20b",
+                        "id": "ec9db2c9-d23c-4a1d-83e8-8eb72b0c7c4c",
+                        "createdOn": "2025-07-22T21:54:57.804749Z",
+                        "version": 0,
+                        "ownerId": "b65139f7-6a46-47f0-8f4f-0f8103456efd",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -71,8 +72,7 @@
                 }
             }
         ],
-        "publishedEvents": [
-        ],
+        "publishedEvents": [],
         "response": {
             "accountIdentity": {
                 "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
@@ -85,7 +85,7 @@
         "outcome": "Succeeded",
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
-            "apiVersion": "1.0",
+            "apiVersion": "1.3",
             "studyId": "00000000-0000-0000-0000-000000000001",
             "group": [
                 {
@@ -96,10 +96,8 @@
                 }
             ]
         },
-        "precedingEvents": [
-        ],
-        "publishedEvents": [
-        ],
+        "precedingEvents": [],
+        "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
             "id": "00000000-0000-0000-0000-000000000003",
@@ -153,13 +151,11 @@
         "outcome": "Succeeded",
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
-            "apiVersion": "1.0",
+            "apiVersion": "1.3",
             "studyId": "00000000-0000-0000-0000-000000000001"
         },
-        "precedingEvents": [
-        ],
-        "publishedEvents": [
-        ],
+        "precedingEvents": [],
+        "publishedEvents": [],
         "response": [
             {
                 "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
@@ -215,13 +211,11 @@
         "outcome": "Succeeded",
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
-            "apiVersion": "1.0",
+            "apiVersion": "1.3",
             "studyId": "00000000-0000-0000-0000-000000000001"
         },
-        "precedingEvents": [
-        ],
-        "publishedEvents": [
-        ],
+        "precedingEvents": [],
+        "publishedEvents": [],
         "response": [
             {
                 "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
@@ -248,11 +242,14 @@
                                 "isPrimaryDevice": true,
                                 "roleName": "User's phone"
                             },
+                            "deviceRegistration": {
+                                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                                "registrationCreatedOn": "2025-07-22T21:54:57.805772Z",
+                                "deviceId": "217389cc-975b-4a6f-8924-56299ae67af9"
+                            },
                             "canBeDeployed": true,
-                            "remainingDevicesToRegisterToObtainDeployment": [
-                            ],
-                            "remainingDevicesToRegisterBeforeDeployment": [
-                            ]
+                            "remainingDevicesToRegisterToObtainDeployment": [],
+                            "remainingDevicesToRegisterBeforeDeployment": []
                         }
                     ],
                     "participantStatusList": [
@@ -275,13 +272,11 @@
         "outcome": "Succeeded",
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
-            "apiVersion": "1.0",
+            "apiVersion": "1.3",
             "studyId": "00000000-0000-0000-0000-000000000001"
         },
-        "precedingEvents": [
-        ],
-        "publishedEvents": [
-        ],
+        "precedingEvents": [],
+        "publishedEvents": [],
         "response": [
             {
                 "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Running",
@@ -307,6 +302,11 @@
                                 "__type": "dk.cachet.carp.common.application.devices.Smartphone",
                                 "isPrimaryDevice": true,
                                 "roleName": "User's phone"
+                            },
+                            "deviceRegistration": {
+                                "__type": "dk.cachet.carp.common.application.devices.DefaultDeviceRegistration",
+                                "registrationCreatedOn": "2025-07-22T21:54:57.805772Z",
+                                "deviceId": "217389cc-975b-4a6f-8924-56299ae67af9"
                             }
                         }
                     ],
@@ -331,13 +331,11 @@
         "outcome": "Succeeded",
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
-            "apiVersion": "1.0",
+            "apiVersion": "1.3",
             "studyId": "00000000-0000-0000-0000-000000000001"
         },
-        "precedingEvents": [
-        ],
-        "publishedEvents": [
-        ],
+        "precedingEvents": [],
+        "publishedEvents": [],
         "response": [
             {
                 "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Running",
@@ -394,14 +392,12 @@
         "outcome": "Succeeded",
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup",
-            "apiVersion": "1.0",
+            "apiVersion": "1.3",
             "studyId": "00000000-0000-0000-0000-000000000001",
             "groupId": "00000000-0000-0000-0000-000000000003"
         },
-        "precedingEvents": [
-        ],
-        "publishedEvents": [
-        ],
+        "precedingEvents": [],
+        "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Stopped",
             "id": "00000000-0000-0000-0000-000000000003",

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipantGroupStatusList_returns_multiple_deployments.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipantGroupStatusList_returns_multiple_deployments.json
@@ -1,0 +1,342 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "10587d75-3bb9-46a6-bdee-20448e9f0a48",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "10587d75-3bb9-46a6-bdee-20448e9f0a48",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "e4dd9aa1-f060-4c5c-9065-04aef1245969",
+                        "createdOn": "2025-07-22T21:54:57.822558Z",
+                        "version": 0,
+                        "ownerId": "33767253-9b4f-4137-b8f3-359de0b0a550",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test2@test.com"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test2@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000004"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000004",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000005",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test2@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000004"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000005",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000004",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            },
+                            "canBeDeployed": true,
+                            "remainingDevicesToRegisterToObtainDeployment": [
+                                "User's phone"
+                            ],
+                            "remainingDevicesToRegisterBeforeDeployment": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+                "id": "00000000-0000-0000-0000-000000000005",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test2@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000004"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000005",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            },
+                            "canBeDeployed": true,
+                            "remainingDevicesToRegisterToObtainDeployment": [
+                                "User's phone"
+                            ],
+                            "remainingDevicesToRegisterBeforeDeployment": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000004",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": null
+                }
+            }
+        ]
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipantGroupStatusLists_fails_for_unknown_studyId.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipantGroupStatusLists_fails_for_unknown_studyId.json
@@ -1,0 +1,13 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.3",
+            "studyId": "df573012-8d1c-487d-8788-f643491d50c9"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipant_fails_for_unknown_id.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipant_fails_for_unknown_id.json
@@ -1,0 +1,43 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipant",
+            "apiVersion": "1.3",
+            "studyId": "df573012-8d1c-487d-8788-f643491d50c9",
+            "participantId": "df573012-8d1c-487d-8788-f643491d50c9"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "360b7cbd-a4ed-4cb6-8e75-aeb2dd37a2f4",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipant",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "participantId": "df573012-8d1c-487d-8788-f643491d50c9"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipants_fails_for_unknown_studyId.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipants_fails_for_unknown_studyId.json
@@ -1,0 +1,13 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipants",
+            "apiVersion": "1.3",
+            "studyId": "df573012-8d1c-487d-8788-f643491d50c9"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_empty_group.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_empty_group.json
@@ -1,0 +1,78 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": []
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "c001de5e-a1dc-4628-a9c2-18d15aa36aad",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "c001de5e-a1dc-4628-a9c2-18d15aa36aad",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "cd6e6e7c-87ad-49b2-b847-dceed4380e9c",
+                        "createdOn": "2025-07-22T21:54:57.841398Z",
+                        "version": 0,
+                        "ownerId": "e2eacf40-9f93-4e79-9d06-d55ac7e5eb03",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_participant_roles.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_participant_roles.json
@@ -1,0 +1,106 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "5b07ea4a-7c64-4c37-b405-52738927c27d",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "5b07ea4a-7c64-4c37-b405-52738927c27d",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "20a9fd17-6909-42ee-9eb3-b7c3818344be",
+                        "createdOn": "2025-07-22T21:54:57.761745Z",
+                        "version": 0,
+                        "ownerId": "e456689c-6195-4d6e-8195-dd64b7ae6ad4",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Unknown role"
+                        ]
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_participants.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_participants.json
@@ -1,0 +1,85 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "df573012-8d1c-487d-8788-f643491d50c9",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "cdd78418-2c36-4cef-bf37-dfe94f10b5cc",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "cdd78418-2c36-4cef-bf37-dfe94f10b5cc",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "76abd87f-aec6-4352-913d-2b2fd08c0aad",
+                        "createdOn": "2025-07-22T21:54:57.753472Z",
+                        "version": 0,
+                        "ownerId": "43c5f2ac-0130-4cdb-bd8b-d0a7dc93b073",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_studyId.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_studyId.json
@@ -1,0 +1,21 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "df573012-8d1c-487d-8788-f643491d50c9",
+            "group": [
+                {
+                    "participantId": "3bc94f53-2939-487b-9650-5e62fba96ed3",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_when_not_all_participant_roles_assigned.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_when_not_all_participant_roles_assigned.json
@@ -1,0 +1,106 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "aa046eb0-085e-4751-a0d1-85d4dc49ccd5",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "aa046eb0-085e-4751-a0d1-85d4dc49ccd5",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "e995f1f7-0409-4474-83a9-06d5f5286e4d",
+                        "createdOn": "2025-07-22T21:54:57.857237Z",
+                        "version": 0,
+                        "ownerId": "fb5515b3-58f7-472a-b3e9-d201edb535e0",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role"
+                        ]
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_previously_stopped_group_returns_new_group.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_previously_stopped_group_returns_new_group.json
@@ -1,0 +1,278 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "e4e92ac2-29ea-4397-b51d-2cc28f39af1e",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "e4e92ac2-29ea-4397-b51d-2cc28f39af1e",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "07a124a4-eb55-4a0a-a899-21165a76a0e6",
+                        "createdOn": "2025-07-22T21:54:57.784162Z",
+                        "version": 0,
+                        "ownerId": "92ee1bcb-aee5-4d14-9dc2-95a838042d55",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "00000000-0000-0000-0000-000000000003"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Stopped",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null,
+                "stoppedOn": "1970-01-01T00:00:00Z"
+            },
+            "startedOn": null,
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000004",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000004",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_multiple_times_returns_same_group.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_multiple_times_returns_same_group.json
@@ -1,0 +1,216 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "9a9ca529-16be-4336-a1c9-4a6a6791921e",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "9a9ca529-16be-4336-a1c9-4a6a6791921e",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "4daa0b41-82b1-4809-b1f7-950e364c9392",
+                        "createdOn": "2025-07-22T21:54:57.755173Z",
+                        "version": 0,
+                        "ownerId": "313a92ed-a340-42b7-a45d-686165da3bb0",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_succeeds.json
@@ -1,0 +1,210 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "8fe60d05-229f-49c2-acd6-6ac98b22b718",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "8fe60d05-229f-49c2-acd6-6ac98b22b718",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "aa153ada-e369-4de2-813f-eecac04e49fe",
+                        "createdOn": "2025-07-22T21:54:57.748164Z",
+                        "version": 0,
+                        "ownerId": "786b8163-f02f-40d1-acd4-75ea2b6780a4",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "participants": [
+                    {
+                        "accountIdentity": {
+                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                            "emailAddress": "test@test.com"
+                        },
+                        "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "invitedOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentStatus": {
+                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                    "deviceStatusList": [
+                        {
+                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                            "device": {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            },
+                            "canBeDeployed": true,
+                            "remainingDevicesToRegisterToObtainDeployment": [
+                                "User's phone"
+                            ],
+                            "remainingDevicesToRegisterBeforeDeployment": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "participantStatusList": [
+                        {
+                            "participantId": "00000000-0000-0000-0000-000000000002",
+                            "assignedParticipantRoles": {
+                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                            },
+                            "assignedPrimaryDeviceRoleNames": [
+                                "User's phone"
+                            ]
+                        }
+                    ],
+                    "startedOn": null
+                }
+            }
+        ]
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_fails_with_unknown_groupId.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_fails_with_unknown_groupId.json
@@ -1,0 +1,78 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "df573012-8d1c-487d-8788-f643491d50c9"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "317397eb-402c-4765-82e0-bd29eaa247bb",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "317397eb-402c-4765-82e0-bd29eaa247bb",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "cdafade9-fe62-4d6e-8431-5fab3ed73a2e",
+                        "createdOn": "2025-07-22T21:54:57.742115Z",
+                        "version": 0,
+                        "ownerId": "744c8fed-760d-44a4-8908-9f991c56e2f7",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_fails_with_unknown_studyId.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_fails_with_unknown_studyId.json
@@ -1,0 +1,14 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "df573012-8d1c-487d-8788-f643491d50c9",
+            "groupId": "a8fd1f29-38e3-42e0-91bc-5280321542c2"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_succeeds.json
@@ -1,0 +1,212 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "3f18cd69-f971-402a-9014-42a6f0719de2",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "3f18cd69-f971-402a-9014-42a6f0719de2",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "ea3862da-2492-4899-8df8-ca0251ff83e8",
+                        "createdOn": "2025-07-22T21:54:57.771939Z",
+                        "version": 0,
+                        "ownerId": "8feb95f8-a1a2-4880-a971-982043376c80",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "00000000-0000-0000-0000-000000000003"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Stopped",
+            "id": "00000000-0000-0000-0000-000000000003",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000003",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null,
+                "stoppedOn": "1970-01-01T00:00:00Z"
+            },
+            "startedOn": null,
+            "stoppedOn": "1970-01-01T00:00:00Z"
+        }
+    }
+]

--- a/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/OutputRecruitmentServiceTestRequests.kt
+++ b/carp.studies.core/src/jvmTest/kotlin/dk/cachet/carp/studies/infrastructure/versioning/OutputRecruitmentServiceTestRequests.kt
@@ -20,6 +20,6 @@ class OutputRecruitmentServiceTestRequests :
         val sut = RecruitmentServiceHostTest.createSUT()
         val loggedService = createLoggedApplicationService( sut.recruitmentService, sut.eventBus )
 
-        return RecruitmentServiceTest.SUT( loggedService, sut.studyService, sut.eventBus )
+        return RecruitmentServiceTest.SUT( loggedService, sut.studyService, sut.deploymentService, sut.eventBus )
     }
 }

--- a/rpc/schemas/deployments/DeviceDeploymentStatus.json
+++ b/rpc/schemas/deployments/DeviceDeploymentStatus.json
@@ -30,6 +30,14 @@
       },
       "required": [ "remainingDevicesToRegisterToObtainDeployment", "remainingDevicesToRegisterBeforeDeployment" ]
     },
+    "HasRegistration": {
+        "$anchor": "HasRegistration",
+        "type": "object",
+        "properties": {
+            "deviceRegistration": { "$ref": "../common/devices/DeviceRegistration.json" }
+        },
+        "required": [ "deviceRegistration" ]
+    },
     "Unregistered": {
       "$anchor": "Unregistered",
       "allOf": [
@@ -47,7 +55,8 @@
       "$anchor": "Registered",
       "allOf": [
         { "$ref": "#/$defs/DeviceDeploymentStatus" },
-        { "$ref": "#NotDeployed" }
+        { "$ref": "#NotDeployed" },
+        { "$ref": "#HasRegistration" }
       ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered" },
@@ -59,7 +68,8 @@
     "Deployed": {
       "$anchor": "Deployed",
       "allOf": [
-        { "$ref": "#/$defs/DeviceDeploymentStatus" }
+        { "$ref": "#/$defs/DeviceDeploymentStatus" },
+        { "$ref": "#HasRegistration" }
       ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Deployed" }
@@ -70,7 +80,8 @@
       "$anchor": "NeedsRedeployment",
       "allOf": [
         { "$ref": "#/$defs/DeviceDeploymentStatus" },
-        { "$ref": "#NotDeployed" }
+        { "$ref": "#NotDeployed" },
+        { "$ref": "#HasRegistration" }
       ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.NeedsRedeployment" }

--- a/rpc/schemas/studies/RecruitmentService/RecruitmentServiceRequest.json
+++ b/rpc/schemas/studies/RecruitmentService/RecruitmentServiceRequest.json
@@ -10,7 +10,7 @@
     { "$ref": "#StopParticipantGroup" }
   ],
   "$defs": {
-    "ApiVersion": { "const": "1.2" },
+    "ApiVersion": { "const": "1.3" },
     "AddParticipantByEmailAddress": {
       "$anchor": "AddParticipantByEmailAddress",
       "type": "object",

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -192,7 +192,7 @@ private val bikeBeaconPreregistration = bikeBeacon.createRegistration {
 private val phoneRegistration = phone.createRegistration {
     deviceId = UUID( "fc7b41b0-e9e2-4b5d-8c3d-5119b556a3f0" ).toString()
 }.setRegistrationCreatedOn( Instant.fromEpochSeconds( 1642514110 ) )
-private val bikeBeaconStatus = DeviceDeploymentStatus.Registered( bikeBeacon, false, emptySet(), emptySet() )
+private val bikeBeaconStatus = DeviceDeploymentStatus.Registered( bikeBeacon, phoneRegistration, false, emptySet(), emptySet() )
 private val participantStatusList = listOf(
     ParticipantStatus( participantId, participantAssignedRoles, setOf( phone.roleName ) )
 )
@@ -210,7 +210,7 @@ private val runningDeploymentStatus = StudyDeploymentStatus.Running(
     deploymentCreatedOn,
     deploymentId,
     listOf(
-        DeviceDeploymentStatus.Deployed( phone ),
+        DeviceDeploymentStatus.Deployed( phone, phoneRegistration ),
         bikeBeaconStatus
     ),
     participantStatusList,
@@ -220,7 +220,7 @@ private val stoppedDeploymentStatus = StudyDeploymentStatus.Stopped(
     deploymentCreatedOn,
     deploymentId,
     listOf(
-        DeviceDeploymentStatus.Deployed( phone ),
+        DeviceDeploymentStatus.Deployed( phone, phoneRegistration ),
         bikeBeaconStatus
     ),
     participantStatusList,
@@ -425,7 +425,7 @@ private val exampleRequests: Map<KFunction<*>, LoggedRequest.Succeeded<*>> = map
             deploymentCreatedOn,
             deploymentId,
             listOf(
-                DeviceDeploymentStatus.Registered( phone, true, emptySet(), emptySet() ),
+                DeviceDeploymentStatus.Registered( phone, phoneRegistration, true, emptySet(), emptySet() ),
                 bikeBeaconStatus
             ),
             participantStatusList,


### PR DESCRIPTION
`DeviceRegistration` is added to `DeviceDeploymentStatus`, which is part of `StudyDeploymentStatus`. A new interface `HasDeviceRegistration` is introduced to keep this field since `Unregistered` would not need this field.

A regression test case was added in a separate commit as I'm not sure if it is desired. The test case amis to test `GetStudyDeploymentStatusList` endpoint with registered devices in one of the deployments. This is not covered since `DeploymentServiceTest` tests minimum usage for `GetStudyDeploymentStatusList`, as it is just a list representation of `GetDeploymentStatus`. I added it since json migration for this endpoint works differently.
