### PR TITLE
Fix: incorrect order of migrations in downgradeResponse

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/versioning/ApplicationServiceApiMigrator.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/versioning/ApplicationServiceApiMigrator.kt
@@ -63,7 +63,7 @@ class ApplicationServiceApiMigrator<
         // Defer applying response migrations.
         fun downgradeResponse( response: JsonElement?, ex: Exception? ): JsonElement
         {
-            val updatedResponse = toApply.fold( ApiResponse( response, ex ) ) { curResponse, migration ->
+            val updatedResponse = toApply.reversed().fold( ApiResponse( response, ex ) ) { curResponse, migration ->
                 migration.migrateResponse( request, curResponse, requestVersion )
             }
 


### PR DESCRIPTION
The `downgradeResponse` function in the `ResponseMigrator` applied migrations in forward order, which is incorrect for downgrades.

Response downgrades should reverse the effects of request upgrades, so the migrations must be applied in reverse order.