### PR TITLE
Upgrade to Kotlin 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,10 @@ fabric.properties
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+replay_pid*
+
+# Missing from gitignore.io template
+.kotlin/
 
 ### Node ###
 # Logs

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
         versions = [
             // Kotlin multiplatform versions.
-            kotlin:'1.9.23',
+            kotlin:'2.1.20',
             serialization:'1.6.3',
             coroutines:'1.8.0',
             datetime:'0.5.0',
@@ -110,6 +110,10 @@ configure( subprojects - devOpsModules ) {
                         it.optIn.add('kotlinx.coroutines.ExperimentalCoroutinesApi')
                     }
                     it.freeCompilerArgs.add('-Xexpect-actual-classes') // https://youtrack.jetbrains.com/issue/KT-61573
+
+                    // Already opt in globally to behavior which will become default in Kotlin 2.2:
+                    // https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-consistent-copy-visibility/
+                    it.freeCompilerArgs.add('-Xconsistent-data-class-copy-visibility')
                 } )
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
             // Kotlin multiplatform versions.
             kotlin:'2.1.20',
             serialization:'1.6.3',
-            coroutines:'1.8.0',
+            coroutines:'1.10.2',
             datetime:'0.5.0',
 
             // JVM versions.
@@ -19,14 +19,14 @@ buildscript {
             reflections:'0.10.2',
 
             // JS versions.
-            nodePlugin:'7.0.2',
-            bigJs:'6.2.1',
+            nodePlugin:'7.1.0',
+            bigJs:'7.0.1',
 
             // DevOps versions.
-            detektPlugin:'1.23.5',
-            detektVerifyImplementation:'1.2.5',
-            nexusPublishPlugin:'1.3.0',
-            apacheCommons:'2.15.1'
+            detektPlugin:'1.23.8',
+            detektVerifyImplementation:'1.2.6',
+            nexusPublishPlugin:'2.0.0',
+            apacheCommons:'2.19.0'
         ]
 
         commonModule = subprojects.find { it.name == 'carp.common' }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         versions = [
             // Kotlin multiplatform versions.
             kotlin:'2.1.20',
-            serialization:'1.6.3',
+            serialization:'1.8.1',
             coroutines:'1.10.2',
             datetime:'0.6.2',
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
             kotlin:'2.1.20',
             serialization:'1.6.3',
             coroutines:'1.10.2',
-            datetime:'0.5.0',
+            datetime:'0.6.2',
 
             // JVM versions.
             jvmTarget:'1.8',

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/RecurrenceRule.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/RecurrenceRule.kt
@@ -119,10 +119,10 @@ data class RecurrenceRule(
         /**
          * Bounds the recurrence rule in an inclusive manner to the associated start date of this rule plus [elapsedTime].
          */
+        @Suppress( "NON_EXPORTABLE_TYPE" )
         @Serializable
         data class Until(
             @Serializable( DurationSerializer::class )
-            @Suppress( "NON_EXPORTABLE_TYPE" )
             val elapsedTime: Duration
         ) : End()
         {

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/data/input/CustomInput.kt
@@ -11,7 +11,6 @@ import kotlin.reflect.KClass
 /**
  * Holds custom input data as requested by a researcher.
  */
-@Serializable( CustomInputSerializer::class )
 @SerialName( CUSTOM_INPUT_TYPE_NAME )
 @Suppress( "Immutable" ) // TODO: `assumeImmutable` configuration in detekt.yml is not working.
 @JsExport

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/TaskConfigurationList.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/tasks/TaskConfigurationList.kt
@@ -1,5 +1,6 @@
 package dk.cachet.carp.common.application.tasks
 
+import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.devices.DeviceConfiguration
 import kotlin.js.JsExport
 import kotlin.js.JsName
@@ -11,10 +12,11 @@ import kotlin.js.JsName
  *
  * Extend from this class as an object and assign members as follows: `val SOME_TASK = add { SomeTaskBuilder() }`.
  */
+@Suppress( "NON_EXPORTABLE_TYPE" )
 @JsExport
 open class TaskConfigurationList private constructor(
-    private val list: MutableList<SupportedTaskConfiguration<*, *>>
-) : List<SupportedTaskConfiguration<*, *>> by list
+    private val list: MutableList<SupportedTaskConfiguration<*, *, *>>
+) : List<SupportedTaskConfiguration<*, *, *>> by list
 {
     @JsName( "create" )
     constructor() : this( mutableListOf() )
@@ -28,9 +30,10 @@ open class TaskConfigurationList private constructor(
 
 
     protected fun <
-        TConfiguration : TaskConfiguration<*>,
+        TConfiguration : TaskConfiguration<TData>,
+        TData : Data,
         TBuilder : TaskConfigurationBuilder<TConfiguration>
-    > add( builder: () -> TBuilder ): SupportedTaskConfiguration<TConfiguration, TBuilder> =
+    > add( builder: () -> TBuilder ): SupportedTaskConfiguration<TConfiguration, TData, TBuilder> =
         SupportedTaskConfiguration( builder ).also { list.add( it ) }
 }
 
@@ -40,7 +43,8 @@ open class TaskConfigurationList private constructor(
  */
 @JsExport
 class SupportedTaskConfiguration<
-    TConfiguration : TaskConfiguration<*>,
+    TConfiguration : TaskConfiguration<TData>,
+    TData : Data,
     TBuilder : TaskConfigurationBuilder<TConfiguration>
 >( private val createBuilder: () -> TBuilder )
 {

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ElapsedTimeTrigger.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ElapsedTimeTrigger.kt
@@ -14,7 +14,7 @@ import kotlin.time.Duration
  * The start of a study deployment is determined by the first successful deployment of all participating devices.
  * This trigger needs to be evaluated on a primary device since it is time bound and therefore requires a task scheduler.
  */
-@Suppress( "DataClassPrivateConstructor" )
+@Suppress( "DataClassPrivateConstructor", "NON_EXPORTABLE_TYPE" )
 @Serializable
 @JsExport
 data class ElapsedTimeTrigger private constructor(

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ScheduledTrigger.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/triggers/ScheduledTrigger.kt
@@ -14,7 +14,13 @@ import kotlin.js.JsName
  * The iCalendar RFC 5545 standard is used to specify the recurrence rule: https://tools.ietf.org/html/rfc5545#section-3.3.10
  * This trigger needs to be evaluated on a primary device since it is time bound and therefore requires a task scheduler.
  */
-@Suppress( "DataClassPrivateConstructor" )
+@Suppress(
+    "DataClassPrivateConstructor",
+
+    // Needed, but not recognized by IDE.
+    "NON_EXPORTABLE_TYPE",
+    "KotlinRedundantDiagnosticSuppress"
+)
 @Serializable
 @JsExport
 data class ScheduledTrigger private constructor(

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializer.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownPolymorphicSerializer.kt
@@ -75,7 +75,8 @@ abstract class UnknownPolymorphicSerializer<P : Any, W : P>(
         }
 
         // Write the JSON object.
-        encoder.encodeStructure( overrideDescriptor )
+        val overrideEncoder = encoder.encodeInline( overrideDescriptor )
+        overrideEncoder.encodeStructure( overrideDescriptor )
         {
             var id = 0
             for ( field in unknownTypeFields.values )

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/CustomSerializerWrapperTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/CustomSerializerWrapperTest.kt
@@ -19,11 +19,10 @@ class CustomSerializerWrapperTest
     fun can_enforce_serializing_as_polymorph_base_class()
     {
         val wrapper = customSerializerWrapper( SealedBase.ExtendsSealed(), SealedBase.serializer() )
-        val json = Json {}
 
-        val serialized = json.encodeToString( CustomSerializerWrapper.serializer(), wrapper )
+        val serialized = Json.encodeToString( CustomSerializerWrapper.serializer(), wrapper )
 
-        val jsonObject = json.parseToJsonElement( serialized ) as JsonObject
+        val jsonObject = Json.parseToJsonElement( serialized ) as JsonObject
         assertTrue( jsonObject.contains( "type" ) )
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
@@ -70,7 +70,7 @@ class SerializationTest : ConcreteTypesSerializationTest(
     }
 
     @Test
-    fun can_serialize_generic_CustomInput()
+    fun can_serialize_polymorphic_CustomInput()
     {
         val data: Data = CustomInput( 42 )
         val dataSerializer = PolymorphicSerializer( Data::class )

--- a/carp.data.core/src/jsMain/kotlin/dk/cachet/carp/data/application/SyncPoint.kt
+++ b/carp.data.core/src/jsMain/kotlin/dk/cachet/carp/data/application/SyncPoint.kt
@@ -11,11 +11,15 @@ import dk.cachet.carp.common.application.toEpochMicroseconds
 external fun Big( number: Number ): dynamic
 
 
+@Suppress( "UNUSED_VARIABLE" )
 actual fun SyncPoint.applyToTimestamp( timestamp: Long ): Long
 {
-    val excludingEpoch = Big( relativeClockSpeed ).times(
-        Big( timestamp - sensorTimestampAtSyncPoint )
-    ).toFixed() as String
+    val bigClock = Big( relativeClockSpeed )
+    val bigOffset = Big( timestamp - sensorTimestampAtSyncPoint )
+
+    // `js` needs to be used here to prevent `.times()` from being transpiled into a `*` operator:
+    // https://youtrack.jetbrains.com/issue/KT-77320/Kotlin-JS-compiles-Big.js-times-method-to-operator
+    val excludingEpoch = js( "bigClock.times( bigOffset )" ).toFixed() as String
 
     return excludingEpoch.toLong() + synchronizedOn.toEpochMicroseconds()
 }

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/AssignedPrimaryDevice.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/users/AssignedPrimaryDevice.kt
@@ -9,6 +9,7 @@ import kotlin.js.JsExport
 /**
  * Primary [device] and its current [registration] assigned to participants as part of a participant group.
  */
+@Suppress( "NON_EXPORTABLE_TYPE", "KotlinRedundantDiagnosticSuppress" ) // Needed, but not recognized by IDE.
 @Serializable
 @JsExport
 data class AssignedPrimaryDevice(

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentSnapshotTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentSnapshotTest.kt
@@ -35,7 +35,6 @@ class StudyDeploymentSnapshotTest :
     /**
      * Types not known at compile time should not prevent deserializing a deployment, but should be loaded through a 'Custom' type wrapper.
      */
-    @ExperimentalSerializationApi
     @Test
     fun unknown_types_are_wrapped_when_deserializing()
     {
@@ -49,7 +48,6 @@ class StudyDeploymentSnapshotTest :
     /**
      * Types which were wrapped in a 'Custom' type wrapper upon deserialization should be serialized to their original form (returning the original type, not the wrapper).
      */
-    @ExperimentalSerializationApi
     @Test
     fun serializing_unknown_types_removes_the_wrapper()
     {
@@ -63,7 +61,6 @@ class StudyDeploymentSnapshotTest :
     /**
      * Create a serialized deployment (snapshot) of a study protocol with exactly one primary device which is registered using an unknown device registration.
      */
-    @ExperimentalSerializationApi
     private fun serializeDeploymentSnapshotIncludingUnknownRegistration(): String
     {
         val protocol = createEmptyProtocol()

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentStatusTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentStatusTest.kt
@@ -49,7 +49,6 @@ class StudyDeploymentStatusTest
         assertEquals( status, parsed )
     }
 
-    @ExperimentalSerializationApi
     @Test
     fun serializing_deployment_when_unknown_devices_are_involved()
     {

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentTest.kt
@@ -61,7 +61,6 @@ class StudyDeploymentTest
         }
     }
 
-    @ExperimentalSerializationApi
     @Test
     fun create_deployment_fromSnapshot_with_custom_extending_types_succeeds()
     {

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolVersion.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/application/ProtocolVersion.kt
@@ -12,11 +12,11 @@ import kotlin.js.JsExport
  *
  * @param date The date when this version of the protocol was created.
  */
+@Suppress( "NON_EXPORTABLE_TYPE" )
 @Serializable
 @JsExport
 data class ProtocolVersion(
     val tag: String,
     @Required
-    @Suppress( "NON_EXPORTABLE_TYPE" )
     val date: Instant = Clock.System.now()
 )

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
@@ -38,7 +38,6 @@ class StudyProtocolSnapshotTest :
     /**
      * Types not known at compile time should not prevent deserializing a protocol, but should be loaded through a 'Custom' type wrapper.
      */
-    @ExperimentalSerializationApi
     @Test
     fun unknown_types_are_wrapped_when_deserializing()
     {
@@ -55,7 +54,6 @@ class StudyProtocolSnapshotTest :
         assertEquals( 1, parsed.triggers.count { t -> t.value is CustomTriggerConfiguration } )
     }
 
-    @ExperimentalSerializationApi
     @Test
     fun unknown_connected_primary_device_is_deserialized_as_a_primary_device()
     {
@@ -76,7 +74,6 @@ class StudyProtocolSnapshotTest :
     /**
      * Types which were wrapped in a 'Custom' type wrapper upon deserialization should be serialized to their original form (returning the original type, not the wrapper).
      */
-    @ExperimentalSerializationApi
     @Test
     fun serializing_unknown_types_removes_the_wrapper()
     {
@@ -87,7 +84,6 @@ class StudyProtocolSnapshotTest :
         assertEquals( serialized, customSerialized )
     }
 
-    @ExperimentalSerializationApi
     @Test
     fun create_protocol_fromSnapshot_with_custom_extending_types_succeeds()
     {
@@ -104,7 +100,6 @@ class StudyProtocolSnapshotTest :
      * (3) known task with an unknown measure and known data type
      * There is thus exactly one unknown object for each of these types, except for 'Measure' which has two.
      */
-    @ExperimentalSerializationApi
     private fun serializeProtocolSnapshotIncludingUnknownTypes(): String
     {
         val protocol = createComplexProtocol()

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -44,7 +44,15 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.25":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.9":
   version "0.3.20"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz#72e45707cf240fa6b081d0366f8265b0cd10197f"
   integrity sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==
@@ -97,11 +105,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
-  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
-
 "@types/cors@^2.8.12":
   version "2.8.15"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.15.tgz#eb143aa2f8807ddd78e83cbff141bbedd91b60ee"
@@ -109,26 +112,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/eslint-scope@^3.7.3":
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.6.tgz#585578b368ed170e67de8aae7b93f54a1b2fdc26"
-  integrity sha512-zfM4ipmxVKWdxtDaJ3MP3pBurDXOCoyjvlpE3u6Qzrmw4BPbfm4/ambIeTk/r/J0iq/+2/xp0Fmt+gFvXJY2PQ==
-  dependencies:
-    "@types/eslint" "*"
-    "@types/estree" "*"
-
-"@types/eslint@*":
-  version "8.44.6"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.44.6.tgz#60e564551966dd255f4c01c459f0b4fb87068603"
-  integrity sha512-P6bY56TVmX8y9J87jHNgQh43h6VVU+6H7oN7hgvivV81K2XY8qJZ5vqPy/HdUoVIelii2kChYVzQanlswPWVFw==
-  dependencies:
-    "@types/estree" "*"
-    "@types/json-schema" "*"
-
-"@types/estree@*", "@types/estree@^1.0.0":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.3.tgz#2be19e759a3dd18c79f9f436bd7363556c1a73dd"
-  integrity sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==
+"@types/estree@^1.0.5":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
+  integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.33":
   version "4.17.39"
@@ -162,7 +149,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.14"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.14.tgz#74a97a5573980802f32c8e47b663530ab3b6b7d1"
   integrity sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==
@@ -230,145 +217,145 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ws@^8.5.1":
-  version "8.5.8"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.8.tgz#13efec7bd439d0bdf2af93030804a94f163b1430"
-  integrity sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==
+"@types/ws@^8.5.5":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
   dependencies:
     "@types/node" "*"
 
-"@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.6.tgz#db046555d3c413f8966ca50a95176a0e2c642e24"
-  integrity sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==
+"@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.12.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.14.1.tgz#a9f6a07f2b03c95c8d38c4536a1fdfb521ff55b6"
+  integrity sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==
   dependencies:
-    "@webassemblyjs/helper-numbers" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
+    "@webassemblyjs/helper-numbers" "1.13.2"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
 
-"@webassemblyjs/floating-point-hex-parser@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz#dacbcb95aff135c8260f77fa3b4c5fea600a6431"
-  integrity sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==
+"@webassemblyjs/floating-point-hex-parser@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz#fcca1eeddb1cc4e7b6eed4fc7956d6813b21b9fb"
+  integrity sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==
 
-"@webassemblyjs/helper-api-error@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz#6132f68c4acd59dcd141c44b18cbebbd9f2fa768"
-  integrity sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==
+"@webassemblyjs/helper-api-error@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz#e0a16152248bc38daee76dd7e21f15c5ef3ab1e7"
+  integrity sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==
 
-"@webassemblyjs/helper-buffer@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz#b66d73c43e296fd5e88006f18524feb0f2c7c093"
-  integrity sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==
+"@webassemblyjs/helper-buffer@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz#822a9bc603166531f7d5df84e67b5bf99b72b96b"
+  integrity sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==
 
-"@webassemblyjs/helper-numbers@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz#cbce5e7e0c1bd32cf4905ae444ef64cea919f1b5"
-  integrity sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==
+"@webassemblyjs/helper-numbers@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz#dbd932548e7119f4b8a7877fd5a8d20e63490b2d"
+  integrity sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==
   dependencies:
-    "@webassemblyjs/floating-point-hex-parser" "1.11.6"
-    "@webassemblyjs/helper-api-error" "1.11.6"
+    "@webassemblyjs/floating-point-hex-parser" "1.13.2"
+    "@webassemblyjs/helper-api-error" "1.13.2"
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/helper-wasm-bytecode@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz#bb2ebdb3b83aa26d9baad4c46d4315283acd51e9"
-  integrity sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==
+"@webassemblyjs/helper-wasm-bytecode@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz#e556108758f448aae84c850e593ce18a0eb31e0b"
+  integrity sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==
 
-"@webassemblyjs/helper-wasm-section@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz#ff97f3863c55ee7f580fd5c41a381e9def4aa577"
-  integrity sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==
+"@webassemblyjs/helper-wasm-section@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz#9629dda9c4430eab54b591053d6dc6f3ba050348"
+  integrity sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-buffer" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/wasm-gen" "1.11.6"
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-buffer" "1.14.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
+    "@webassemblyjs/wasm-gen" "1.14.1"
 
-"@webassemblyjs/ieee754@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz#bb665c91d0b14fffceb0e38298c329af043c6e3a"
-  integrity sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==
+"@webassemblyjs/ieee754@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz#1c5eaace1d606ada2c7fd7045ea9356c59ee0dba"
+  integrity sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
 
-"@webassemblyjs/leb128@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.6.tgz#70e60e5e82f9ac81118bc25381a0b283893240d7"
-  integrity sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==
+"@webassemblyjs/leb128@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.13.2.tgz#57c5c3deb0105d02ce25fa3fd74f4ebc9fd0bbb0"
+  integrity sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==
   dependencies:
     "@xtuc/long" "4.2.2"
 
-"@webassemblyjs/utf8@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz#90f8bc34c561595fe156603be7253cdbcd0fab5a"
-  integrity sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==
+"@webassemblyjs/utf8@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.13.2.tgz#917a20e93f71ad5602966c2d685ae0c6c21f60f1"
+  integrity sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==
 
-"@webassemblyjs/wasm-edit@^1.11.5":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz#c72fa8220524c9b416249f3d94c2958dfe70ceab"
-  integrity sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==
+"@webassemblyjs/wasm-edit@^1.12.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz#ac6689f502219b59198ddec42dcd496b1004d597"
+  integrity sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-buffer" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/helper-wasm-section" "1.11.6"
-    "@webassemblyjs/wasm-gen" "1.11.6"
-    "@webassemblyjs/wasm-opt" "1.11.6"
-    "@webassemblyjs/wasm-parser" "1.11.6"
-    "@webassemblyjs/wast-printer" "1.11.6"
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-buffer" "1.14.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
+    "@webassemblyjs/helper-wasm-section" "1.14.1"
+    "@webassemblyjs/wasm-gen" "1.14.1"
+    "@webassemblyjs/wasm-opt" "1.14.1"
+    "@webassemblyjs/wasm-parser" "1.14.1"
+    "@webassemblyjs/wast-printer" "1.14.1"
 
-"@webassemblyjs/wasm-gen@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz#fb5283e0e8b4551cc4e9c3c0d7184a65faf7c268"
-  integrity sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==
+"@webassemblyjs/wasm-gen@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz#991e7f0c090cb0bb62bbac882076e3d219da9570"
+  integrity sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/ieee754" "1.11.6"
-    "@webassemblyjs/leb128" "1.11.6"
-    "@webassemblyjs/utf8" "1.11.6"
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
+    "@webassemblyjs/ieee754" "1.13.2"
+    "@webassemblyjs/leb128" "1.13.2"
+    "@webassemblyjs/utf8" "1.13.2"
 
-"@webassemblyjs/wasm-opt@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz#d9a22d651248422ca498b09aa3232a81041487c2"
-  integrity sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==
+"@webassemblyjs/wasm-opt@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz#e6f71ed7ccae46781c206017d3c14c50efa8106b"
+  integrity sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-buffer" "1.11.6"
-    "@webassemblyjs/wasm-gen" "1.11.6"
-    "@webassemblyjs/wasm-parser" "1.11.6"
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-buffer" "1.14.1"
+    "@webassemblyjs/wasm-gen" "1.14.1"
+    "@webassemblyjs/wasm-parser" "1.14.1"
 
-"@webassemblyjs/wasm-parser@1.11.6", "@webassemblyjs/wasm-parser@^1.11.5":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz#bb85378c527df824004812bbdb784eea539174a1"
-  integrity sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==
+"@webassemblyjs/wasm-parser@1.14.1", "@webassemblyjs/wasm-parser@^1.12.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz#b3e13f1893605ca78b52c68e54cf6a865f90b9fb"
+  integrity sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-api-error" "1.11.6"
-    "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/ieee754" "1.11.6"
-    "@webassemblyjs/leb128" "1.11.6"
-    "@webassemblyjs/utf8" "1.11.6"
+    "@webassemblyjs/ast" "1.14.1"
+    "@webassemblyjs/helper-api-error" "1.13.2"
+    "@webassemblyjs/helper-wasm-bytecode" "1.13.2"
+    "@webassemblyjs/ieee754" "1.13.2"
+    "@webassemblyjs/leb128" "1.13.2"
+    "@webassemblyjs/utf8" "1.13.2"
 
-"@webassemblyjs/wast-printer@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz#a7bf8dd7e362aeb1668ff43f35cb849f188eff20"
-  integrity sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==
+"@webassemblyjs/wast-printer@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz#3bb3e9638a8ae5fdaf9610e7a06b4d9f9aa6fe07"
+  integrity sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
+    "@webassemblyjs/ast" "1.14.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^2.1.0":
+"@webpack-cli/configtest@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-2.1.1.tgz#3b2f852e91dac6e3b85fb2a314fb8bef46d94646"
   integrity sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==
 
-"@webpack-cli/info@^2.0.1":
+"@webpack-cli/info@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-2.0.2.tgz#cc3fbf22efeb88ff62310cf885c5b09f44ae0fdd"
   integrity sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==
 
-"@webpack-cli/serve@^2.0.3":
+"@webpack-cli/serve@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
@@ -383,11 +370,6 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-abab@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
-  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -396,10 +378,10 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.7.6:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
-  integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
+acorn-import-attributes@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
 
 acorn@^8.7.1, acorn@^8.8.2:
   version "8.10.0"
@@ -445,10 +427,10 @@ ajv@^8.0.0, ajv@^8.9.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ansi-colors@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+ansi-colors@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
 ansi-html-community@^0.0.8:
   version "0.0.8"
@@ -583,20 +565,20 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browser-stdout@1.3.1:
+browser-stdout@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.14.5:
-  version "4.22.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.1.tgz#ba91958d1a59b87dab6fed8dfbcb3da5e2e9c619"
-  integrity sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==
+browserslist@^4.21.10:
+  version "4.24.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.5.tgz#aa0f5b8560fe81fde84c6dcb38f759bafba0e11b"
+  integrity sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==
   dependencies:
-    caniuse-lite "^1.0.30001541"
-    electron-to-chromium "^1.4.535"
-    node-releases "^2.0.13"
-    update-browserslist-db "^1.0.13"
+    caniuse-lite "^1.0.30001716"
+    electron-to-chromium "^1.5.149"
+    node-releases "^2.0.19"
+    update-browserslist-db "^1.1.3"
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -627,10 +609,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001541:
-  version "1.0.30001551"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz#1f2cfa8820bd97c971a57349d7fd8f6e08664a3e"
-  integrity sha512-vtBAez47BoGMMzlbYhfXrMV1kvRF2WP/lqiMuDu1Sb4EE4LKEgjopFDSRtZfdVnslNRpOqV/woE+Xgrwj6VQlg==
+caniuse-lite@^1.0.30001716:
+  version "1.0.30001716"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz#39220dfbc58c85d9d4519e7090b656aa11ca4b85"
+  integrity sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==
 
 chalk@^4.1.0:
   version "4.1.2"
@@ -640,7 +622,7 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@3.5.3, chokidar@^3.5.1, chokidar@^3.5.3:
+chokidar@^3.5.1, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -767,10 +749,10 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
-cookie@~0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
-  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+cookie@~0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -811,12 +793,19 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.4, debug@^4.1.0, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
+debug@^4.1.0, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^4.3.5:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+  dependencies:
+    ms "^2.1.3"
 
 decamelize@^4.0.0:
   version "4.0.0"
@@ -869,10 +858,10 @@ di@^0.0.1:
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==
 
-diff@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+diff@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
+  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -901,10 +890,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.4.535:
-  version "1.4.563"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.563.tgz#dabb424202754c1fed2d2938ff564b23d3bbf0d3"
-  integrity sha512-dg5gj5qOgfZNkPNeyKBZQAQitIQ/xwfIDmEQJHCbXaD9ebTZxwJXUsDYcBlAvZGZLi+/354l35J1wkmP6CqYaw==
+electron-to-chromium@^1.5.149:
+  version "1.5.149"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.149.tgz#b6d1a468b9537165e2494d0b5b82e9b3392d0ddb"
+  integrity sha512-UyiO82eb9dVOx8YO3ajDf9jz2kKyt98DEITRdeLPstOEuTlLzDA4Gyq5K9he71TQziU5jUVu2OAu5N48HmQiyQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -921,26 +910,25 @@ engine.io-parser@~5.2.1:
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.2.1.tgz#9f213c77512ff1a6cc0c7a86108a7ffceb16fcfb"
   integrity sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==
 
-engine.io@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.5.3.tgz#80b0692912cef3a417e1b7433301d6397bf0374b"
-  integrity sha512-IML/R4eG/pUS5w7OfcDE0jKrljWS9nwnEfsxWCIJF5eO6AHo6+Hlv+lQbdlAYsiJPHzUthLm1RUjnBzWOs45cw==
+engine.io@~6.6.0:
+  version "6.6.4"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.6.4.tgz#0a89a3e6b6c1d4b0c2a2a637495e7c149ec8d8ee"
+  integrity sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==
   dependencies:
-    "@types/cookie" "^0.4.1"
     "@types/cors" "^2.8.12"
     "@types/node" ">=10.0.0"
     accepts "~1.3.4"
     base64id "2.0.0"
-    cookie "~0.4.1"
+    cookie "~0.7.2"
     cors "~2.8.5"
     debug "~4.3.1"
     engine.io-parser "~5.2.1"
-    ws "~8.11.0"
+    ws "~8.17.1"
 
-enhanced-resolve@^5.13.0:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz#1af946c7d93603eb88e9896cee4904dc012e9c35"
-  integrity sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==
+enhanced-resolve@^5.17.1:
+  version "5.18.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz#728ab082f8b7b6836de51f1637aab5d3b9568faf"
+  integrity sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -965,12 +953,17 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
+escalade@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-escape-string-regexp@4.0.0:
+escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
@@ -1127,20 +1120,20 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
-find-up@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
 find-up@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 flat@^5.0.2:
@@ -1234,18 +1227,6 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^7.1.3, glob@^7.1.7:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -1258,6 +1239,17 @@ glob@^7.1.3, glob@^7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -1265,7 +1257,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1304,7 +1296,7 @@ hasown@^2.0.0:
   dependencies:
     function-bind "^1.1.2"
 
-he@1.2.0:
+he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -1539,7 +1531,7 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-js-yaml@4.1.0:
+js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -1589,19 +1581,19 @@ karma-sourcemap-loader@0.4.0:
   dependencies:
     graceful-fs "^4.2.10"
 
-karma-webpack@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.0.tgz#2a2c7b80163fe7ffd1010f83f5507f95ef39f840"
-  integrity sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==
+karma-webpack@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.1.tgz#4eafd31bbe684a747a6e8f3e4ad373e53979ced4"
+  integrity sha512-oo38O+P3W2mSPCSUrQdySSPv1LvPpXP+f+bBimNomS5sW+1V4SuhCuW8TfJzV+rDv921w2fDSDw0xJbPe6U+kQ==
   dependencies:
     glob "^7.1.3"
-    minimatch "^3.0.4"
+    minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.2.tgz#a983f874cee6f35990c4b2dcc3d274653714de8e"
-  integrity sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==
+karma@6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.4.tgz#dfa5a426cf5a8b53b43cd54ef0d0d09742351492"
+  integrity sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
@@ -1622,7 +1614,7 @@ karma@6.4.2:
     qjobs "^1.2.0"
     range-parser "^1.2.1"
     rimraf "^3.0.2"
-    socket.io "^4.4.1"
+    socket.io "^4.7.2"
     source-map "^0.6.1"
     tmp "^0.2.1"
     ua-parser-js "^0.7.30"
@@ -1632,6 +1624,13 @@ kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+kotlin-web-helpers@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-2.0.0.tgz#b112096b273c1e733e0b86560998235c09a19286"
+  integrity sha512-xkVGl60Ygn/zuLkDPx+oHj7jeLR7hCvoNF99nhwXMn8a3ApB4lLiC9pk4ol4NHPjyoCbvQctBqvzUcp8pkqyWw==
+  dependencies:
+    format-util "^1.0.5"
 
 launch-editor@^2.6.0:
   version "2.6.1"
@@ -1665,7 +1664,7 @@ lodash@^4.17.15, lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@4.1.0:
+log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -1751,19 +1750,26 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1, minimatch@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.3:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.8"
@@ -1777,32 +1783,31 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
-  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+mocha@10.7.3:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.3.tgz#ae32003cabbd52b59aece17846056a68eb4b0752"
+  integrity sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==
   dependencies:
-    ansi-colors "4.1.1"
-    browser-stdout "1.3.1"
-    chokidar "3.5.3"
-    debug "4.3.4"
-    diff "5.0.0"
-    escape-string-regexp "4.0.0"
-    find-up "5.0.0"
-    glob "7.2.0"
-    he "1.2.0"
-    js-yaml "4.1.0"
-    log-symbols "4.1.0"
-    minimatch "5.0.1"
-    ms "2.1.3"
-    nanoid "3.3.3"
-    serialize-javascript "6.0.0"
-    strip-json-comments "3.1.1"
-    supports-color "8.1.1"
-    workerpool "6.2.1"
-    yargs "16.2.0"
-    yargs-parser "20.2.4"
-    yargs-unparser "2.0.0"
+    ansi-colors "^4.1.3"
+    browser-stdout "^1.3.1"
+    chokidar "^3.5.3"
+    debug "^4.3.5"
+    diff "^5.2.0"
+    escape-string-regexp "^4.0.0"
+    find-up "^5.0.0"
+    glob "^8.1.0"
+    he "^1.2.0"
+    js-yaml "^4.1.0"
+    log-symbols "^4.1.0"
+    minimatch "^5.1.6"
+    ms "^2.1.3"
+    serialize-javascript "^6.0.2"
+    strip-json-comments "^3.1.1"
+    supports-color "^8.1.1"
+    workerpool "^6.5.1"
+    yargs "^16.2.0"
+    yargs-parser "^20.2.9"
+    yargs-unparser "^2.0.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1814,7 +1819,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -1826,11 +1831,6 @@ multicast-dns@^7.2.5:
   dependencies:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
-
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -1847,10 +1847,10 @@ node-forge@^1:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
-node-releases@^2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
-  integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
+node-releases@^2.0.19:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
+  integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -1996,6 +1996,11 @@ picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
@@ -2175,7 +2180,7 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-schema-utils@^3.1.1, schema-utils@^3.1.2:
+schema-utils@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
   integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
@@ -2188,6 +2193,16 @@ schema-utils@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.2.0.tgz#70d7c93e153a273a805801882ebd3bff20d89c8b"
   integrity sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.9.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.1.0"
+
+schema-utils@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.2.tgz#0c10878bf4a73fd2b1dfd14b9462b26788c806ae"
+  integrity sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
     ajv "^8.9.0"
@@ -2225,17 +2240,10 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
-  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
-  integrity sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==
+serialize-javascript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
 
@@ -2335,16 +2343,16 @@ socket.io-parser@~4.2.4:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
-socket.io@^4.4.1:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.7.2.tgz#22557d76c3f3ca48f82e73d68b7add36a22df002"
-  integrity sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==
+socket.io@^4.7.2:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.8.1.tgz#fa0eaff965cc97fdf4245e8d4794618459f7558a"
+  integrity sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==
   dependencies:
     accepts "~1.3.4"
     base64id "~2.0.0"
     cors "~2.8.5"
     debug "~4.3.2"
-    engine.io "~6.5.2"
+    engine.io "~6.6.0"
     socket.io-adapter "~2.5.2"
     socket.io-parser "~4.2.4"
 
@@ -2362,12 +2370,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
-source-map-loader@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-4.0.1.tgz#72f00d05f5d1f90f80974eda781cbd7107c125f2"
-  integrity sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==
+source-map-loader@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-5.0.0.tgz#f593a916e1cc54471cfc8851b905c8a845fc7e38"
+  integrity sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==
   dependencies:
-    abab "^2.0.6"
     iconv-lite "^0.6.3"
     source-map-js "^1.0.2"
 
@@ -2461,22 +2468,22 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-json-comments@3.1.1:
+strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-supports-color@8.1.1, supports-color@^8.0.0:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
 
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.0.0, supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -2490,21 +2497,21 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-terser-webpack-plugin@^5.3.7:
-  version "5.3.9"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
-  integrity sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==
+terser-webpack-plugin@^5.3.10:
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz#9031d48e57ab27567f02ace85c7d690db66c3e06"
+  integrity sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.17"
+    "@jridgewell/trace-mapping" "^0.3.25"
     jest-worker "^27.4.5"
-    schema-utils "^3.1.1"
-    serialize-javascript "^6.0.1"
-    terser "^5.16.8"
+    schema-utils "^4.3.0"
+    serialize-javascript "^6.0.2"
+    terser "^5.31.1"
 
-terser@^5.16.8:
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.22.0.tgz#4f18103f84c5c9437aafb7a14918273310a8a49d"
-  integrity sha512-hHZVLgRA2z4NWcN6aS5rQDc+7Dcy58HOf2zbYwmFcQ+ua3h6eEFf5lIDKTzbWwlazPyOZsFQO8V80/IjVNExEw==
+terser@^5.31.1:
+  version "5.39.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.39.0.tgz#0e82033ed57b3ddf1f96708d123cca717d86ca3a"
+  integrity sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
@@ -2543,10 +2550,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 ua-parser-js@^0.7.30:
   version "0.7.36"
@@ -2568,13 +2575,13 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
-update-browserslist-db@^1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"
-  integrity sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==
+update-browserslist-db@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz#348377dd245216f9e7060ff50b15a1b740b75420"
+  integrity sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==
   dependencies:
-    escalade "^3.1.1"
-    picocolors "^1.0.0"
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -2608,10 +2615,10 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==
 
-watchpack@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
-  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
+watchpack@^2.4.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.2.tgz#2feeaed67412e7c33184e5a79ca738fbd38564da"
+  integrity sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
@@ -2623,15 +2630,15 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-webpack-cli@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.0.tgz#abc4b1f44b50250f2632d8b8b536cfe2f6257891"
-  integrity sha512-a7KRJnCxejFoDpYTOwzm5o21ZXMaNqtRlvS183XzGDUPRdVEzJNImcQokqYZ8BNTnk9DkKiuWxw75+DCCoZ26w==
+webpack-cli@5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz#c8e046ba7eaae4911d7e71e2b25b776fcc35759b"
+  integrity sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^2.1.0"
-    "@webpack-cli/info" "^2.0.1"
-    "@webpack-cli/serve" "^2.0.3"
+    "@webpack-cli/configtest" "^2.1.1"
+    "@webpack-cli/info" "^2.0.2"
+    "@webpack-cli/serve" "^2.0.5"
     colorette "^2.0.14"
     commander "^10.0.1"
     cross-spawn "^7.0.3"
@@ -2642,10 +2649,10 @@ webpack-cli@5.1.0:
     rechoir "^0.8.0"
     webpack-merge "^5.7.3"
 
-webpack-dev-middleware@^5.3.1:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
-  integrity sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==
+webpack-dev-middleware@^5.3.4:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz#eb7b39281cbce10e104eb2b8bf2b63fce49a3517"
+  integrity sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==
   dependencies:
     colorette "^2.0.10"
     memfs "^3.4.3"
@@ -2653,10 +2660,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@4.15.0:
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.15.0.tgz#87ba9006eca53c551607ea0d663f4ae88be7af21"
-  integrity sha512-HmNB5QeSl1KpulTBQ8UT4FPrByYyaLxpJoQ0+s7EvUrMc16m0ZS1sgb1XGqzmgCPk0c9y+aaXxn11tbLzuM7NQ==
+webpack-dev-server@4.15.2:
+  version "4.15.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz#9e0c70a42a012560860adb186986da1248333173"
+  integrity sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"
@@ -2664,7 +2671,7 @@ webpack-dev-server@4.15.0:
     "@types/serve-index" "^1.9.1"
     "@types/serve-static" "^1.13.10"
     "@types/sockjs" "^0.3.33"
-    "@types/ws" "^8.5.1"
+    "@types/ws" "^8.5.5"
     ansi-html-community "^0.0.8"
     bonjour-service "^1.0.11"
     chokidar "^3.5.3"
@@ -2686,7 +2693,7 @@ webpack-dev-server@4.15.0:
     serve-index "^1.9.1"
     sockjs "^0.3.24"
     spdy "^4.0.2"
-    webpack-dev-middleware "^5.3.1"
+    webpack-dev-middleware "^5.3.4"
     ws "^8.13.0"
 
 webpack-merge@^4.1.5:
@@ -2710,34 +2717,33 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.82.0:
-  version "5.82.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.82.0.tgz#3c0d074dec79401db026b4ba0fb23d6333f88e7d"
-  integrity sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==
+webpack@5.94.0:
+  version "5.94.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.94.0.tgz#77a6089c716e7ab90c1c67574a28da518a20970f"
+  integrity sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==
   dependencies:
-    "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^1.0.0"
-    "@webassemblyjs/ast" "^1.11.5"
-    "@webassemblyjs/wasm-edit" "^1.11.5"
-    "@webassemblyjs/wasm-parser" "^1.11.5"
+    "@types/estree" "^1.0.5"
+    "@webassemblyjs/ast" "^1.12.1"
+    "@webassemblyjs/wasm-edit" "^1.12.1"
+    "@webassemblyjs/wasm-parser" "^1.12.1"
     acorn "^8.7.1"
-    acorn-import-assertions "^1.7.6"
-    browserslist "^4.14.5"
+    acorn-import-attributes "^1.9.5"
+    browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.13.0"
+    enhanced-resolve "^5.17.1"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.9"
+    graceful-fs "^4.2.11"
     json-parse-even-better-errors "^2.3.1"
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
-    schema-utils "^3.1.2"
+    schema-utils "^3.2.0"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.7"
-    watchpack "^2.4.0"
+    terser-webpack-plugin "^5.3.10"
+    watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
@@ -2773,10 +2779,10 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
 
-workerpool@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
-  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
+workerpool@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
+  integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -2802,22 +2808,22 @@ ws@~8.11.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
 
+ws@~8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yargs-parser@20.2.4:
-  version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
-
-yargs-parser@^20.2.2:
+yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-unparser@2.0.0:
+yargs-unparser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
   integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
@@ -2827,7 +2833,7 @@ yargs-unparser@2.0.0:
     flat "^5.0.2"
     is-plain-obj "^2.1.0"
 
-yargs@16.2.0, yargs@^16.1.1:
+yargs@^16.1.1, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -487,10 +487,10 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
 
-big.js@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.2.1.tgz#7205ce763efb17c2e41f26f121c420c6a7c2744f"
-  integrity sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==
+big.js@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-7.0.1.tgz#c537c649ec6ea11d1306723d13c096ba199aadc4"
+  integrity sha512-iFgV784tD8kq4ccF1xtNMZnXeZzVuXWWM+ERFzKQjv+A5G9HC8CY3DuV45vgzFFcW+u2tIvmF95+AzWgs6BjCg==
 
 binary-extensions@^2.0.0:
   version "2.2.0"

--- a/publish-npm-packages/src/forced-exports/Kotlin-DateTime-library-kotlinx-datetime
+++ b/publish-npm-packages/src/forced-exports/Kotlin-DateTime-library-kotlinx-datetime
@@ -1,3 +1,3 @@
 System
-System_getInstance
+System_instance
 Instant_0

--- a/publish-npm-packages/src/forced-exports/kotlin-kotlin-stdlib
+++ b/publish-npm-packages/src/forced-exports/kotlin-kotlin-stdlib
@@ -1,5 +1,5 @@
 Long
-toLong_0
+toLong
 EmptyList
 AbstractMutableList
 HashSet
@@ -10,6 +10,6 @@ to
 listOf_0
 setOf_0
 mapOf_0
-Companion_getInstance_13
+Companion_getInstance_17
 _Duration___get_inWholeMilliseconds__impl__msfiry
 _Duration___get_inWholeMicroseconds__impl__8oe8vv

--- a/publish-npm-packages/src/forced-exports/kotlin-kotlin-stdlib
+++ b/publish-npm-packages/src/forced-exports/kotlin-kotlin-stdlib
@@ -10,6 +10,6 @@ to
 listOf_0
 setOf_0
 mapOf_0
-Companion_getInstance_17
+Companion_getInstance_20
 _Duration___get_inWholeMilliseconds__impl__msfiry
 _Duration___get_inWholeMicroseconds__impl__8oe8vv

--- a/publish-npm-packages/src/forced-exports/kotlinx-serialization-kotlinx-serialization-json
+++ b/publish-npm-packages/src/forced-exports/kotlinx-serialization-kotlinx-serialization-json
@@ -1,2 +1,2 @@
-JsonImpl
+Json
 Default_getInstance

--- a/typescript-declarations/carp-common/index.ts
+++ b/typescript-declarations/carp-common/index.ts
@@ -23,6 +23,7 @@ declare module "@cachet/carp-common-generated"
     }
     namespace kotlin.collections
     {
+        type Collection<E> = kotlinStdLib.collections.Collection<E>
         type List<T> = kotlinStdLib.collections.List<T>
         type Set<T> = kotlinStdLib.collections.Set<T>
         type Map<K, V> = kotlinStdLib.collections.Map<K, V>
@@ -36,6 +37,10 @@ declare module "@cachet/carp-common-generated"
         type Json = kotlinSerialization.serialization.json.Json
     }
 }
+
+
+// Set namespace objects of dependent imported modules, so that they aren't "undefined" at runtime.
+(extend as any).kotlin = kotlinStdLib
 
 
 // Re-export augmented types.

--- a/typescript-declarations/carp-data-core/index.ts
+++ b/typescript-declarations/carp-data-core/index.ts
@@ -1,7 +1,7 @@
-import * as extend from "@cachet/carp-data-core-generated"
-import * as kotlinStdLib from "@cachet/carp-kotlin"
-import * as kotlinDateTime from "@cachet/carp-kotlinx-datetime"
-import * as kotlinSerialization from "@cachet/carp-kotlinx-serialization"
+import extend from "@cachet/carp-data-core-generated"
+import kotlinStdLib from "@cachet/carp-kotlin"
+import kotlinDateTime from "@cachet/carp-kotlinx-datetime"
+import kotlinSerialization from "@cachet/carp-kotlinx-serialization"
 import carpCommon from "@cachet/carp-common"
 
 
@@ -10,7 +10,7 @@ declare module "@cachet/carp-data-core-generated"
     // Declare missing types for which no imports were generated.
     namespace kotlin
     {
-        type Long = kotlinStdLib.kotlin.Long
+        type Long = kotlinStdLib.Long
     }
     namespace kotlin.reflect
     {
@@ -20,28 +20,30 @@ declare module "@cachet/carp-data-core-generated"
     }
     namespace kotlin.time
     {
-        type Duration = kotlinStdLib.kotlin.time.Duration
+        type Duration = kotlinStdLib.time.Duration
     }
     namespace kotlin.collections
     {
-        type List<T> = kotlinStdLib.kotlin.collections.List<T>
-        type Set<T> = kotlinStdLib.kotlin.collections.Set<T>
-        type Map<K, V> = kotlinStdLib.kotlin.collections.Map<K, V>
+        type Collection<E> = kotlinStdLib.collections.Collection<E>
+        type List<T> = kotlinStdLib.collections.List<T>
+        type Set<T> = kotlinStdLib.collections.Set<T>
+        type Map<K, V> = kotlinStdLib.collections.Map<K, V>
     }
     namespace kotlinx.datetime
     {
-        type Instant = kotlinDateTime.kotlinx.datetime.Instant
+        type Instant = kotlinDateTime.datetime.Instant
     }
     namespace kotlinx.serialization.json
     {
-        type Json = kotlinSerialization.kotlinx.serialization.json.Json
+        type Json = kotlinSerialization.serialization.json.Json
     }
 }
 
 
 // Set namespace objects of dependent imported modules, so that they aren't "undefined" at runtime.
+(extend as any).kotlin = kotlinStdLib
 extend.dk.cachet.carp.common = carpCommon.dk.cachet.carp.common as any;
 
 
 // Export facade.
-export * from "@cachet/carp-data-core-generated"
+export { default } from "@cachet/carp-data-core-generated"

--- a/typescript-declarations/carp-deployments-core/index.ts
+++ b/typescript-declarations/carp-deployments-core/index.ts
@@ -24,6 +24,7 @@ declare module "@cachet/carp-deployments-core-generated"
     }
     namespace kotlin.collections
     {
+        type Collection<E> = kotlinStdLib.collections.Collection<E>
         type List<T> = kotlinStdLib.collections.List<T>
         type Set<T> = kotlinStdLib.collections.Set<T>
         type Map<K, V> = kotlinStdLib.collections.Map<K, V>
@@ -40,6 +41,7 @@ declare module "@cachet/carp-deployments-core-generated"
 
 
 // Set namespace objects of dependent imported modules, so that they aren't "undefined" at runtime.
+(extend as any).kotlin = kotlinStdLib
 extend.dk.cachet.carp.common = carpCommon.dk.cachet.carp.common as any;
 
 

--- a/typescript-declarations/carp-kotlin/index.ts
+++ b/typescript-declarations/carp-kotlin/index.ts
@@ -15,8 +15,8 @@ export namespace kotlinExport
     {
         constructor( first: K, second: V ) {
             let kotlinPair = new extend.$_$.Pair( first, second );
-            kotlinPair.first = kotlinPair.he_1;
-            kotlinPair.second = kotlinPair.ie_1;
+            kotlinPair.first = kotlinPair.me_1;
+            kotlinPair.second = kotlinPair.ne_1;
             return kotlinPair;
         }
         get first(): K { return this.first; }
@@ -60,10 +60,10 @@ export namespace kotlinExport.time
     }
     export namespace Duration
     {
-        export const Companion: any = extend.$_$.Companion_getInstance_17()
-        export const parseIsoString: (isoDuration: string) => Duration = Companion.fh
-        export const ZERO: Duration = Companion.ch_1
-        export const INFINITE: Duration = Companion.dh_1
+        export const Companion: any = extend.$_$.Companion_getInstance_20()
+        export const parseIsoString: (isoDuration: string) => Duration = Companion.ii
+        export const ZERO: Duration = Companion.fi_1
+        export const INFINITE: Duration = Companion.gi_1
     }
 }
 

--- a/typescript-declarations/carp-kotlin/index.ts
+++ b/typescript-declarations/carp-kotlin/index.ts
@@ -15,8 +15,8 @@ export namespace kotlinExport
     {
         constructor( first: K, second: V ) {
             let kotlinPair = new extend.$_$.Pair( first, second );
-            kotlinPair.first = kotlinPair.ge_1;
-            kotlinPair.second = kotlinPair.he_1;
+            kotlinPair.first = kotlinPair.he_1;
+            kotlinPair.second = kotlinPair.ie_1;
             return kotlinPair;
         }
         get first(): K { return this.first; }
@@ -61,9 +61,9 @@ export namespace kotlinExport.time
     export namespace Duration
     {
         export const Companion: any = extend.$_$.Companion_getInstance_17()
-        export const parseIsoString: (isoDuration: string) => Duration = Companion.eh
-        export const ZERO: Duration = Companion.bh_1
-        export const INFINITE: Duration = Companion.ch_1
+        export const parseIsoString: (isoDuration: string) => Duration = Companion.fh
+        export const ZERO: Duration = Companion.ch_1
+        export const INFINITE: Duration = Companion.dh_1
     }
 }
 
@@ -102,7 +102,7 @@ declare module "@cachet/kotlin-kotlin-stdlib"
 
 
 // Implement base interfaces in internal types.
-extend.$_$.Long.prototype.toNumber = function(): number { return this.g1(); };
+extend.$_$.Long.prototype.toNumber = function(): number { return this.h1(); };
 Object.defineProperty( extend.$_$.Long.prototype, "inWholeMilliseconds", {
     get: function inWholeMilliseconds()
     {
@@ -118,12 +118,12 @@ Object.defineProperty( extend.$_$.Long.prototype, "inWholeMicroseconds", {
 extend.$_$.EmptyList.prototype.contains = function<T>( value: T ): boolean { return false; }
 extend.$_$.EmptyList.prototype.size = function<T>(): number { return 0; }
 extend.$_$.EmptyList.prototype.toArray = function<T>(): T[] { return []; }
-extend.$_$.AbstractMutableList.prototype.contains = function<T>( value: T ): boolean { return this.i1( value ); }
+extend.$_$.AbstractMutableList.prototype.contains = function<T>( value: T ): boolean { return this.j1( value ); }
 extend.$_$.AbstractMutableList.prototype.size = function<T>(): number { return this.m(); }
 extend.$_$.EmptySet.prototype.contains = function<T>( value: T ): boolean { return false; }
 extend.$_$.EmptySet.prototype.size = function<T>(): number { return 0; }
 extend.$_$.EmptySet.prototype.toArray = function<T>(): T[] { return []; }
-extend.$_$.HashSet.prototype.contains = function<T>( value: T ): boolean { return this.i1( value ); }
+extend.$_$.HashSet.prototype.contains = function<T>( value: T ): boolean { return this.j1( value ); }
 extend.$_$.HashSet.prototype.size = function<T>(): number { return this.m(); }
 extend.$_$.HashMap.prototype.get = function<K, V>( key: K ): V { return this.g2( key ); }
 Object.defineProperty( extend.$_$.HashMap.prototype, "keys", {

--- a/typescript-declarations/carp-kotlin/index.ts
+++ b/typescript-declarations/carp-kotlin/index.ts
@@ -3,28 +3,32 @@ import extend from "@cachet/kotlin-kotlin-stdlib"
 
 
 // Facade with better method names and type conversions for internal types.
-export namespace kotlin
+export namespace kotlinExport
 {
     export type Nullable<T> = T | null | undefined
     export interface Long
     {
         toNumber(): number
     }
-    export const toLong: (number: number) => Long = extend.$_$.toLong_0
+    export const toLong: (number: number) => Long = extend.$_$.toLong
     export class Pair<K, V>
     {
         constructor( first: K, second: V ) {
             let kotlinPair = new extend.$_$.Pair( first, second );
-            kotlinPair.first = kotlinPair.md_1;
-            kotlinPair.second = kotlinPair.nd_1;
+            kotlinPair.first = kotlinPair.ge_1;
+            kotlinPair.second = kotlinPair.he_1;
             return kotlinPair;
         }
         get first(): K { return this.first; }
         get second(): V { return this.second; }
     }
 }
-export namespace kotlin.collections
+export namespace kotlinExport.collections
 {
+    export const KtList = extend.kotlin.collections.KtList
+    export const KtSet = extend.kotlin.collections.KtSet
+    export const KtMap = extend.kotlin.collections.KtMap
+
     export interface Collection<T>
     {
         contains( value: T ): boolean
@@ -42,12 +46,12 @@ export namespace kotlin.collections
     export const listOf: <T>(array: T[]) => List<T> = extend.$_$.listOf_0
     export const setOf: <T>(array: T[]) => Set<T> = extend.$_$.setOf_0
     export const mapOf =
-        function<K, V>( pairs: kotlin.Pair<K, V>[] ): Map<K, V>
+        function<K, V>( pairs: kotlinExport.Pair<K, V>[] ): Map<K, V>
         {
             return extend.$_$.mapOf_0( pairs as any )
         }
 }
-export namespace kotlin.time
+export namespace kotlinExport.time
 {
     export interface Duration
     {
@@ -56,10 +60,10 @@ export namespace kotlin.time
     }
     export namespace Duration
     {
-        export const Companion: any = extend.$_$.Companion_getInstance_13()
-        export const parseIsoString: (isoDuration: string) => Duration = Companion.zf
-        export const ZERO: Duration = Companion.wf_1
-        export const INFINITE: Duration = Companion.xf_1
+        export const Companion: any = extend.$_$.Companion_getInstance_17()
+        export const parseIsoString: (isoDuration: string) => Duration = Companion.eh
+        export const ZERO: Duration = Companion.bh_1
+        export const INFINITE: Duration = Companion.ch_1
     }
 }
 
@@ -69,36 +73,36 @@ declare module "@cachet/kotlin-kotlin-stdlib"
 {
     namespace $_$
     {
-        abstract class Long implements kotlin.Long
+        abstract class Long implements kotlinExport.Long
         {
             toNumber(): number
             inWholeMilliseconds(): number
             inWholeMicroseconds(): number
         }
-        interface Pair<K, V> extends kotlin.Pair<K, V>
+        interface Pair<K, V> extends kotlinExport.Pair<K, V>
         {
             first: K
             second: V
         }
-        interface Collection<T> extends kotlin.collections.Collection<T> {}
-        abstract class EmptyList<T> implements kotlin.collections.List<T> {}
-        abstract class AbstractMutableList<T> implements kotlin.collections.List<T> {}
-        interface Set<T> extends kotlin.collections.Set<T> {}
-        abstract class EmptySet<T> implements kotlin.collections.Set<T> {}
-        abstract class HashSet<T> implements kotlin.collections.Set<T> {}
-        interface Map<K, V> extends kotlin.collections.Map<K, V> {}
-        abstract class HashMap<K, V> implements kotlin.collections.Map<K, V>
+        interface Collection<T> extends kotlinExport.collections.Collection<T> {}
+        abstract class EmptyList<T> implements kotlinExport.collections.List<T> {}
+        abstract class AbstractMutableList<T> implements kotlinExport.collections.List<T> {}
+        interface Set<T> extends kotlinExport.collections.Set<T> {}
+        abstract class EmptySet<T> implements kotlinExport.collections.Set<T> {}
+        abstract class HashSet<T> implements kotlinExport.collections.Set<T> {}
+        interface Map<K, V> extends kotlinExport.collections.Map<K, V> {}
+        abstract class HashMap<K, V> implements kotlinExport.collections.Map<K, V>
         {
             get( key: K ): V
-            keys: kotlin.collections.Set<K>
-            values: kotlin.collections.Collection<V>
+            keys: kotlinExport.collections.Set<K>
+            values: kotlinExport.collections.Collection<V>
         }
     }
 }
 
 
 // Implement base interfaces in internal types.
-extend.$_$.Long.prototype.toNumber = function(): number { return this.da(); };
+extend.$_$.Long.prototype.toNumber = function(): number { return this.g1(); };
 Object.defineProperty( extend.$_$.Long.prototype, "inWholeMilliseconds", {
     get: function inWholeMilliseconds()
     {
@@ -114,21 +118,21 @@ Object.defineProperty( extend.$_$.Long.prototype, "inWholeMicroseconds", {
 extend.$_$.EmptyList.prototype.contains = function<T>( value: T ): boolean { return false; }
 extend.$_$.EmptyList.prototype.size = function<T>(): number { return 0; }
 extend.$_$.EmptyList.prototype.toArray = function<T>(): T[] { return []; }
-extend.$_$.AbstractMutableList.prototype.contains = function<T>( value: T ): boolean { return this.p( value ); }
-extend.$_$.AbstractMutableList.prototype.size = function<T>(): number { return this.n(); }
+extend.$_$.AbstractMutableList.prototype.contains = function<T>( value: T ): boolean { return this.i1( value ); }
+extend.$_$.AbstractMutableList.prototype.size = function<T>(): number { return this.m(); }
 extend.$_$.EmptySet.prototype.contains = function<T>( value: T ): boolean { return false; }
 extend.$_$.EmptySet.prototype.size = function<T>(): number { return 0; }
 extend.$_$.EmptySet.prototype.toArray = function<T>(): T[] { return []; }
-extend.$_$.HashSet.prototype.contains = function<T>( value: T ): boolean { return this.p( value ); }
-extend.$_$.HashSet.prototype.size = function<T>(): number { return this.n(); }
-extend.$_$.HashMap.prototype.get = function<K, V>( key: K ): V { return this.x2( key ); }
+extend.$_$.HashSet.prototype.contains = function<T>( value: T ): boolean { return this.i1( value ); }
+extend.$_$.HashSet.prototype.size = function<T>(): number { return this.m(); }
+extend.$_$.HashMap.prototype.get = function<K, V>( key: K ): V { return this.g2( key ); }
 Object.defineProperty( extend.$_$.HashMap.prototype, "keys", {
-    get: function keys() { return this.l2(); }
+    get: function keys() { return this.h2(); }
 } );
 Object.defineProperty( extend.$_$.HashMap.prototype, "values", {
-    get: function values() { return this.m2(); }
+    get: function values() { return this.i2(); }
 } );
 
 
 // Export facade.
-export default kotlin
+export default kotlinExport

--- a/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
+++ b/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
@@ -5,28 +5,28 @@ declare module "@cachet/kotlin-kotlin-stdlib"
         interface Long
         {
             // toNumber
-            da(): number
+            g1(): number
         }
-        function toLong_0( number: number ): Long
+        function toLong( number: number ): Long
 
         class Pair<K, V>
         {
             constructor( first: K, second: V )
 
             // first
-            md_1: K
+            ge_1: K
 
             // second
-            nd_1: V
+            he_1: V
         }
 
         interface Collection<T>
         {
             // contains
-            p( value: T ): boolean
+            i1( value: T ): boolean
 
             // size
-            n(): number
+            m(): number
 
             toArray(): Array<T>
         }
@@ -44,13 +44,13 @@ declare module "@cachet/kotlin-kotlin-stdlib"
         interface Map<K, V>
         {
             // get
-            x2( key: K ): V
+            g2( key: K ): V
 
             // keys
-            l2(): Set<K>
+            h2(): Set<K>
 
             // values
-            m2(): Collection<V>
+            i2(): Collection<V>
         }
         interface HashMap<K, V> extends Map<K, V> {}
         function mapOf_0<K, V>( pairs: Pair<K, V>[] ): Map<K, V>
@@ -59,16 +59,26 @@ declare module "@cachet/kotlin-kotlin-stdlib"
         interface DurationCompanion
         {
             // parseIsoString
-            zf(): Duration
+            eh(): Duration
 
             // ZERO
-            wf_1: Duration
+            bh_1: Duration
 
             // INFINITE
-            xf_1: Duration
+            ch_1: Duration
         }
-        function Companion_getInstance_13(): DurationCompanion
+        function Companion_getInstance_17(): DurationCompanion
         function _Duration___get_inWholeMilliseconds__impl__msfiry(duration: Duration): Long
         function _Duration___get_inWholeMicroseconds__impl__8oe8vv(duration: Duration): Long
+    }
+
+    namespace kotlin
+    {
+        namespace collections
+        {
+            const KtList: any
+            const KtSet: any
+            const KtMap: any
+        }
     }
 }

--- a/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
+++ b/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
@@ -5,7 +5,7 @@ declare module "@cachet/kotlin-kotlin-stdlib"
         interface Long
         {
             // toNumber
-            g1(): number
+            h1(): number
         }
         function toLong( number: number ): Long
 
@@ -14,16 +14,16 @@ declare module "@cachet/kotlin-kotlin-stdlib"
             constructor( first: K, second: V )
 
             // first
-            ge_1: K
+            he_1: K
 
             // second
-            he_1: V
+            ie_1: V
         }
 
         interface Collection<T>
         {
             // contains
-            i1( value: T ): boolean
+            j1( value: T ): boolean
 
             // size
             m(): number
@@ -59,13 +59,13 @@ declare module "@cachet/kotlin-kotlin-stdlib"
         interface DurationCompanion
         {
             // parseIsoString
-            eh(): Duration
+            fh(): Duration
 
             // ZERO
-            bh_1: Duration
+            ch_1: Duration
 
             // INFINITE
-            ch_1: Duration
+            dh_1: Duration
         }
         function Companion_getInstance_17(): DurationCompanion
         function _Duration___get_inWholeMilliseconds__impl__msfiry(duration: Duration): Long

--- a/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
+++ b/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
@@ -14,10 +14,10 @@ declare module "@cachet/kotlin-kotlin-stdlib"
             constructor( first: K, second: V )
 
             // first
-            he_1: K
+            me_1: K
 
             // second
-            ie_1: V
+            ne_1: V
         }
 
         interface Collection<T>
@@ -59,15 +59,15 @@ declare module "@cachet/kotlin-kotlin-stdlib"
         interface DurationCompanion
         {
             // parseIsoString
-            fh(): Duration
+            ii(): Duration
 
             // ZERO
-            ch_1: Duration
+            fi_1: Duration
 
             // INFINITE
-            dh_1: Duration
+            gi_1: Duration
         }
-        function Companion_getInstance_17(): DurationCompanion
+        function Companion_getInstance_20(): DurationCompanion
         function _Duration___get_inWholeMilliseconds__impl__msfiry(duration: Duration): Long
         function _Duration___get_inWholeMicroseconds__impl__8oe8vv(duration: Duration): Long
     }

--- a/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime.d.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime.d.ts
@@ -5,14 +5,14 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime"
         interface System
         {
             // now
-            o14(): Instant_0
+            p14(): Instant_0
         }
         const System_instance: System
 
         interface Instant_0
         {
             // toEpochMilliseconds
-            b15(): number
+            u1k(): number
         }
     }
 }

--- a/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime.d.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime.d.ts
@@ -5,14 +5,14 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime"
         interface System
         {
             // now
-            p14(): Instant_0
+            d16(): Instant_0
         }
         const System_instance: System
 
         interface Instant_0
         {
             // toEpochMilliseconds
-            u1k(): number
+            h1m(): number
         }
     }
 }

--- a/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime.d.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/Kotlin-DateTime-library-kotlinx-datetime.d.ts
@@ -5,14 +5,14 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime"
         interface System
         {
             // now
-            p13(): Instant_0
+            o14(): Instant_0
         }
-        function System_getInstance(): System
+        const System_instance: System
 
         interface Instant_0
         {
             // toEpochMilliseconds
-            c14(): number
+            b15(): number
         }
     }
 }

--- a/typescript-declarations/carp-kotlinx-datetime/index.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/index.ts
@@ -34,8 +34,8 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime"
 
 
 // Implement base interfaces in internal types.
-extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.o14(); };
-extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.b15(); };
+extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.p14(); };
+extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.u1k(); };
 
 
 // Export facade.

--- a/typescript-declarations/carp-kotlinx-datetime/index.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/index.ts
@@ -34,8 +34,8 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime"
 
 
 // Implement base interfaces in internal types.
-extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.p14(); };
-extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.u1k(); };
+extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.d16(); };
+extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.h1m(); };
 
 
 // Export facade.

--- a/typescript-declarations/carp-kotlinx-datetime/index.ts
+++ b/typescript-declarations/carp-kotlinx-datetime/index.ts
@@ -11,7 +11,7 @@ export namespace kotlinx.datetime
     }
     export namespace Clock
     {
-        export const System: Clock = extend.$_$.System_getInstance()
+        export const System: Clock = extend.$_$.System_instance
     }
     export interface Instant
     {
@@ -34,8 +34,8 @@ declare module "@cachet/Kotlin-DateTime-library-kotlinx-datetime"
 
 
 // Implement base interfaces in internal types.
-extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.p13(); };
-extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.c14(); };
+extend.$_$.System.prototype.now = function(): kotlinx.datetime.Instant { return this.o14(); };
+extend.$_$.Instant_0.prototype.toEpochMilliseconds = function(): number { return this.b15(); };
 
 
 // Export facade.

--- a/typescript-declarations/carp-kotlinx-serialization/index.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/index.ts
@@ -7,7 +7,7 @@ import extendJson from "@cachet/kotlinx-serialization-kotlinx-serialization-json
 // Facade with better method names and type conversions for internal types.
 export namespace kotlinx.serialization
 {
-    export function getSerializer( type: any ) { return type.Companion.i17() }
+    export function getSerializer( type: any ) { return type.Companion.h1n() }
 }
 export namespace kotlinx.serialization.json
 {
@@ -44,12 +44,12 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
 extendJson.$_$.Json.prototype.encodeToString =
     function( serializer: any, value: any ): string
     {
-        return this.g15( serializer, value );
+        return this.f1l( serializer, value );
     };
 extendJson.$_$.Json.prototype.decodeFromString =
     function( serializer: any, string: string ): any
     {
-        return this.h15( serializer, string );
+        return this.g1l( serializer, string );
     };
 
 

--- a/typescript-declarations/carp-kotlinx-serialization/index.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/index.ts
@@ -7,7 +7,7 @@ import extendJson from "@cachet/kotlinx-serialization-kotlinx-serialization-json
 // Facade with better method names and type conversions for internal types.
 export namespace kotlinx.serialization
 {
-    export function getSerializer( type: any ) { return type.Companion.h1n() }
+    export function getSerializer( type: any ) { return type.Companion.w1o() }
 }
 export namespace kotlinx.serialization.json
 {
@@ -44,12 +44,12 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
 extendJson.$_$.Json.prototype.encodeToString =
     function( serializer: any, value: any ): string
     {
-        return this.f1l( serializer, value );
+        return this.s1m( serializer, value );
     };
 extendJson.$_$.Json.prototype.decodeFromString =
     function( serializer: any, string: string ): any
     {
-        return this.g1l( serializer, string );
+        return this.t1m( serializer, string );
     };
 
 

--- a/typescript-declarations/carp-kotlinx-serialization/index.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/index.ts
@@ -7,7 +7,7 @@ import extendJson from "@cachet/kotlinx-serialization-kotlinx-serialization-json
 // Facade with better method names and type conversions for internal types.
 export namespace kotlinx.serialization
 {
-    export function getSerializer( type: any ) { return type.Companion.i16() }
+    export function getSerializer( type: any ) { return type.Companion.i17() }
 }
 export namespace kotlinx.serialization.json
 {
@@ -34,22 +34,22 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
 {
     namespace $_$
     {
-        interface JsonImpl extends kotlinx.serialization.json.Json {}
-        abstract class JsonImpl implements kotlinx.serialization.json.Json {}
+        interface Json extends kotlinx.serialization.json.Json {}
+        abstract class Json implements kotlinx.serialization.json.Json {}
     }
 }
 
 
 // Implement base interfaces in internal types.
-extendJson.$_$.JsonImpl.prototype.encodeToString =
+extendJson.$_$.Json.prototype.encodeToString =
     function( serializer: any, value: any ): string
     {
-        return this.h14( serializer, value );
+        return this.g15( serializer, value );
     };
-extendJson.$_$.JsonImpl.prototype.decodeFromString =
+extendJson.$_$.Json.prototype.decodeFromString =
     function( serializer: any, string: string ): any
     {
-        return this.i14( serializer, string );
+        return this.h15( serializer, string );
     };
 
 

--- a/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
@@ -5,10 +5,10 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
         interface Json
         {
             // encodeToString
-            g15( serializer: any, instance: any ): string
+            f1l( serializer: any, instance: any ): string
 
             // decodeFromString
-            h15( serializer: any, string: string ): string
+            g1l( serializer: any, string: string ): string
         }
         function Default_getInstance(): Json
     }

--- a/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
@@ -5,10 +5,10 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
         interface Json
         {
             // encodeToString
-            f1l( serializer: any, instance: any ): string
+            s1m( serializer: any, instance: any ): string
 
             // decodeFromString
-            g1l( serializer: any, string: string ): string
+            t1m( serializer: any, string: string ): string
         }
         function Default_getInstance(): Json
     }

--- a/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
+++ b/typescript-declarations/carp-kotlinx-serialization/kotlinx-serialization-kotlinx-serialization-json.d.ts
@@ -2,14 +2,14 @@ declare module "@cachet/kotlinx-serialization-kotlinx-serialization-json"
 {
     namespace $_$
     {
-        interface JsonImpl
+        interface Json
         {
             // encodeToString
-            h14( serializer: any, instance: any ): string
+            g15( serializer: any, instance: any ): string
 
             // decodeFromString
-            i14( serializer: any, string: string ): string
+            h15( serializer: any, string: string ): string
         }
-        function Default_getInstance(): JsonImpl
+        function Default_getInstance(): Json
     }
 }

--- a/typescript-declarations/carp-protocols-core/index.ts
+++ b/typescript-declarations/carp-protocols-core/index.ts
@@ -24,6 +24,7 @@ declare module "@cachet/carp-protocols-core-generated"
     }
     namespace kotlin.collections
     {
+        type Collection<E> = kotlinStdLib.collections.Collection<E>
         type List<T> = kotlinStdLib.collections.List<T>
         type Set<T> = kotlinStdLib.collections.Set<T>
         type Map<K, V> = kotlinStdLib.collections.Map<K, V>
@@ -40,6 +41,7 @@ declare module "@cachet/carp-protocols-core-generated"
 
 
 // Set namespace objects of dependent imported modules, so that they aren't "undefined" at runtime.
+(extend as any).kotlin = kotlinStdLib
 extend.dk.cachet.carp.common = carpCommon.dk.cachet.carp.common as any;
 
 

--- a/typescript-declarations/carp-studies-core/index.ts
+++ b/typescript-declarations/carp-studies-core/index.ts
@@ -42,6 +42,7 @@ declare module "@cachet/carp-studies-core-generated"
 
 
 // Set namespace objects of dependent imported modules, so that they aren't "undefined" at runtime.
+(extend as any).kotlin = kotlinStdLib
 extend.dk.cachet.carp.common = carpCommon.dk.cachet.carp.common as any;
 extend.dk.cachet.carp.deployments = carpDeployments.dk.cachet.carp.deployments as any;
 

--- a/typescript-declarations/tests/carp-common-test.ts
+++ b/typescript-declarations/tests/carp-common-test.ts
@@ -1,13 +1,15 @@
 import { expect } from 'chai'
 
 import kotlin from '@cachet/carp-kotlin'
-import setOf = kotlin.collections.setOf
 import Duration = kotlin.time.Duration
 
 import kotlinx from '@cachet/carp-kotlinx-serialization'
 import getSerializer = kotlinx.serialization.getSerializer
 
 import carp from '@cachet/carp-common'
+
+import KtSet = carp.kotlin.collections.KtSet
+
 import dk = carp.dk
 import Trilean = dk.cachet.carp.common.application.Trilean
 import toTrilean = dk.cachet.carp.common.application.toTrilean
@@ -79,9 +81,10 @@ describe( "carp-common", () => {
 
     describe( "ExpectedParticipantData", () => {
         it( "can serialize and deserialize", () => {
+            const roles = new Set( [ "Roles are added" ] );
             const expectedData = new ExpectedParticipantData(
                 new ParticipantAttribute.DefaultParticipantAttribute( new NamespacedId( "namespace", "type" ) ),
-                new AssignedTo.Roles( setOf( [ "Roles are added" ] ) )
+                new AssignedTo.Roles( KtSet.fromJsSet( roles ) )
             )
 
             const serializer = getSerializer( ExpectedParticipantData )

--- a/typescript-declarations/tests/carp-deployments-test.ts
+++ b/typescript-declarations/tests/carp-deployments-test.ts
@@ -2,12 +2,11 @@ import { expect } from 'chai'
 
 import kotlin from '@cachet/carp-kotlin'
 import Nullable = kotlin.Nullable
-import mapOf = kotlin.collections.mapOf
-import Map = kotlin.collections.Map
-import Pair = kotlin.Pair
 
 import carp from '@cachet/carp-deployments-core'
 import dk = carp.dk
+
+import KtMap = carp.kotlin.collections.KtMap
 
 import common = dk.cachet.carp.common
 import NamespacedId = common.application.NamespacedId
@@ -24,8 +23,10 @@ describe( "carp-deployments-core", () => {
     describe( "ParticipationServiceRequest", () => {
         it( "can initialize SetParticipantData", () => {
             const inputByParticipantRole: string | null = null // Shorter alternative to using `Nullable<string>`.
-            const participantData: Map<NamespacedId, Nullable<Data>> = // So, `Map<NamespacedId, Data | null>` would work as well.
-                mapOf( [ new Pair( CarpInputDataTypes.SEX, Sex.Male ) ] )
+            const participantDataMap = new Map<NamespacedId, Nullable<Data>>( [ // So, `Map<NamespacedId, Data | null>` would work as well.
+                [CarpInputDataTypes.SEX, Sex.Male],
+            ] );
+            const participantData = KtMap.fromJsMap( participantDataMap )
             const setParticipantData = new ParticipationServiceRequest.SetParticipantData(
                 UUID.Companion.randomUUID(),
                 participantData,

--- a/typescript-declarations/tests/carp-kotlinx-serialization-test.ts
+++ b/typescript-declarations/tests/carp-kotlinx-serialization-test.ts
@@ -8,7 +8,7 @@ import Json = kotlinx.serialization.json.Json
 describe( "kotlinx-serialization", () => {
     it( "verify module declarations", async () => {
         const instances: any[] = [
-            [ "JsonImpl", Json.Default ]
+            [ "Json", Json.Default ]
         ]
 
         const moduleVerifier = new VerifyModule(

--- a/typescript-declarations/tests/carp-studies-test.ts
+++ b/typescript-declarations/tests/carp-studies-test.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai'
 
 import kotlin from '@cachet/carp-kotlin'
-import setOf = kotlin.collections.setOf
 import listOf = kotlin.collections.listOf
 
 import kxd from '@cachet/carp-kotlinx-datetime'
@@ -13,6 +12,9 @@ import ListSerializer = kxs.serialization.builtins.ListSerializer
 
 import carp from '@cachet/carp-studies-core'
 import dk = carp.dk
+
+import KtList = carp.kotlin.collections.KtList
+import KtSet = carp.kotlin.collections.KtSet
 
 import common = dk.cachet.carp.common
 import UUID = common.application.UUID
@@ -43,11 +45,12 @@ describe( "carp-studies-core", () => {
         it( "getAssigned participantIds and participantRoles works", () => {
             const participant1 = UUID.Companion.randomUUID()
             const participant2 = UUID.Companion.randomUUID()
-            const assigned1 = new AssignedParticipantRoles( participant1, new AssignedTo.Roles( setOf( [ "Test" ] ) ) )
+            const roles = new Set( [ "Test" ] );
+            const assigned1 = new AssignedParticipantRoles( participant1, new AssignedTo.Roles( KtSet.fromJsSet( roles ) ) )
             const assigned2 = new AssignedParticipantRoles( participant2, AssignedTo.All )
             const assignedGroup = listOf( [ assigned1, assigned2 ] )
-            expect( participantIds( assignedGroup ).contains( participant1 ) ).is.true
-            expect( participantRoles( assignedGroup ).contains( "Test" ) ).is.true
+            expect( participantIds( assignedGroup ).asJsReadonlySetView().has( participant1 ) ).is.true
+            expect( participantRoles( assignedGroup ).asJsReadonlySetView().has( "Test" ) ).is.true
         } )
     } )
 
@@ -93,11 +96,10 @@ describe( "carp-studies-core", () => {
 
     describe( "RecruitmentServiceRequest", () => {
         it( "can serialize DeployParticipantGroup", () => {
+            const assignedRoles = new Set( [ new AssignedParticipantRoles( UUID.Companion.randomUUID(), AssignedTo.All ) ] );
             const deployGroup = new RecruitmentServiceRequest.InviteNewParticipantGroup(
                 UUID.Companion.randomUUID(),
-                setOf( [
-                    new AssignedParticipantRoles( UUID.Companion.randomUUID(), AssignedTo.All )
-                ] )
+                KtSet.fromJsSet( assignedRoles )
             )
 
             const serializer = RecruitmentServiceRequest.Serializer
@@ -116,8 +118,11 @@ describe( "carp-studies-core", () => {
         it( "can serialize ParticipantGroupStatus", () => {
             const deploymentId = UUID.Companion.randomUUID()
             const now = Clock.System.now()
-            const deploymentStatus = new StudyDeploymentStatus.Running( now, deploymentId, listOf<DeviceDeploymentStatus>( [] ), listOf<ParticipantStatus>( [] ), now )
-            const participants = setOf( [ new Participant( new UsernameAccountIdentity( new Username( "Test" ) ) ) ] )
+            const emptyDeploymentStatusList = KtList.fromJsArray( [] )
+            const emptyParticipantStatusList = KtList.fromJsArray( [] )
+            const deploymentStatus = new StudyDeploymentStatus.Running( now, deploymentId, emptyDeploymentStatusList, emptyParticipantStatusList, now )
+            const participantsSet = new Set( [ new Participant( new UsernameAccountIdentity( new Username( "Test" ) ) ) ] )
+            const participants = KtSet.fromJsSet( participantsSet )
             const group = new ParticipantGroupStatus.Invited( deploymentId, participants, now, deploymentStatus )
 
             const serializer = getSerializer( ParticipantGroupStatus )


### PR DESCRIPTION
I got JS/JVM tests passing on the latest version of Kotlin (2.1.20) (closes #499).
As expected, this required quite extensive changes to the TypeScript wrappers (including adopting KtSet/KtList/KtMap; closes #495). With a bit of hacking, I got this to work as well!

What is left is:
- [x] Upgrading kotlinx.datetime to 0.6.2
- [x] Upgrading kotlinx.serialization to 1.8.1
- [x] ... and while we are at it, nexusPublishPlugin to '2.0.0' (it's a major version, so we need to double-check whether further changes are needed not to break automated publishing of artifacts)