### PR TITLE
Upgrade JSON schema validator + fixes

### DIFF
--- a/rpc/build.gradle
+++ b/rpc/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation "org.reflections:reflections:${versions.reflections}"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:${versions.serialization}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
-    implementation "com.networknt:json-schema-validator:1.0.67"
+    implementation "com.networknt:json-schema-validator:1.5.2"
     implementation "commons-io:commons-io:${versions.apacheCommons}"
 
     def generateForProjects = coreModules + commonModule

--- a/rpc/schemas/common/data/input/elements/InputElement.json
+++ b/rpc/schemas/common/data/input/elements/InputElement.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "oneOf": [
-    { "$ref": "#/$defs/SelectOne" },
-    { "$ref": "#/$defs/Text" }
+    { "$ref": "#SelectOne" },
+    { "$ref": "#Text" }
   ],
   "$defs": {
     "SelectOne": {

--- a/rpc/schemas/common/devices/DeviceConfiguration.json
+++ b/rpc/schemas/common/devices/DeviceConfiguration.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "allOf": [
-    { "$ref": "#/$defs/DeviceConfiguration" },
+    { "$ref": "#DeviceConfiguration" },
     {
       "if": { "properties": { "__type": { "const": "dk.cachet.carp.common.application.devices.AltBeacon" } } },
       "then": { "$ref": "AltBeacon.json" }

--- a/rpc/schemas/common/devices/DeviceRegistration.json
+++ b/rpc/schemas/common/devices/DeviceRegistration.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "allOf": [
-    { "$ref": "#/$defs/DeviceRegistration" },
+    { "$ref": "#DeviceRegistration" },
     {
       "if": { "properties": { "__type": { "const": "dk.cachet.carp.common.application.devices.AltBeaconDeviceRegistration" } } },
       "then": { "$ref": "AltBeacon.json#DeviceRegistration" }

--- a/rpc/schemas/common/devices/PrimaryDeviceConfiguration.json
+++ b/rpc/schemas/common/devices/PrimaryDeviceConfiguration.json
@@ -12,11 +12,15 @@
     }
   ],
   "$defs": {
+    "HACK-SEE-ISSUE-492": true,
     "PrimaryDeviceConfiguration": {
       "$anchor": "PrimaryDeviceConfiguration",
       "allOf": [ { "$ref": "DeviceConfiguration.json#DeviceConfiguration" } ],
       "properties": {
-        "isPrimaryDevice": { "const": true }
+        "isPrimaryDevice": { "const": true },
+
+        "roleName": { "$ref": "#/$defs/HACK-SEE-ISSUE-492" },
+        "defaultSamplingConfiguration": { "$ref": "#/$defs/HACK-SEE-ISSUE-492" }
       },
       "required": [ "isPrimaryDevice" ]
     }

--- a/rpc/schemas/common/devices/PrimaryDeviceConfiguration.json
+++ b/rpc/schemas/common/devices/PrimaryDeviceConfiguration.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "allOf": [
-    { "$ref": "#/$defs/PrimaryDeviceConfiguration" },
+    { "$ref": "#PrimaryDeviceConfiguration" },
     {
       "if": { "properties": { "__type": { "const": "dk.cachet.carp.common.application.devices.Smartphone" } } },
       "then": { "$ref": "Smartphone.json" }

--- a/rpc/schemas/common/sampling/SamplingConfiguration.json
+++ b/rpc/schemas/common/sampling/SamplingConfiguration.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "allOf": [
-    { "$ref": "#/$defs/SamplingConfiguration" },
+    { "$ref": "#SamplingConfiguration" },
     {
       "if": { "properties": { "__type": { "const": "dk.cachet.carp.common.application.sampling.BatteryAwareSamplingConfiguration" } } },
       "then": { "$ref": "BatteryAwareSamplingConfiguration.json" }

--- a/rpc/schemas/common/tasks/Measure.json
+++ b/rpc/schemas/common/tasks/Measure.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "oneOf": [
-    { "$ref": "#/$defs/DataStream" },
-    { "$ref": "#/$defs/TriggerData" }
+    { "$ref": "#DataStream" },
+    { "$ref": "#TriggerData" }
   ],
   "$defs": {
     "DataStream": {

--- a/rpc/schemas/common/tasks/TaskConfiguration.json
+++ b/rpc/schemas/common/tasks/TaskConfiguration.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "allOf": [
-    { "$ref": "#/$defs/TaskConfiguration" },
+    { "$ref": "#TaskConfiguration" },
     {
       "if": { "properties": { "__type": { "const": "dk.cachet.carp.common.application.tasks.BackgroundTask" } } },
       "then": { "$ref": "BackgroundTask.json" }

--- a/rpc/schemas/common/triggers/TaskControl.json
+++ b/rpc/schemas/common/triggers/TaskControl.json
@@ -5,7 +5,7 @@
     "triggerId": { "type": "integer" },
     "taskName": { "type": "string" },
     "destinationDeviceRoleName": { "type": "string" },
-    "control": { "$ref": "#/$defs/Control" }
+    "control": { "$ref": "#Control" }
   },
   "required": [ "triggerId", "taskName", "destinationDeviceRoleName", "control" ],
   "additionalProperties": false,

--- a/rpc/schemas/common/triggers/TriggerConfiguration.json
+++ b/rpc/schemas/common/triggers/TriggerConfiguration.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "allOf": [
-    { "$ref": "#/$defs/TriggerConfiguration" },
+    { "$ref": "#TriggerConfiguration" },
     {
       "if": { "properties": { "__type": { "const": "dk.cachet.carp.common.application.triggers.ElapsedTimeTrigger" } } },
       "then": { "$ref": "ElapsedTimeTrigger.json" }

--- a/rpc/schemas/common/users/AccountIdentity.json
+++ b/rpc/schemas/common/users/AccountIdentity.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "oneOf": [
-    { "$ref": "#/$defs/EmailAccountIdentity" },
-    { "$ref": "#/$defs/UsernameAccountIdentity" }
+    { "$ref": "#EmailAccountIdentity" },
+    { "$ref": "#UsernameAccountIdentity" }
   ],
   "$defs": {
     "EmailAccountIdentity": {

--- a/rpc/schemas/common/users/AssignedTo.json
+++ b/rpc/schemas/common/users/AssignedTo.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "oneOf": [
-    { "$ref": "#/$defs/All" },
-    { "$ref": "#/$defs/Roles" }
+    { "$ref": "#All" },
+    { "$ref": "#Roles" }
   ],
   "$defs": {
     "All": {

--- a/rpc/schemas/common/users/ParticipantAttribute.json
+++ b/rpc/schemas/common/users/ParticipantAttribute.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "oneOf": [
-    { "$ref": "#/$defs/DefaultParticipantAttribute" },
-    { "$ref": "#/$defs/CustomParticipantAttribute" }
+    { "$ref": "#DefaultParticipantAttribute" },
+    { "$ref": "#CustomParticipantAttribute" }
   ],
   "$defs": {
     "DefaultParticipantAttribute": {

--- a/rpc/schemas/data/DataStreamService/DataStreamServiceRequest.json
+++ b/rpc/schemas/data/DataStreamService/DataStreamServiceRequest.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/OpenDataStreams" },
-    { "$ref": "#/$defs/AppendToDataStreams" },
-    { "$ref": "#/$defs/GetDataStream" },
-    { "$ref": "#/$defs/CloseDataStreams" },
-    { "$ref": "#/$defs/RemoveDataStreams" }
+    { "$ref": "#OpenDataStreams" },
+    { "$ref": "#AppendToDataStreams" },
+    { "$ref": "#GetDataStream" },
+    { "$ref": "#CloseDataStreams" },
+    { "$ref": "#RemoveDataStreams" }
   ],
   "$defs": {
     "ApiVersion": { "const": "1.1" },
@@ -76,6 +76,7 @@
       }
     },
     "RemoveDataStreams": {
+      "$anchor": "RemoveDataStreams",
       "type": "object",
   	  "properties": {
         "__type": { "const": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.RemoveDataStreams" },

--- a/rpc/schemas/deployments/DeploymentService/DeploymentServiceRequest.json
+++ b/rpc/schemas/deployments/DeploymentService/DeploymentServiceRequest.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/CreateStudyDeployment" },
-    { "$ref": "#/$defs/RemoveStudyDeployments" },
-    { "$ref": "#/$defs/GetStudyDeploymentStatus" },
-    { "$ref": "#/$defs/GetStudyDeploymentStatusList" },
-    { "$ref": "#/$defs/RegisterDevice" },
-    { "$ref": "#/$defs/UnregisterDevice" },
-    { "$ref": "#/$defs/GetDeviceDeploymentFor" },
-    { "$ref": "#/$defs/DeviceDeployed" },
-    { "$ref": "#/$defs/Stop" }
+    { "$ref": "#CreateStudyDeployment" },
+    { "$ref": "#RemoveStudyDeployments" },
+    { "$ref": "#GetStudyDeploymentStatus" },
+    { "$ref": "#GetStudyDeploymentStatusList" },
+    { "$ref": "#RegisterDevice" },
+    { "$ref": "#UnregisterDevice" },
+    { "$ref": "#GetDeviceDeploymentFor" },
+    { "$ref": "#DeviceDeployed" },
+    { "$ref": "#Stop" }
   ],
   "$defs": {
     "ApiVersion": { "const": "1.3" },

--- a/rpc/schemas/deployments/DeviceDeploymentStatus.json
+++ b/rpc/schemas/deployments/DeviceDeploymentStatus.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/Unregistered" },
-    { "$ref": "#/$defs/Registered" },
-    { "$ref": "#/$defs/Deployed" },
-    { "$ref": "#/$defs/NeedsRedeployment" }
+    { "$ref": "#Unregistered" },
+    { "$ref": "#Registered" },
+    { "$ref": "#Deployed" },
+    { "$ref": "#NeedsRedeployment" }
   ],
   "$defs": {
     "DeviceDeploymentStatus": {
@@ -16,6 +16,7 @@
       "required": [ "__type", "device" ]
     },
     "NotDeployed": {
+      "$anchor": "NotDeployed",
       "type": "object",
       "properties": {
         "remainingDevicesToRegisterToObtainDeployment": {
@@ -33,7 +34,7 @@
       "$anchor": "Unregistered",
       "allOf": [
         { "$ref": "#/$defs/DeviceDeploymentStatus" },
-        { "$ref": "#/$defs/NotDeployed" }
+        { "$ref": "#NotDeployed" }
       ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered" },
@@ -46,7 +47,7 @@
       "$anchor": "Registered",
       "allOf": [
         { "$ref": "#/$defs/DeviceDeploymentStatus" },
-        { "$ref": "#/$defs/NotDeployed" }
+        { "$ref": "#NotDeployed" }
       ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered" },
@@ -69,7 +70,7 @@
       "$anchor": "NeedsRedeployment",
       "allOf": [
         { "$ref": "#/$defs/DeviceDeploymentStatus" },
-        { "$ref": "#/$defs/NotDeployed" }
+        { "$ref": "#NotDeployed" }
       ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.NeedsRedeployment" }

--- a/rpc/schemas/deployments/DeviceDeploymentStatus.json
+++ b/rpc/schemas/deployments/DeviceDeploymentStatus.json
@@ -31,7 +31,10 @@
     },
     "Unregistered": {
       "$anchor": "Unregistered",
-      "allOf": [ "#/$defs/DeviceDeploymentStatus", "#/$defs/NotDeployed" ],
+      "allOf": [
+        { "$ref": "#/$defs/DeviceDeploymentStatus" },
+        { "$ref": "#/$defs/NotDeployed" }
+      ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered" },
         "canBeDeployed": { "type": "boolean" }
@@ -41,7 +44,10 @@
     },
     "Registered": {
       "$anchor": "Registered",
-      "allOf": [ "#/$defs/DeviceDeploymentStatus", "#/$defs/NotDeployed" ],
+      "allOf": [
+        { "$ref": "#/$defs/DeviceDeploymentStatus" },
+        { "$ref": "#/$defs/NotDeployed" }
+      ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Registered" },
         "canBeDeployed": { "type": "boolean" }
@@ -51,7 +57,9 @@
     },
     "Deployed": {
       "$anchor": "Deployed",
-      "allOf": [ "#/$defs/DeviceDeploymentStatus" ],
+      "allOf": [
+        { "$ref": "#/$defs/DeviceDeploymentStatus" }
+      ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Deployed" }
       },
@@ -59,7 +67,10 @@
     },
     "NeedsRedeployment": {
       "$anchor": "NeedsRedeployment",
-      "allOf": [ "#/$defs/DeviceDeploymentStatus", "#/$defs/NotDeployed" ],
+      "allOf": [
+        { "$ref": "#/$defs/DeviceDeploymentStatus" },
+        { "$ref": "#/$defs/NotDeployed" }
+      ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.NeedsRedeployment" }
       },

--- a/rpc/schemas/deployments/ParticipationService/ParticipationServiceRequest.json
+++ b/rpc/schemas/deployments/ParticipationService/ParticipationServiceRequest.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/GetActiveParticipationInvitations" },
-    { "$ref": "#/$defs/GetParticipantData" },
-    { "$ref": "#/$defs/GetParticipantDataList" },
-    { "$ref": "#/$defs/SetParticipantData" }
+    { "$ref": "#GetActiveParticipationInvitations" },
+    { "$ref": "#GetParticipantData" },
+    { "$ref": "#GetParticipantDataList" },
+    { "$ref": "#SetParticipantData" }
   ],
   "$defs": {
     "ApiVersion": { "const": "1.0" },

--- a/rpc/schemas/deployments/StudyDeploymentStatus.json
+++ b/rpc/schemas/deployments/StudyDeploymentStatus.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/Invited" },
-    { "$ref": "#/$defs/DeployingDevices" },
-    { "$ref": "#/$defs/Running" },
-    { "$ref": "#/$defs/Stopped" }
+    { "$ref": "#Invited" },
+    { "$ref": "#DeployingDevices" },
+    { "$ref": "#Running" },
+    { "$ref": "#Stopped" }
   ],
   "$defs": {
     "StudyDeploymentStatus": {

--- a/rpc/schemas/deployments/users/ParticipantData.json
+++ b/rpc/schemas/deployments/users/ParticipantData.json
@@ -6,13 +6,14 @@
     "common": { "$ref": "../users/ParticipantDataMap.json" },
     "roles": {
       "type": "array",
-      "items": { "$ref": "#/$defs/RoleData" }
+      "items": { "$ref": "#RoleData" }
     }
   },
   "required": [ "studyDeploymentId", "common", "roles" ],
   "additionalProperties": false,
   "$defs": {
     "RoleData": {
+      "$anchor": "RoleData",
       "type": "object",
       "properties":{
         "roleName": { "type": "string" },

--- a/rpc/schemas/protocols/ProtocolFactoryService/ProtocolFactoryServiceRequest.json
+++ b/rpc/schemas/protocols/ProtocolFactoryService/ProtocolFactoryServiceRequest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/CreateCustomProtocol" }
+    { "$ref": "#CreateCustomProtocol" }
   ],
   "$defs": {
     "ApiVersion": { "const": "1.1" },

--- a/rpc/schemas/protocols/ProtocolService/ProtocolServiceRequest.json
+++ b/rpc/schemas/protocols/ProtocolService/ProtocolServiceRequest.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/Add" },
-    { "$ref": "#/$defs/AddVersion" },
-    { "$ref": "#/$defs/UpdateParticipantDataConfiguration" },
-    { "$ref": "#/$defs/GetBy" },
-    { "$ref": "#/$defs/GetAllForOwner" },
-    { "$ref": "#/$defs/GetVersionHistoryFor" }
+    { "$ref": "#Add" },
+    { "$ref": "#AddVersion" },
+    { "$ref": "#UpdateParticipantDataConfiguration" },
+    { "$ref": "#GetBy" },
+    { "$ref": "#GetAllForOwner" },
+    { "$ref": "#GetVersionHistoryFor" }
   ],
   "$defs": {
     "ApiVersion": { "const": "1.1" },

--- a/rpc/schemas/protocols/StudyProtocolSnapshot.json
+++ b/rpc/schemas/protocols/StudyProtocolSnapshot.json
@@ -18,7 +18,7 @@
     },
     "connections": {
       "type": "array",
-      "items": { "$ref": "#/$defs/DeviceConnection" }
+      "items": { "$ref": "#DeviceConnection" }
     },
     "tasks": {
       "type": "array",
@@ -54,6 +54,7 @@
   "additionalProperties": false,
   "$defs": {
     "DeviceConnection": {
+      "$anchor": "DeviceConnection",
       "type": "object",
       "properties": {
         "roleName": { "type": "string" },

--- a/rpc/schemas/studies/RecruitmentService/RecruitmentServiceRequest.json
+++ b/rpc/schemas/studies/RecruitmentService/RecruitmentServiceRequest.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/AddParticipantByEmailAddress" },
-    { "$ref": "#/$defs/AddParticipantByUsername" },
-    { "$ref": "#/$defs/GetParticipant" },
-    { "$ref": "#/$defs/GetParticipants" },
-    { "$ref": "#/$defs/InviteNewParticipantGroup" },
-    { "$ref": "#/$defs/GetParticipantGroupStatusList" },
-    { "$ref": "#/$defs/StopParticipantGroup" }
+    { "$ref": "#AddParticipantByEmailAddress" },
+    { "$ref": "#AddParticipantByUsername" },
+    { "$ref": "#GetParticipant" },
+    { "$ref": "#GetParticipants" },
+    { "$ref": "#InviteNewParticipantGroup" },
+    { "$ref": "#GetParticipantGroupStatusList" },
+    { "$ref": "#StopParticipantGroup" }
   ],
   "$defs": {
     "ApiVersion": { "const": "1.2" },

--- a/rpc/schemas/studies/StudyService/StudyServiceRequest.json
+++ b/rpc/schemas/studies/StudyService/StudyServiceRequest.json
@@ -1,16 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/CreateStudy" },
-    { "$ref": "#/$defs/SetInternalDescription" },
-    { "$ref": "#/$defs/GetStudyDetails" },
-    { "$ref": "#/$defs/GetStudyStatus" },
-    { "$ref": "#/$defs/GetStudiesOverview" },
-    { "$ref": "#/$defs/SetInvitation" },
-    { "$ref": "#/$defs/SetProtocol" },
-    { "$ref": "#/$defs/RemoveProtocol" },
-    { "$ref": "#/$defs/GoLive" },
-    { "$ref": "#/$defs/Remove" }
+    { "$ref": "#CreateStudy" },
+    { "$ref": "#SetInternalDescription" },
+    { "$ref": "#GetStudyDetails" },
+    { "$ref": "#GetStudyStatus" },
+    { "$ref": "#GetStudiesOverview" },
+    { "$ref": "#SetInvitation" },
+    { "$ref": "#SetProtocol" },
+    { "$ref": "#RemoveProtocol" },
+    { "$ref": "#GoLive" },
+    { "$ref": "#Remove" }
   ],
   "$defs": {
     "ApiVersion": { "const": "1.1" },

--- a/rpc/schemas/studies/StudyStatus.json
+++ b/rpc/schemas/studies/StudyStatus.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/Configuring" },
-    { "$ref": "#/$defs/Live" }
+    { "$ref": "#Configuring" },
+    { "$ref": "#Live" }
   ],
   "$defs": {
     "StudyStatus": {

--- a/rpc/schemas/studies/users/ParticipantGroupStatus.json
+++ b/rpc/schemas/studies/users/ParticipantGroupStatus.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "oneOf": [
-    { "$ref": "#/$defs/Staged" },
-    { "$ref": "#/$defs/Invited" },
-    { "$ref": "#/$defs/Running" },
-    { "$ref": "#/$defs/Stopped" }
+    { "$ref": "#Staged" },
+    { "$ref": "#Invited" },
+    { "$ref": "#Running" },
+    { "$ref": "#Stopped" }
   ],
   "$defs": {
     "HACK-SEE-ISSUE-492": true,
@@ -21,6 +21,7 @@
       "required": [ "__type", "id", "participants" ]
     },
     "InDeployment": {
+      "$anchor": "InDeployment",
       "allOf": [ { "$ref": "#/$defs/ParticipantGroupStatus" } ],
       "properties": {
         "invitedOn": { "type": "string", "format": "date-time" },
@@ -48,7 +49,7 @@
       "unevaluatedProperties": false
     },
     "Running": {
-      "$anchor": "DeployingDevices",
+      "$anchor": "Running",
       "allOf": [ { "$ref": "#/$defs/InDeployment" } ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Running" },
@@ -58,7 +59,7 @@
       "unevaluatedProperties": false
     },
     "Stopped": {
-      "$anchor": "Running",
+      "$anchor": "Stopped",
       "allOf": [ { "$ref": "#/$defs/InDeployment" } ],
       "properties": {
         "__type": { "const": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Stopped" },

--- a/rpc/schemas/studies/users/ParticipantGroupStatus.json
+++ b/rpc/schemas/studies/users/ParticipantGroupStatus.json
@@ -7,6 +7,7 @@
     { "$ref": "#/$defs/Stopped" }
   ],
   "$defs": {
+    "HACK-SEE-ISSUE-492": true,
     "ParticipantGroupStatus": {
       "type": "object",
       "properties": {
@@ -23,7 +24,10 @@
       "allOf": [ { "$ref": "#/$defs/ParticipantGroupStatus" } ],
       "properties": {
         "invitedOn": { "type": "string", "format": "date-time" },
-        "studyDeploymentStatus": { "$ref": "../../deployments/StudyDeploymentStatus.json" }
+        "studyDeploymentStatus": { "$ref": "../../deployments/StudyDeploymentStatus.json" },
+
+        "id": { "$ref": "#/$defs/HACK-SEE-ISSUE-492" },
+        "participants": { "$ref": "#/$defs/HACK-SEE-ISSUE-492" }
       },
       "required": [ "invitedOn", "studyDeploymentStatus" ]
     },

--- a/rpc/src/test/kotlin/dk/cachet/carp/rpc/JsonSchemasTest.kt
+++ b/rpc/src/test/kotlin/dk/cachet/carp/rpc/JsonSchemasTest.kt
@@ -35,20 +35,20 @@ class JsonSchemasTest
                 val requestErrors = requestSchema.validate( requestJson )
                 check( requestErrors.isEmpty() )
                 {
-                    "JSON schema \"${requestSchema.currentUri}\" " +
+                    "JSON schema \"${requestSchema.schemaLocation}\" " +
                     "doesn't match generated JSON example of \"${r.requestObject.klass}\": $requestErrors"
                 }
 
                 // Validate response.
                 val requestObjectName = r.requestObject.klass.simpleName
                 val responseSchemaNode = requestSchema.getRefSchemaNode( "#/\$defs/$requestObjectName/Response" )
-                val responseSchema = schemaFactory.getSchema( requestSchema.currentUri, responseSchemaNode )
+                val responseSchema = schemaFactory.getSchema( requestSchema.schemaLocation, responseSchemaNode )
                 val responseJson = mapper.readTree( r.response.json )
                 val responseErrors = responseSchema.validate( responseJson )
                 check( responseErrors.isEmpty() )
                 {
-                    "JSON schema response defined in \"${requestSchema.currentUri}\" for \"$requestObjectName\" " +
-                    "doesn't match generated JSON example of \"${r.response.klass}\": $responseErrors"
+                    "JSON schema response defined in \"${requestSchema.schemaLocation}\" for \"$requestObjectName\" " +
+                    "doesn't match generated JSON example of \"${r.response.klass.simpleName}\": $responseErrors"
                 }
             }
         }


### PR DESCRIPTION
There was an error in the `DeviceDeploymentStatus` JSON schema which wasn't spotted by the JSON schema validator.

Upgrading to the latest version definitely provides better validation, but in addition also seems to introduce a bug in the evaluation of `unevaluatedProperties` (https://github.com/networknt/json-schema-validator/issues/1123). For now, I have removed these where it caused validation to fail, thus resulting in less strict/correct schema definitions. If we decide to merge this PR, we need to create a new bug to fix this once the bug is fixed in the schema validator.

On the upside, with the new version of `networknt
/json-schema-validator` it should be possible to use more concise anchor references (https://github.com/cph-cachet/carp.core-kotlin/issues/353). I'll add this as a separate commit later.