### PR TITLE
Persist participant `roleAssignment` in `StagedParticipantGroup`

### DIFF
--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
@@ -133,13 +133,11 @@ class RecruitmentServiceHost(
         val recruitment = getRecruitmentOrThrow( studyId )
         val (protocol, invitations) = recruitment.createInvitations( group )
 
-        // In case the same participants have been invited before,
+        // In case the same participants with the same roles have been invited with the same group name before,
         // and that deployment is still running, return the existing group.
-        // TODO: The same participants might be invited for different role names, which we currently cannot differentiate between.
-        val toDeployParticipantIds = group.map { it.participantId }.toSet()
         val deployedStatus = recruitment.participantGroups.entries
-            .firstOrNull { (_, group) ->
-                group.participantIds == toDeployParticipantIds && group.name == name
+            .firstOrNull { (_, existingGroup) ->
+                existingGroup.roleAssignments == group && existingGroup.name == name
             }
             ?.let { deploymentService.getStudyDeploymentStatus( it.key ) }
         if ( deployedStatus != null && deployedStatus !is StudyDeploymentStatus.Stopped )
@@ -148,7 +146,7 @@ class RecruitmentServiceHost(
         }
 
         // Create participant group and mark as deployed.
-        val participantGroup = recruitment.addParticipantGroup( toDeployParticipantIds, name, uuidFactory.randomUUID() )
+        val participantGroup = recruitment.addParticipantGroup( group, name, uuidFactory.randomUUID() )
         participantGroup.markAsDeployed()
         participantRepository.updateRecruitment( recruitment )
 

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/ParticipantGroupStatus.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/users/ParticipantGroupStatus.kt
@@ -35,6 +35,11 @@ sealed class ParticipantGroupStatus
      */
     abstract val participants: Set<Participant>
 
+    /**
+     * The participant role assignments in this group.
+     */
+    abstract val assignedParticipantRoles: Set<AssignedParticipantRoles>
+
 
     /**
      * The [participants] have not yet been invited. The list of participants can still be modified.
@@ -43,6 +48,7 @@ sealed class ParticipantGroupStatus
     data class Staged(
         override val id: UUID,
         override val participants: Set<Participant>,
+        override val assignedParticipantRoles: Set<AssignedParticipantRoles>,
         override val name: String? = null
     ) : ParticipantGroupStatus()
 
@@ -60,6 +66,7 @@ sealed class ParticipantGroupStatus
              */
             fun fromDeploymentStatus(
                 participants: Set<Participant>,
+                roleAssignment: Set<AssignedParticipantRoles>,
                 deploymentStatus: StudyDeploymentStatus,
                 name: String?
             ): InDeployment
@@ -73,14 +80,29 @@ sealed class ParticipantGroupStatus
                     is StudyDeploymentStatus.Invited,
                     is StudyDeploymentStatus.DeployingDevices ->
                         // If deployment was ready at one point (`startedOn`), consider the study 'Running'.
-                        if ( startedOn == null ) Invited( id, participants, createdOn, deploymentStatus, name )
-                        else Running( id, participants, createdOn, deploymentStatus, startedOn, name )
+                        if ( startedOn == null )
+                        {
+                            Invited( id, participants, roleAssignment, createdOn, deploymentStatus, name )
+                        }
+                        else
+                        {
+                            Running( id, participants, roleAssignment, createdOn, deploymentStatus, startedOn, name )
+                        }
                     is StudyDeploymentStatus.Running ->
-                        Running( id, participants, createdOn, deploymentStatus, checkNotNull( startedOn ), name )
+                        Running(
+                            id,
+                            participants,
+                            roleAssignment,
+                            createdOn,
+                            deploymentStatus,
+                            checkNotNull( startedOn ),
+                            name
+                        )
                     is StudyDeploymentStatus.Stopped ->
                         Stopped(
                             id,
                             participants,
+                            roleAssignment,
                             createdOn,
                             deploymentStatus,
                             startedOn,
@@ -111,6 +133,7 @@ sealed class ParticipantGroupStatus
     data class Invited(
         override val id: UUID,
         override val participants: Set<Participant>,
+        override val assignedParticipantRoles: Set<AssignedParticipantRoles>,
         override val invitedOn: Instant,
         override val studyDeploymentStatus: StudyDeploymentStatus,
         override val name: String? = null
@@ -124,6 +147,7 @@ sealed class ParticipantGroupStatus
     data class Running(
         override val id: UUID,
         override val participants: Set<Participant>,
+        override val assignedParticipantRoles: Set<AssignedParticipantRoles>,
         override val invitedOn: Instant,
         override val studyDeploymentStatus: StudyDeploymentStatus,
         /**
@@ -141,6 +165,7 @@ sealed class ParticipantGroupStatus
     data class Stopped(
         override val id: UUID,
         override val participants: Set<Participant>,
+        override val assignedParticipantRoles: Set<AssignedParticipantRoles>,
         override val invitedOn: Instant,
         override val studyDeploymentStatus: StudyDeploymentStatus,
         /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.studies.domain.users
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AccountIdentity
+import dk.cachet.carp.common.application.users.AssignedTo
 import dk.cachet.carp.common.application.users.EmailAccountIdentity
 import dk.cachet.carp.common.application.users.UsernameAccountIdentity
 import dk.cachet.carp.common.domain.AggregateRoot
@@ -29,7 +30,10 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
     sealed class Event : DomainEvent
     {
         data class ParticipantAdded( val participant: Participant ) : Event()
-        data class ParticipantGroupAdded( val participantIds: Set<UUID> ) : Event()
+        data class ParticipantGroupAdded(
+            val participants: Set<AssignedParticipantRoles>,
+            val name: String? = null
+        ) : Event()
     }
 
 
@@ -174,27 +178,29 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
     private val _participantGroups: MutableMap<UUID, StagedParticipantGroup> = mutableMapOf()
 
     /**
-     * Create and add the participants identified by [participantIds] as a participant group, optionally with a [name]
-     * representing this group.
+     * Create and add the [participants] with assigned roles to a participant group, and optionally give it a [name].
      *
-     * @throws IllegalArgumentException when one or more of the participants aren't in this recruitment.
+     * @throws IllegalArgumentException when:
+     *  - one or more of the participants aren't in this recruitment.
+     *  - any of the participant roles specified in [participants] are not part of the configured study protocol.
      * @throws IllegalStateException when the study is not yet ready for deployment.
      */
     fun addParticipantGroup(
-        participantIds: Set<UUID>,
+        participants: Set<AssignedParticipantRoles>,
         name: String? = null,
         id: UUID = UUID.randomUUID()
     ): StagedParticipantGroup
     {
-        require( participants.map { it.id }.containsAll( participantIds ) )
-            { "One of the participants for which to create a participant group isn't part of this recruitment." }
-        check( getStatus() is RecruitmentStatus.ReadyForDeployment ) { "The study is not yet ready for deployment." }
+        val status = getStatus()
+        check( status is RecruitmentStatus.ReadyForDeployment ) { "The study is not yet ready for deployment." }
+
+        validateRoleAssignments( status.studyProtocol, participants )
 
         val group = StagedParticipantGroup( id, name )
-        group.addParticipants( participantIds )
+        group.addParticipants( participants )
 
         _participantGroups[ group.id ] = group
-        event( Event.ParticipantGroupAdded( participantIds ) )
+        event( Event.ParticipantGroupAdded( participants, null ) )
 
         return group
     }
@@ -213,6 +219,7 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
         val participants = group.participantIds.map { id -> _participants.first { it.id == id } }
         return ParticipantGroupStatus.InDeployment.fromDeploymentStatus(
             participants.toSet(),
+            group.roleAssignments,
             studyDeploymentStatus,
             group.name
         )
@@ -223,4 +230,29 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
      */
     override fun getSnapshot( version: Int ): RecruitmentSnapshot =
         RecruitmentSnapshot.fromParticipantRecruitment( this, version )
+
+    /**
+     * Validate that all participants exist in this recruitment and that all assigned roles are part of the protocol.
+     *
+     * @throws IllegalArgumentException when:
+     *  - one or more of the participants aren't in this recruitment.
+     *  - any of the participant roles specified in [participants] are not part of the configured study protocol.
+     */
+    private fun validateRoleAssignments( protocol: StudyProtocolSnapshot, participants: Set<AssignedParticipantRoles> )
+    {
+        require( this.participants.map { it.id }.containsAll( participants.participantIds() ) )
+            { "One of the participants for which to create a participant group isn't part of this recruitment." }
+
+        val assignedParticipantRoles = participants
+            .map { it.assignedRoles }
+            .filterIsInstance<AssignedTo.Roles>()
+            .flatMap { it.roleNames }
+            .toSet()
+        val availableRoles = protocol.participantRoles.map { it.role }.toSet()
+
+        assignedParticipantRoles.forEach { assigned ->
+            require( assigned in availableRoles )
+                { "The assigned participant role \"$assigned\" is not part of the study protocol." }
+        }
+    }
 }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroup.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroup.kt
@@ -1,6 +1,8 @@
 package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
+import dk.cachet.carp.studies.application.users.participantIds
 import kotlinx.serialization.*
 
 
@@ -17,12 +19,17 @@ data class StagedParticipantGroup(
     /**
      * An optional name to represent the group of participants.
      */
-    val name: String? = null,
+    var name: String? = null,
 )
 {
-    private val _participantIds: MutableSet<UUID> = mutableSetOf()
+    private val _roleAssignments: MutableSet<AssignedParticipantRoles> = mutableSetOf()
+    /**
+     * The roles assigned to participants in this group.
+     */
+    val roleAssignments: Set<AssignedParticipantRoles>
+        get() = _roleAssignments
     val participantIds: Set<UUID>
-        get() = _participantIds
+        get() = _roleAssignments.participantIds()
 
     /**
      * Determines whether this participant group has been deployed.
@@ -30,19 +37,17 @@ data class StagedParticipantGroup(
     var isDeployed: Boolean = false
         private set
 
-
-
     /**
-     * Add participants with [participantIds] to this group.
+     * Add [participants] with assigned roles to this group.
      * This is only allowed when the group hasn't been deployed yet.
      *
      * @throws IllegalStateException when this participant group is already deployed.
      */
-    fun addParticipants( participantIds: Set<UUID> )
+    fun addParticipants( participants: Set<AssignedParticipantRoles> )
     {
-        check( !isDeployed ) { "Can't add participant after a participant group has been deployed." }
+        check( !isDeployed ) { "Can't add participants after a participant group has been deployed." }
 
-        _participantIds.addAll( participantIds )
+        _roleAssignments.addAll( participants )
     }
 
     /**

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/RecruitmentServiceApiMigrator.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/versioning/RecruitmentServiceApiMigrator.kt
@@ -70,8 +70,9 @@ private val major1Minor2To3Migration =
                 }
             }
 
-            // Remove newly added 'name' field from 'ParticipantGroupStatus'.
+            // Remove newly added fields from `ParticipantGroupStatus`.
             json.remove( "name" )
+            json.remove( "assignedParticipantRoles" )
         }
 
         override fun migrateEvent( event: JsonObject ) = event

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
@@ -185,6 +185,8 @@ interface RecruitmentServiceTest
             setOf( assignedParticipant ),
             "Group 1"
         )
+
+        // Deploy the same participants in a group with a different name.
         val groupStatus2 = recruitmentService.inviteNewParticipantGroup(
             studyId,
             setOf( assignedParticipant ),
@@ -230,6 +232,7 @@ interface RecruitmentServiceTest
         val assignedP1 = AssignedParticipantRoles( p1.id, AssignedTo.All )
         recruitmentService.inviteNewParticipantGroup( studyId, setOf( assignedP1 ), sameName )
 
+        // Second group with different participants but same group same name.
         val p2 = recruitmentService.addParticipant( studyId, EmailAddress( "test2@test.com" ) )
         val assignedP2 = AssignedParticipantRoles( p2.id, AssignedTo.All )
         recruitmentService.inviteNewParticipantGroup( studyId, setOf( assignedP2 ), sameName )
@@ -237,6 +240,31 @@ interface RecruitmentServiceTest
         val participantGroups = recruitmentService.getParticipantGroupStatusList( studyId )
         assertNotEquals( participantGroups[0].id, participantGroups[1].id )
         assertEquals( participantGroups[0].name, participantGroups[1].name )
+    }
+
+    @Test
+    fun inviteNewParticipantGroup_for_same_participant_different_roles_succeeds() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, protocol) = createLiveStudy( studyService )
+        val participant1 = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val participant2 = recruitmentService.addParticipant( studyId, EmailAddress( "test2@test.com" ) )
+        val role1 = protocol.participantRoles.map { it.role }.first()
+        val role2 = protocol.participantRoles.map { it.role }.last()
+
+        // First group: participant1 has role1, participant2 has role2.
+        val assignedSpecificRoles1 = AssignedParticipantRoles( participant1.id, AssignedTo.Roles( setOf ( role1 ) ) )
+        val assignedSpecificRoles2 = AssignedParticipantRoles( participant2.id, AssignedTo.Roles( setOf ( role2 ) ) )
+        val groupStatus1 = recruitmentService.inviteNewParticipantGroup(
+            studyId, setOf( assignedSpecificRoles1, assignedSpecificRoles2 )
+        )
+
+        // Second group: participant1 has role2, participant2 has role1.
+        val assignedSpecificRoles3 = AssignedParticipantRoles( participant1.id, AssignedTo.Roles( setOf ( role2 ) ) )
+        val assignedSpecificRoles4 = AssignedParticipantRoles( participant2.id, AssignedTo.Roles( setOf ( role1 ) ) )
+        val groupStatus2 = recruitmentService.inviteNewParticipantGroup(
+            studyId, setOf( assignedSpecificRoles3, assignedSpecificRoles4 )
+        )
+        assertNotEquals( groupStatus1, groupStatus2 )
     }
 
     @Test

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/users/ParticipantGroupStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/users/ParticipantGroupStatusTest.kt
@@ -18,6 +18,7 @@ class ParticipantGroupStatusTest
     private val participantGroupName = "Test group"
     private val deviceStatusList = emptyList<DeviceDeploymentStatus>()
     private val participants: Set<Participant> = emptySet()
+    private val roleAssignments: Set<AssignedParticipantRoles> = emptySet()
     private val participantStatusList: List<ParticipantStatus> = emptyList()
 
 
@@ -28,6 +29,7 @@ class ParticipantGroupStatusTest
 
         val status = ParticipantGroupStatus.InDeployment.fromDeploymentStatus(
             participants,
+            roleAssignments,
             deployingDevices,
             participantGroupName
         )
@@ -42,6 +44,7 @@ class ParticipantGroupStatusTest
 
         val status = ParticipantGroupStatus.InDeployment.fromDeploymentStatus(
             participants,
+            roleAssignments,
             redeployingDevices,
             participantGroupName
         )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/CreateTestObjects.kt
@@ -3,9 +3,11 @@ package dk.cachet.carp.studies.domain
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.devices.Smartphone
+import dk.cachet.carp.common.application.users.AssignedTo
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createComplexProtocol
+import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
 import dk.cachet.carp.studies.domain.users.Recruitment
 
 
@@ -34,9 +36,10 @@ fun createComplexRecruitment(): Recruitment
     val studyId = UUID.randomUUID()
     val recruitment = Recruitment( studyId ).apply {
         val participant = addParticipant( EmailAddress( "test@test.com" ) )
+        val roleAssignment = AssignedParticipantRoles( participant.id, AssignedTo.All )
         val name = "Test Group"
         lockInStudy( createComplexProtocol().getSnapshot(), StudyInvitation( "Test" ) )
-        addParticipantGroup( setOf( participant.id ), name )
+        addParticipantGroup( setOf( roleAssignment ), name )
     }
 
     return recruitment

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
@@ -2,11 +2,13 @@ package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.EmailAddress
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.common.application.users.AssignedTo
 import dk.cachet.carp.common.application.users.EmailAccountIdentity
 import dk.cachet.carp.deployments.application.StudyDeploymentStatus
 import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSinglePrimaryDeviceProtocol
+import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
 import kotlinx.datetime.Clock
 import kotlin.test.*
 
@@ -27,8 +29,9 @@ class RecruitmentTest
         val participant = recruitment.addParticipant( participantEmail )
         val protocol = createEmptyProtocol()
         val invitation = StudyInvitation( "Test", "A study" )
+        val roleAssignment = setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
         recruitment.lockInStudy( protocol.getSnapshot(), invitation )
-        recruitment.addParticipantGroup( setOf( participant.id ) )
+        recruitment.addParticipantGroup( roleAssignment )
 
         val snapshot = recruitment.getSnapshot()
         val fromSnapshot = Recruitment.fromSnapshot( snapshot )
@@ -105,9 +108,9 @@ class RecruitmentTest
 
         assertTrue( recruitment.getStatus() is RecruitmentStatus.ReadyForDeployment )
 
-        val participantIds = setOf( participant.id )
-        val group = recruitment.addParticipantGroup( participantIds, groupName )
-        assertEquals( Recruitment.Event.ParticipantGroupAdded( participantIds ), recruitment.consumeEvents().last() )
+        val roleAssignment = setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
+        val group = recruitment.addParticipantGroup( roleAssignment, groupName )
+        assertEquals( Recruitment.Event.ParticipantGroupAdded( roleAssignment ), recruitment.consumeEvents().last() )
         assertEquals(
             participant.id,
             recruitment.participantGroups[ group.id ]?.participantIds?.singleOrNull()
@@ -123,10 +126,22 @@ class RecruitmentTest
 
         assertFalse( recruitment.getStatus() is RecruitmentStatus.ReadyForDeployment )
 
-        val participantIds = setOf( participant.id )
-        assertFailsWith<IllegalStateException> { recruitment.addParticipantGroup( participantIds ) }
+        val roleAssignment = setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
+        assertFailsWith<IllegalStateException> { recruitment.addParticipantGroup( roleAssignment ) }
         val participationEvents = recruitment.consumeEvents().filterIsInstance<Recruitment.Event.ParticipantGroupAdded>()
         assertEquals( 0, participationEvents.count() )
+    }
+
+    @Test
+    fun addParticipantGroup_fails_for_unknown_participant_roles()
+    {
+        val recruitment = Recruitment( studyId )
+        val participant = recruitment.addParticipant( participantEmail )
+        val protocol = createEmptyProtocol()
+        recruitment.lockInStudy( protocol.getSnapshot(), StudyInvitation( "Some study" ) )
+        val unknownRole = AssignedTo.Roles( setOf( "Unknown role" ) )
+        val unknownRoleAssignment = setOf( AssignedParticipantRoles( participant.id, unknownRole ) )
+        assertFailsWith<IllegalArgumentException> { recruitment.addParticipantGroup( unknownRoleAssignment ) }
     }
 
     @Test
@@ -134,9 +149,10 @@ class RecruitmentTest
     {
         val recruitment = Recruitment( studyId )
         val participant = recruitment.addParticipant( participantEmail )
+        val roleAssignment = setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
         val protocol = createEmptyProtocol()
         recruitment.lockInStudy( protocol.getSnapshot(), StudyInvitation( "Some study" ) )
-        val group = recruitment.addParticipantGroup( setOf( participant.id ) )
+        val group = recruitment.addParticipantGroup( roleAssignment )
 
         val stubDeploymentStatus =
             StudyDeploymentStatus.DeployingDevices( Clock.System.now(), group.id, emptyList(), emptyList(), null )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroupTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/StagedParticipantGroupTest.kt
@@ -1,9 +1,8 @@
 package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.UUID
-import dk.cachet.carp.deployments.application.StudyDeploymentStatus
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import dk.cachet.carp.common.application.users.AssignedTo
+import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
 import kotlin.test.*
 
 
@@ -16,35 +15,37 @@ class StagedParticipantGroupTest
     fun addParticipants_succeeds()
     {
         val group = StagedParticipantGroup()
-        val participantId = UUID.randomUUID()
-        group.addParticipants( setOf( participantId ) )
+        val roleAssignment = AssignedParticipantRoles( participantId = UUID.randomUUID(), AssignedTo.All )
+        group.addParticipants( setOf( roleAssignment ) )
 
-        assertEquals( participantId, group.participantIds.singleOrNull() )
+        assertEquals( roleAssignment.participantId, group.participantIds.singleOrNull() )
+        assertEquals( roleAssignment, group.roleAssignments.singleOrNull() )
     }
 
     @Test
     fun addParticipants_fails_when_already_deployed()
     {
         val group = StagedParticipantGroup()
-        val participantId = UUID.randomUUID()
-        group.addParticipants( setOf( participantId ) )
+        val roleAssignment = AssignedParticipantRoles( participantId = UUID.randomUUID(), AssignedTo.All )
+        group.addParticipants( setOf( roleAssignment ) )
         group.markAsDeployed()
 
-        val newParticipantId = UUID.randomUUID()
-        assertFailsWith<IllegalStateException> { group.addParticipants( setOf( newParticipantId ) ) }
+        val newRoleAssignment = AssignedParticipantRoles( participantId = UUID.randomUUID(), AssignedTo.All )
+        assertFailsWith<IllegalStateException> { group.addParticipants( setOf( newRoleAssignment ) ) }
     }
 
     @Test
     fun markAsDeployed_succeeds()
     {
         val group = StagedParticipantGroup()
-        val participantId = UUID.randomUUID()
-        group.addParticipants( setOf( participantId ) )
+        val roleAssignment = AssignedParticipantRoles( participantId = UUID.randomUUID(), AssignedTo.All )
+        group.addParticipants( setOf( roleAssignment ) )
         assertFalse( group.isDeployed )
 
         group.markAsDeployed()
 
         assertTrue( group.isDeployed )
+        assertEquals( roleAssignment, group.roleAssignments.singleOrNull() )
     }
 
     @Test

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantGroupStatusTest.kt
@@ -2,8 +2,10 @@ package dk.cachet.carp.studies.infrastructure
 
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AccountIdentity
+import dk.cachet.carp.common.application.users.AssignedTo
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.deployments.application.StudyDeploymentStatus
+import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
 import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
 import kotlinx.datetime.Clock
@@ -21,8 +23,14 @@ class ParticipantGroupStatusTest
         val studyDeploymentId = UUID.randomUUID()
         val deploymentStatus = StudyDeploymentStatus.Invited( Clock.System.now(), studyDeploymentId, listOf(), emptyList(), null )
         val participants = setOf( Participant( AccountIdentity.fromEmailAddress( "test@test.com" ) ) )
+        val roleAssignment = setOf( AssignedParticipantRoles( participants.first().id, AssignedTo.All ) )
         val name = "Test Group"
-        val groupStatus = ParticipantGroupStatus.InDeployment.fromDeploymentStatus( participants, deploymentStatus, name )
+        val groupStatus = ParticipantGroupStatus.InDeployment.fromDeploymentStatus(
+            participants,
+            roleAssignment,
+            deploymentStatus,
+            name,
+        )
 
         val serialized: String = JSON.encodeToString( ParticipantGroupStatus.serializer(), groupStatus )
         val parsed: ParticipantGroupStatus = JSON.decodeFromString( ParticipantGroupStatus.serializer(), serialized )

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipantGroupStatusList_returns_multiple_deployments.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/getParticipantGroupStatusList_returns_multiple_deployments.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "9ed836f8-1139-450d-94f5-bf985a6be59c",
+                    "ownerId": "3407151a-879d-45ac-a6dc-51de89f7be9a",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "9ed836f8-1139-450d-94f5-bf985a6be59c",
+                    "ownerId": "3407151a-879d-45ac-a6dc-51de89f7be9a",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "5205f824-6fb7-463d-9671-32ab337b2c67",
-                        "createdOn": "2025-08-09T15:18:12.646803800Z",
+                        "id": "0f147969-bcaa-44ce-9309-7bbeacae60cd",
+                        "createdOn": "2025-10-16T17:11:47.478183Z",
                         "version": 0,
-                        "ownerId": "e73c2530-dc44-4598-a195-47f6d8fcb397",
+                        "ownerId": "70b656d7-e3e7-423d-b054-22c549126ef1",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -108,6 +108,14 @@
                         "emailAddress": "test@test.com"
                     },
                     "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
                 }
             ],
             "invitedOn": "1970-01-01T00:00:00Z",
@@ -194,6 +202,14 @@
                     "id": "00000000-0000-0000-0000-000000000004"
                 }
             ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000004",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
             "invitedOn": "1970-01-01T00:00:00Z",
             "studyDeploymentStatus": {
                 "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
@@ -253,6 +269,14 @@
                         "id": "00000000-0000-0000-0000-000000000002"
                     }
                 ],
+                "assignedParticipantRoles": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        }
+                    }
+                ],
                 "invitedOn": "1970-01-01T00:00:00Z",
                 "studyDeploymentStatus": {
                     "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
@@ -299,6 +323,14 @@
                             "emailAddress": "test2@test.com"
                         },
                         "id": "00000000-0000-0000-0000-000000000004"
+                    }
+                ],
+                "assignedParticipantRoles": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000004",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        }
                     }
                 ],
                 "invitedOn": "1970-01-01T00:00:00Z",

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_empty_group.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_empty_group.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e2ed4d64-2511-4f2c-9df7-7e588825be0e",
+                    "ownerId": "1eb51bd2-78b8-498f-aec8-d9d4d61f321b",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e2ed4d64-2511-4f2c-9df7-7e588825be0e",
+                    "ownerId": "1eb51bd2-78b8-498f-aec8-d9d4d61f321b",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "d86c4fa8-19bf-4fa4-b9fd-596bb53057b9",
-                        "createdOn": "2025-08-09T15:18:12.650803700Z",
+                        "id": "003175c7-e357-4c67-9ad1-58d436266981",
+                        "createdOn": "2025-10-16T17:11:09.251624Z",
                         "version": 0,
-                        "ownerId": "06842957-3786-4536-832c-33c9b7c82a2f",
+                        "ownerId": "38870679-7c69-4a42-a804-b2fec9911b30",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_participant_roles.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_participant_roles.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e6c315cf-e48f-47af-b70a-97d94b3c6834",
+                    "ownerId": "93fb9e74-6f79-4ede-852f-b61882d21545",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e6c315cf-e48f-47af-b70a-97d94b3c6834",
+                    "ownerId": "93fb9e74-6f79-4ede-852f-b61882d21545",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "06bc9c2a-5b7e-4328-8eac-8fd97247c45c",
-                        "createdOn": "2025-08-09T15:18:12.618803900Z",
+                        "id": "41b99456-a9b4-4dcd-aa6c-510cc204f926",
+                        "createdOn": "2025-10-16T17:11:09.192248Z",
                         "version": 0,
-                        "ownerId": "cbb2175b-ca6b-41cf-b4dc-2759921d9615",
+                        "ownerId": "e0fd5110-65d8-4b6d-80a8-b5e7aa3eb7f6",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_participants.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_participants.json
@@ -7,7 +7,7 @@
             "studyId": "00000000-0000-0000-0000-000000000001",
             "group": [
                 {
-                    "participantId": "44fa6907-6e61-4d10-ac3c-4fecd0bb48f5",
+                    "participantId": "cda4f8f0-7426-4504-875b-713102ec4b5e",
                     "assignedRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     }
@@ -21,7 +21,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "3686ea9b-dde1-46b1-9ccc-92dc2790e2eb",
+                    "ownerId": "0acbddd2-4cf0-420a-b415-9b79f8c5dc44",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -37,7 +37,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "3686ea9b-dde1-46b1-9ccc-92dc2790e2eb",
+                    "ownerId": "0acbddd2-4cf0-420a-b415-9b79f8c5dc44",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -45,10 +45,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "215129eb-02d5-458a-90b0-199a4257b546",
-                        "createdOn": "2025-08-09T15:18:12.609803300Z",
+                        "id": "e34dc238-b7ca-47da-86f9-9a015d7259d2",
+                        "createdOn": "2025-10-16T17:11:09.178986Z",
                         "version": 0,
-                        "ownerId": "6c384573-e415-4f53-869a-3d21ad1a75c0",
+                        "ownerId": "9fe7c8e4-d790-4947-88ef-5ee8479e757e",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_studyId.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_for_unknown_studyId.json
@@ -4,10 +4,10 @@
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
             "apiVersion": "1.3",
-            "studyId": "44fa6907-6e61-4d10-ac3c-4fecd0bb48f5",
+            "studyId": "cda4f8f0-7426-4504-875b-713102ec4b5e",
             "group": [
                 {
-                    "participantId": "ace001a7-6269-4b4c-8f32-666b2bb40489",
+                    "participantId": "cc6ea4c7-6e25-4b0f-b8a5-19bb44011c10",
                     "assignedRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     }

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_when_not_all_participant_roles_assigned.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_fails_when_not_all_participant_roles_assigned.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "442837a8-ed8b-4f37-9b29-b8eb28d42365",
+                    "ownerId": "116ac4e7-6ef7-441c-8651-fed44bd58982",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "442837a8-ed8b-4f37-9b29-b8eb28d42365",
+                    "ownerId": "116ac4e7-6ef7-441c-8651-fed44bd58982",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "7ad2628d-25fa-4d78-9bbe-e8628a4bb802",
-                        "createdOn": "2025-08-09T15:18:12.654803700Z",
+                        "id": "5cf08c25-da82-47d7-b47d-3710c7070dcb",
+                        "createdOn": "2025-10-16T17:11:09.258468Z",
                         "version": 0,
-                        "ownerId": "488e1ab1-5558-4508-9585-6f48efc8b095",
+                        "ownerId": "301094a1-fb53-4ca7-a1bb-3e3a2521834b",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_multiple_groups_with_same_name_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_multiple_groups_with_same_name_succeeds.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "c6829dd1-26b4-4b66-b6e6-241f2bb67398",
+                    "ownerId": "bc734795-3dd5-4561-af83-fee62ed0b3a4",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "c6829dd1-26b4-4b66-b6e6-241f2bb67398",
+                    "ownerId": "bc734795-3dd5-4561-af83-fee62ed0b3a4",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "30876917-268a-4738-a989-98848b762eea",
-                        "createdOn": "2025-08-27T19:25:11.784560Z",
+                        "id": "079cc410-cc83-4e69-8209-35b608703970",
+                        "createdOn": "2025-10-16T17:11:09.230865Z",
                         "version": 0,
-                        "ownerId": "b618a3eb-6b26-48d3-9db2-c19a9556373d",
+                        "ownerId": "04e0fd86-c25f-4bce-be13-3766a9b086e0",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -95,7 +95,7 @@
                     }
                 }
             ],
-            "name": "Test Group"
+            "name": "Same Group"
         },
         "precedingEvents": [],
         "publishedEvents": [],
@@ -109,6 +109,14 @@
                         "emailAddress": "test@test.com"
                     },
                     "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
                 }
             ],
             "invitedOn": "1970-01-01T00:00:00Z",
@@ -146,7 +154,7 @@
                 ],
                 "startedOn": null
             },
-            "name": "Test Group"
+            "name": "Same Group"
         }
     },
     {
@@ -181,7 +189,7 @@
                     }
                 }
             ],
-            "name": "Test Group"
+            "name": "Same Group"
         },
         "precedingEvents": [],
         "publishedEvents": [],
@@ -195,6 +203,14 @@
                         "emailAddress": "test2@test.com"
                     },
                     "id": "00000000-0000-0000-0000-000000000004"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000004",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
                 }
             ],
             "invitedOn": "1970-01-01T00:00:00Z",
@@ -232,7 +248,7 @@
                 ],
                 "startedOn": null
             },
-            "name": "Test Group"
+            "name": "Same Group"
         }
     },
     {
@@ -255,6 +271,14 @@
                             "emailAddress": "test@test.com"
                         },
                         "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "assignedParticipantRoles": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        }
                     }
                 ],
                 "invitedOn": "1970-01-01T00:00:00Z",
@@ -292,7 +316,7 @@
                     ],
                     "startedOn": null
                 },
-                "name": "Test Group"
+                "name": "Same Group"
             },
             {
                 "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
@@ -304,6 +328,14 @@
                             "emailAddress": "test2@test.com"
                         },
                         "id": "00000000-0000-0000-0000-000000000004"
+                    }
+                ],
+                "assignedParticipantRoles": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000004",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        }
                     }
                 ],
                 "invitedOn": "1970-01-01T00:00:00Z",
@@ -341,7 +373,7 @@
                     ],
                     "startedOn": null
                 },
-                "name": "Test Group"
+                "name": "Same Group"
             }
         ]
     }

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_previously_stopped_group_returns_new_group.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_previously_stopped_group_returns_new_group.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "b2159246-a701-4062-af44-575edd23e084",
+                    "ownerId": "cd232d57-cd94-48fc-8e6f-80843eccef8f",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "b2159246-a701-4062-af44-575edd23e084",
+                    "ownerId": "cd232d57-cd94-48fc-8e6f-80843eccef8f",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "6e1fe4b6-20a1-4bae-a19e-68b47d277fb7",
-                        "createdOn": "2025-08-09T15:18:12.632803300Z",
+                        "id": "4e7cf29a-5e1c-4fc5-b203-b17b70f8b767",
+                        "createdOn": "2025-10-16T17:11:09.217206Z",
                         "version": 0,
-                        "ownerId": "9d8eb47d-434a-43f4-94cb-44080ca4ac9c",
+                        "ownerId": "578c9ac6-b621-4ea8-aa00-0f0542a79aea",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -110,6 +110,14 @@
                     "id": "00000000-0000-0000-0000-000000000002"
                 }
             ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
             "invitedOn": "1970-01-01T00:00:00Z",
             "studyDeploymentStatus": {
                 "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
@@ -167,6 +175,14 @@
                         "emailAddress": "test@test.com"
                     },
                     "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
                 }
             ],
             "invitedOn": "1970-01-01T00:00:00Z",
@@ -236,6 +252,14 @@
                         "emailAddress": "test@test.com"
                     },
                     "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
                 }
             ],
             "invitedOn": "1970-01-01T00:00:00Z",

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_multiple_times_returns_same_group.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_multiple_times_returns_same_group.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "5236c0b2-59bb-4345-9c7b-fa2ad0912e80",
+                    "ownerId": "e8b85ecd-17bd-48b2-b832-30904279b35e",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "5236c0b2-59bb-4345-9c7b-fa2ad0912e80",
+                    "ownerId": "e8b85ecd-17bd-48b2-b832-30904279b35e",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "74e18f73-50b8-4dd1-8293-ae1cd93bdd28",
-                        "createdOn": "2025-08-09T15:18:12.612803500Z",
+                        "id": "b661c11e-1c08-447c-af7a-8126b22c34cc",
+                        "createdOn": "2025-10-16T17:11:09.186323Z",
                         "version": 0,
-                        "ownerId": "9b95519b-5d50-4c5c-b2f3-f5b9a5c5d247",
+                        "ownerId": "d3b42407-c768-4c94-b41d-96e8c9d1d555",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -110,6 +110,14 @@
                     "id": "00000000-0000-0000-0000-000000000002"
                 }
             ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
             "invitedOn": "1970-01-01T00:00:00Z",
             "studyDeploymentStatus": {
                 "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
@@ -174,6 +182,14 @@
                         "emailAddress": "test@test.com"
                     },
                     "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
                 }
             ],
             "invitedOn": "1970-01-01T00:00:00Z",

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_succeeds.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "7cd72eba-618b-4a6d-9b60-1e026b7f5a6f",
+                    "ownerId": "f7b34183-8865-48a3-8cd9-895a642dddc7",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "7cd72eba-618b-4a6d-9b60-1e026b7f5a6f",
+                    "ownerId": "f7b34183-8865-48a3-8cd9-895a642dddc7",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "d4ce6656-7288-43cb-b188-c2dd2155090d",
-                        "createdOn": "2025-08-27T16:24:17.860498Z",
+                        "id": "e46ce5b7-c23c-4f51-8cea-8d4b4a1f13b0",
+                        "createdOn": "2025-10-16T17:11:09.173827Z",
                         "version": 0,
-                        "ownerId": "6a4b2a0c-e3c4-48ed-88bb-ab8bb58f933f",
+                        "ownerId": "9e57a66b-db67-400e-a60a-f98da56bde7f",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -111,6 +111,14 @@
                     "id": "00000000-0000-0000-0000-000000000002"
                 }
             ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
             "invitedOn": "1970-01-01T00:00:00Z",
             "studyDeploymentStatus": {
                 "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
@@ -169,6 +177,14 @@
                             "emailAddress": "test@test.com"
                         },
                         "id": "00000000-0000-0000-0000-000000000002"
+                    }
+                ],
+                "assignedParticipantRoles": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        }
                     }
                 ],
                 "invitedOn": "1970-01-01T00:00:00Z",

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_with_same_participants_different_name_creates_new_group.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_with_same_participants_different_name_creates_new_group.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "b27ea79c-e848-4f15-9290-07b9c66c9335",
+                    "ownerId": "c762dc7f-971c-4c66-bd56-9166341bc02b",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "b27ea79c-e848-4f15-9290-07b9c66c9335",
+                    "ownerId": "c762dc7f-971c-4c66-bd56-9166341bc02b",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "98e51b89-9b04-4c57-83b3-7c970136616d",
-                        "createdOn": "2025-09-04T11:17:33.378332Z",
+                        "id": "204957d7-1922-4a41-850e-4abdff30a900",
+                        "createdOn": "2025-10-16T17:11:09.204556Z",
                         "version": 0,
-                        "ownerId": "cefce5e3-f737-4719-a0e9-2cc5e919d674",
+                        "ownerId": "aeedc3d7-ce9d-4595-ac4b-c47b303245da",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -111,6 +111,14 @@
                     "id": "00000000-0000-0000-0000-000000000002"
                 }
             ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
             "invitedOn": "1970-01-01T00:00:00Z",
             "studyDeploymentStatus": {
                 "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
@@ -177,6 +185,14 @@
                         "emailAddress": "test@test.com"
                     },
                     "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
                 }
             ],
             "invitedOn": "1970-01-01T00:00:00Z",

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_succeeds.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "22f5d24a-84c9-4fdb-bfd0-fe7687080bbc",
+                    "ownerId": "60e0084f-851e-4d5e-b8a9-5d16d0de19bf",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "22f5d24a-84c9-4fdb-bfd0-fe7687080bbc",
+                    "ownerId": "60e0084f-851e-4d5e-b8a9-5d16d0de19bf",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "9e1ad296-022e-40df-ba08-1470a7904a1a",
-                        "createdOn": "2025-08-09T15:18:12.627804500Z",
+                        "id": "84388d2b-7a8b-439a-80e8-f8ce9d9edee8",
+                        "createdOn": "2025-10-16T17:12:43.957095Z",
                         "version": 0,
-                        "ownerId": "09313bd4-4f3a-41f4-9a5c-9dfa22369364",
+                        "ownerId": "0a128998-dedb-4232-a6bf-e5077bf02eab",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -110,6 +110,14 @@
                     "id": "00000000-0000-0000-0000-000000000002"
                 }
             ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
             "invitedOn": "1970-01-01T00:00:00Z",
             "studyDeploymentStatus": {
                 "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
@@ -167,6 +175,14 @@
                         "emailAddress": "test@test.com"
                     },
                     "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
                 }
             ],
             "invitedOn": "1970-01-01T00:00:00Z",

--- a/rpc/schemas/studies/users/ParticipantGroupStatus.json
+++ b/rpc/schemas/studies/users/ParticipantGroupStatus.json
@@ -16,9 +16,13 @@
         "participants": {
           "type": "array",
           "items": { "$ref": "../users/Participant.json" }
+        },
+        "assignedParticipantRoles": {
+          "type": "array",
+          "items": { "$ref": "../users/AssignedParticipantRoles.json" }
         }
       },
-      "required": [ "__type", "id", "participants" ]
+      "required": [ "__type", "id", "participants", "assignedParticipantRoles" ]
     },
     "InDeployment": {
       "$anchor": "InDeployment",

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -166,6 +166,7 @@ private val studyInvitation = StudyInvitation(
     ApplicationData( "{\"trialGroup\", \"A\"}" )
 )
 private val participantAssignedRoles = AssignedTo.Roles( setOf( participantRole.role ) )
+private val roleAssignment = setOf( AssignedParticipantRoles( participantId, participantAssignedRoles ) )
 private val participantInvitation = ParticipantInvitation(
     participantId,
     participantAssignedRoles,
@@ -390,6 +391,7 @@ private val exampleRequests: Map<KFunction<*>, LoggedRequest.Succeeded<*>> = map
         response = ParticipantGroupStatus.Invited(
             deploymentId,
             participants,
+            roleAssignment,
             participantGroupInvitedOn,
             invitedDeploymentStatus,
             deploymentName
@@ -401,6 +403,7 @@ private val exampleRequests: Map<KFunction<*>, LoggedRequest.Succeeded<*>> = map
             ParticipantGroupStatus.Running(
                 deploymentId,
                 participants,
+                roleAssignment,
                 participantGroupInvitedOn,
                 runningDeploymentStatus,
                 runningDeploymentStatus.startedOn,
@@ -413,6 +416,7 @@ private val exampleRequests: Map<KFunction<*>, LoggedRequest.Succeeded<*>> = map
         response = ParticipantGroupStatus.Stopped(
             deploymentId,
             participants,
+            roleAssignment,
             participantGroupInvitedOn,
             stoppedDeploymentStatus,
             stoppedDeploymentStatus.startedOn,

--- a/typescript-declarations/tests/carp-studies-test.ts
+++ b/typescript-declarations/tests/carp-studies-test.ts
@@ -122,9 +122,11 @@ describe( "carp-studies-core", () => {
             const emptyDeploymentStatusList = KtList.fromJsArray( [] )
             const emptyParticipantStatusList = KtList.fromJsArray( [] )
             const deploymentStatus = new StudyDeploymentStatus.Running( now, deploymentId, emptyDeploymentStatusList, emptyParticipantStatusList, now )
-            const participantsSet = new Set( [ new Participant( new UsernameAccountIdentity( new Username( "Test" ) ) ) ] )
-            const participants = KtSet.fromJsSet( participantsSet )
-            const group = new ParticipantGroupStatus.Invited( deploymentId, participants, now, deploymentStatus, "Test group" )
+            const participantsSet = [ new Participant( new UsernameAccountIdentity( new Username( "Test" ) ) ) ]
+            const participants = KtSet.fromJsSet( new Set( participantsSet ) )
+            const roleAssignmentsSet = new Set( [ new AssignedParticipantRoles( participantsSet[0].id, AssignedTo.All ) ] )
+            const roleAssignments = KtSet.fromJsSet( roleAssignmentsSet )
+            const group = new ParticipantGroupStatus.Invited( deploymentId, participants, roleAssignments, now, deploymentStatus, "Test group" )
 
             const serializer = getSerializer( ParticipantGroupStatus )
             const serialized = JSON.encodeToString( serializer, group )


### PR DESCRIPTION
In preparation for [editing `StagedParticipantGroup`](#319 ), creation and invitation process for new participant groups should be separated. Persist participants' `roleAssignment` provides the ability to modify `StagedParticipantGroup` before they are invited.

Note: 

- This change requires data migration: currently, role assignments are persisted in deployment subsystem.

- For implementations with event-driven databases, the `ParticipantGroupAdded` event now takes new parameters consisting of a `Set<AssignedParticipantRoles>` and an optional `name: String?`.