### PR TITLE
Fix publication of snapshots

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -30,4 +30,4 @@ jobs:
 
       - name: Deploy snapshot
         if: success()
-        run: ./gradlew setSnapshotVersion publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew -Psnapshot publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Gradle wrapper validation
-        uses: gradle/wrapper-validation-action@v1.0.3
+        uses: gradle/actions/wrapper-validation@v3
 
       - name: Build and test
         run: ./gradlew build 
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
          
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ buildscript {
     ext {
         // Version used for submodule artifacts.
         // Snapshot publishing changes (or adds) the suffix after '-' with 'SNAPSHOT' prior to publishing.
-        globalVersion = '1.2.1'
-        clientsVersion = '1.2.1-alpha.1' // The clients subsystem is still expected to change drastically.
+        globalVersion = '1.3.0'
+        clientsVersion = '1.3.0-alpha.1' // The clients subsystem is still expected to change drastically.
 
         versions = [
             // Kotlin multiplatform versions.

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
             // JVM versions.
             jvmTarget:'1.8',
-            dokkaPlugin:'1.9.20',
+            dokkaPlugin:'2.0.0',
             reflections:'0.10.2',
 
             // JS versions.
@@ -151,19 +151,15 @@ configure( subprojects - devOpsModules ) {
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
     apply plugin: 'org.jetbrains.dokka'
-    task dokkaJvmJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
-        dokkaSourceSets {
-            register("jvm") {
-                platform.set(org.jetbrains.dokka.Platform.jvm)
-                sourceRoots.from(kotlin.sourceSets.getByName("jvmMain").kotlin.srcDirs)
-            }
-        }
+    tasks.withType(org.jetbrains.dokka.gradle.tasks.DokkaGenerateTask).configureEach {
+        // HACK: Dokka 2.0.0 exposes this debug file by default (https://github.com/Kotlin/dokka/issues/3958)
+        dokkaConfigurationJsonFile.convention(null)
     }
     task javadocJar(type: Jar) {
         group JavaBasePlugin.DOCUMENTATION_GROUP
         description 'Create javadoc jar using Dokka'
         archiveClassifier = "javadoc"
-        from dokkaJvmJavadoc
+        from dokkaGeneratePublicationHtml
     }
     publishing {
         publications {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,13 @@ buildscript {
         // Snapshot publishing changes (or adds) the suffix after '-' with 'SNAPSHOT' prior to publishing.
         globalVersion = '1.3.0'
         clientsVersion = '1.3.0-alpha.1' // The clients subsystem is still expected to change drastically.
+        if (project.hasProperty("snapshot"))
+        {
+            def versionSplit = globalVersion.split('-')
+            def snapshotVersion = "${versionSplit[0]}-SNAPSHOT"
+            globalVersion = snapshotVersion
+            clientsVersion = snapshotVersion
+        }
 
         versions = [
             // Kotlin multiplatform versions.
@@ -219,17 +226,6 @@ nexusPublishing {
         sonatype {
             username = publishProperties['repository.username']
             password = publishProperties['repository.password']
-        }
-    }
-}
-task setSnapshotVersion {
-    doFirst {
-        def versionSplit = globalVersion.split('-')
-        def snapshotVersion = "${versionSplit[0]}-SNAPSHOT"
-        version = snapshotVersion
-
-        (rootProject.subprojects - devOpsModules).each { project ->
-            project.version = snapshotVersion
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,6 @@ kotlin.mpp.stability.nowarn=true
 
 # TODO: Prevent dokka out of memory errors. Is this really needed? https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1024m
+
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true


### PR DESCRIPTION
Fixes #496 

In addition, I already bumped the version to 1.3.0, so that snapshots are published as `1.3.0-SNAPSHOT` and not `1.2.1-SNAPSHOT`. And, updated some GitHub action dependencies. On another repo, I saw occasional failures of the gradle wrapper verification, and the version used here is a pretty old.