### PR TITLE
Add separate endpoint for create and invite participant group methods…

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,13 @@ if ( studyStatus.canDeployToParticipants )
     // Create a 'participant group' with a single participant; `AssignedTo.All` assigns the "Patient's phone".
     val participation = AssignedParticipantRoles( participant.id, AssignedTo.All )
     val participantGroup = setOf( participation )
-
-    val groupStatus: ParticipantGroupStatus = recruitmentService.inviteNewParticipantGroup( studyId, participantGroup )
+  
+    val groupId = UUID.randomUUID()
+    var groupStatus: ParticipantGroupStatus =
+        recruitmentService.createParticipantGroup( groupId, participantGroup, studyId )
+    val isStaged = groupStatus is ParticipantGroupStatus.Staged // True.
+  
+    groupStatus = recruitmentService.inviteParticipantGroup( groupId )
     val isInvited = groupStatus is ParticipantGroupStatus.Invited // True.
 }
 ```

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
@@ -74,11 +74,49 @@ interface RecruitmentService : ApplicationService<RecruitmentService, Recruitmen
      *  - not all necessary participant roles part of the study have been assigned a participant
      * @throws IllegalStateException when the study is not yet ready for deployment.
      */
+    @Deprecated(
+        "Use createParticipantGroup and inviteParticipantGroup instead",
+        ReplaceWith(
+            "inviteParticipantGroup( createParticipantGroup( UUID.randomUUID(), group, studyId, name ).id )",
+            "dk.cachet.carp.common.application.UUID"
+        ),
+        level = DeprecationLevel.WARNING
+    )
     suspend fun inviteNewParticipantGroup(
         studyId: UUID,
         group: Set<AssignedParticipantRoles>,
         name: String? = null
     ): ParticipantGroupStatus
+
+    /**
+     * Create a new participant [group] of previously added participants for the study with the given [studyId],
+     * and an optional [name] representing this group, but do not yet send out invitations.
+     * This is used to create a group of participants which can be deployed at a later time.
+     *
+     * As long as no final study protocol is locked in for the study, a participant group can't be created
+     * since participant roles to which participants need to be assigned are unknown.
+     * @throws IllegalArgumentException when:
+     *  - a study with [studyId] does not exist
+     *  - an existing participant group with [groupId] already exists
+     *  - any of the participant roles specified in [group] does not exist
+     * @throws IllegalStateException when the study is not yet ready for deployment.
+     */
+    suspend fun createParticipantGroup(
+        groupId: UUID,
+        group: Set<AssignedParticipantRoles>,
+        studyId: UUID,
+        name: String? = null
+    ): ParticipantGroupStatus
+
+    /**
+     * Invite the participant group with the specified [groupId] to start participating in its study.
+     *
+     * @throws IllegalArgumentException when:
+     *  - the participant group with [groupId] does not exist
+     *  - not all necessary participant roles part of the study have been assigned a participant
+     * @throws IllegalStateException when group has already been deployed.
+     */
+    suspend fun inviteParticipantGroup( groupId: UUID ): ParticipantGroupStatus
 
     /**
      * Get the status of all participant groups in the study with the specified [studyId].

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentService.kt
@@ -81,7 +81,7 @@ interface RecruitmentService : ApplicationService<RecruitmentService, Recruitmen
     ): ParticipantGroupStatus
 
     /**
-     * Get the status of all deployed participant groups in the study with the specified [studyId].
+     * Get the status of all participant groups in the study with the specified [studyId].
      *
      * @throws IllegalArgumentException when a study with [studyId] does not exist.
      */

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
@@ -125,6 +125,13 @@ class RecruitmentServiceHost(
      *  - not all necessary participant roles part of the study have been assigned a participant
      * @throws IllegalStateException when the study is not yet ready for deployment.
      */
+    @Deprecated(
+        "Use createParticipantGroup and inviteParticipantGroup instead",
+        replaceWith = ReplaceWith(
+            "inviteParticipantGroup( createParticipantGroup( UUID.randomUUID(), group, studyId, name ).id )",
+            "dk.cachet.carp.common.application.UUID"
+        )
+    )
     override suspend fun inviteNewParticipantGroup(
         studyId: UUID,
         group: Set<AssignedParticipantRoles>,
@@ -156,6 +163,64 @@ class RecruitmentServiceHost(
         //  This should use eventual consistency: https://github.com/imotions/carp.core-kotlin/issues/295
         //  And probably be separate requests: https://github.com/imotions/carp.core-kotlin/issues/319
         val deploymentStatus = deploymentService.createStudyDeployment( participantGroup.id, protocol, invitations )
+
+        return recruitment.getParticipantGroupStatus( participantGroup.id ) { deploymentStatus }
+    }
+
+    /**
+     * Create a new participant [group] of previously added participants for the study with the given [studyId],
+     * and an optional [name] representing this group, but do not yet send out invitations.
+     * This is used to create a group of participants which can be deployed at a later time.
+     *
+     * As long as no final study protocol is locked in for the study, a participant group can't be created
+     * since participant roles to which participants need to be assigned are unknown.
+     * @throws IllegalArgumentException when:
+     *  - a study with [studyId] does not exist
+     *  - an existing participant group with [groupId] already exists
+     *  - any of the participant roles specified in [group] does not exist
+     * @throws IllegalStateException when the study is not yet ready for deployment.
+     */
+    override suspend fun createParticipantGroup(
+        groupId: UUID,
+        group: Set<AssignedParticipantRoles>,
+        studyId: UUID,
+        name: String?
+    ): ParticipantGroupStatus
+    {
+        val recruitment = getRecruitmentOrThrow( studyId )
+        require( participantRepository.getRecruitmentWithParticipantGroup( groupId ) == null )
+            { "Participant group with ID \"$groupId\" already exists." }
+
+        val participantGroup = recruitment.addParticipantGroup( group, name, groupId )
+        participantRepository.updateRecruitment( recruitment )
+
+        return recruitment.getParticipantGroupStatus( participantGroup.id ) {
+            error( "Participant group with ID \"$groupId\" is not yet deployed." )
+        }
+    }
+
+    /**
+     * Invite the participant group with the specified [groupId] to start participating in its study.
+     *
+     * @throws IllegalArgumentException when:
+     *  - the participant group with [groupId] does not exist
+     *  - not all necessary participant roles part of the study have been assigned a participant
+     * @throws IllegalStateException when group has already been deployed.
+    */
+    override suspend fun inviteParticipantGroup( groupId: UUID ): ParticipantGroupStatus
+    {
+        val (recruitment, participantGroup) = getRecruitmentWithGroupOrThrow( groupId )
+
+        check( !participantGroup.isDeployed ) { "Participant group has already been deployed." }
+
+        val (protocol, invitations) = recruitment.createInvitations( participantGroup.roleAssignments )
+        val deploymentStatus = deploymentService.createStudyDeployment( participantGroup.id, protocol, invitations )
+
+        // Mark participant group as deployed.
+        // TODO: If `createStudyDeployment` succeeds, but 'updateRecruitment' fails, state will be inconsistent.
+        //  This should use eventual consistency: https://github.com/imotions/carp.core-kotlin/issues/295
+        participantGroup.markAsDeployed()
+        participantRepository.updateRecruitment( recruitment )
 
         return recruitment.getParticipantGroupStatus( participantGroup.id ) { deploymentStatus }
     }

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
@@ -16,6 +16,7 @@ import dk.cachet.carp.studies.application.users.Participant
 import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
 import dk.cachet.carp.studies.domain.users.ParticipantRepository
 import dk.cachet.carp.studies.domain.users.Recruitment
+import dk.cachet.carp.studies.domain.users.StagedParticipantGroup
 import kotlinx.datetime.Clock
 
 
@@ -142,7 +143,7 @@ class RecruitmentServiceHost(
             ?.let { deploymentService.getStudyDeploymentStatus( it.key ) }
         if ( deployedStatus != null && deployedStatus !is StudyDeploymentStatus.Stopped )
         {
-            return recruitment.getParticipantGroupStatus( deployedStatus )
+            return recruitment.getParticipantGroupStatus( deployedStatus.studyDeploymentId ) { deployedStatus }
         }
 
         // Create participant group and mark as deployed.
@@ -156,11 +157,11 @@ class RecruitmentServiceHost(
         //  And probably be separate requests: https://github.com/imotions/carp.core-kotlin/issues/319
         val deploymentStatus = deploymentService.createStudyDeployment( participantGroup.id, protocol, invitations )
 
-        return recruitment.getParticipantGroupStatus( deploymentStatus )
+        return recruitment.getParticipantGroupStatus( participantGroup.id ) { deploymentStatus }
     }
 
     /**
-     * Get the status of all deployed participant groups in the study with the specified [studyId].
+     * Get the status of all participant groups in the study with the specified [studyId].
      *
      * @throws IllegalArgumentException when a study with [studyId] does not exist.
      */
@@ -168,13 +169,10 @@ class RecruitmentServiceHost(
     {
         val recruitment: Recruitment = getRecruitmentOrThrow( studyId )
 
-        // Get study deployment status list.
-        val studyDeploymentIds = recruitment.participantGroups.keys
-        val studyDeploymentStatusList: List<StudyDeploymentStatus> =
-            if ( studyDeploymentIds.isEmpty() ) emptyList()
-            else deploymentService.getStudyDeploymentStatusList( studyDeploymentIds )
-
-        return studyDeploymentStatusList.map { recruitment.getParticipantGroupStatus( it ) }
+        return recruitment.getParticipantGroupStatusList(
+            recruitment.participantGroups.keys,
+            deploymentService::getStudyDeploymentStatusList
+        )
     }
 
     /**
@@ -182,23 +180,29 @@ class RecruitmentServiceHost(
      * of the participant group with the specified [groupId] (equivalent to the studyDeploymentId).
      * No further changes to this deployment will be allowed and no more data will be collected.
      *
-     * @throws IllegalArgumentException when a study with [studyId] or participant group with [groupId] does not exist.
+     * @throws IllegalArgumentException when:
+     *  - a study with [studyId] or participant group with [groupId] does not exist
+     *  - the participant group with [groupId] does not belong to the study with [studyId].
      */
     override suspend fun stopParticipantGroup( studyId: UUID, groupId: UUID ): ParticipantGroupStatus
     {
-        val recruitment = getRecruitmentWithGroupOrThrow( studyId, groupId )
+        val (recruitment, participantGroup) = getRecruitmentWithGroupOrThrow( groupId )
+
+        require( recruitment.id == studyId ) {
+            "Participant group with ID \"$groupId\" does not belong to study with ID \"$studyId\"."
+        }
 
         val deploymentStatus = deploymentService.stop( groupId )
-        return recruitment.getParticipantGroupStatus( deploymentStatus )
+        return recruitment.getParticipantGroupStatus( participantGroup.id ) { deploymentStatus }
     }
 
-    private suspend fun getRecruitmentWithGroupOrThrow( studyId: UUID, groupId: UUID ): Recruitment
+    private suspend fun getRecruitmentWithGroupOrThrow( groupId: UUID ): Pair<Recruitment, StagedParticipantGroup>
     {
-        val recruitment: Recruitment = getRecruitmentOrThrow( studyId )
-        val participations = recruitment.participantGroups[ groupId ]
-        requireNotNull( participations ) { "Study deployment with the specified groupId not found." }
+        val recruitment = participantRepository.getRecruitmentWithParticipantGroup( groupId )
+            ?: throw IllegalArgumentException( "Study deployment with the specified groupId not found." )
 
-        return recruitment
+        val group = checkNotNull( recruitment.participantGroups[ groupId ] )
+        return Pair( recruitment, group )
     }
 
     private suspend fun getRecruitmentOrThrow( studyId: UUID ): Recruitment =

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/ParticipantRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/ParticipantRepository.kt
@@ -21,6 +21,12 @@ interface ParticipantRepository
     suspend fun getRecruitment( studyId: UUID ): Recruitment?
 
     /**
+     * Returns the [Recruitment] which contains the participant group with the specified [groupId],
+     * or null when no recruitment containing the specified participant group exists.
+     */
+    suspend fun getRecruitmentWithParticipantGroup( groupId: UUID ): Recruitment?
+
+    /**
      * Update a [Recruitment] which is already stored in this repository.
      *
      * @throws IllegalArgumentException when no previous version of this recruitment is stored in the repository.

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/domain/users/Recruitment.kt
@@ -206,24 +206,78 @@ class Recruitment( val studyId: UUID, id: UUID = UUID.randomUUID(), createdOn: I
     }
 
     /**
-     * Get the [ParticipantGroupStatus] of the study deployment identified by [studyDeploymentStatus].
+     * Get the [ParticipantGroupStatus] for participant groups with [groupIds] in this recruitment.
+     * For deployed participant groups, the matching [StudyDeploymentStatus] is retrieved using
+     * [getDeploymentStatusList].
      *
-     * @throws IllegalArgumentException when the study deployment identified by [studyDeploymentStatus] is not part of this recruitment.
+     * @throws IllegalArgumentException when:
+     * - [groupIds] contains an id which is not part of this recruitment
+     * - [getDeploymentStatusList] doesn't return a matching [StudyDeploymentStatus] for each of the requested IDs
      */
-    fun getParticipantGroupStatus( studyDeploymentStatus: StudyDeploymentStatus ): ParticipantGroupStatus
+    suspend fun getParticipantGroupStatusList(
+        groupIds: Set<UUID>,
+        getDeploymentStatusList: suspend (Set<UUID>) -> List<StudyDeploymentStatus>
+    ): List<ParticipantGroupStatus>
     {
-        val deploymentId = studyDeploymentStatus.studyDeploymentId
-        val group: StagedParticipantGroup = requireNotNull( _participantGroups[ deploymentId ] )
-            { "A study deployment with ID \"$deploymentId\" is not part of this recruitment." }
+        require( participantGroups.keys.containsAll( groupIds ) )
+            { "One of the group IDs a status is requested for isn't part of this recruitment." }
 
-        val participants = group.participantIds.map { id -> _participants.first { it.id == id } }
-        return ParticipantGroupStatus.InDeployment.fromDeploymentStatus(
-            participants.toSet(),
-            group.roleAssignments,
-            studyDeploymentStatus,
-            group.name
-        )
+        val (deployedGroups, stagedGroups) = groupIds
+            .map { participantGroups.getValue( it ) }
+            .partition { it.isDeployed }
+
+        // Get participant group status for staged groups.
+        val stagedGroupStatuses = stagedGroups.map { group ->
+            ParticipantGroupStatus.Staged(
+                id = group.id,
+                participants = getParticipantsFor( group ),
+                assignedParticipantRoles = group.roleAssignments,
+                name = group.name
+            )
+        }
+
+        // Get deployment status for deployed participant groups.
+        val deployedGroupIds = deployedGroups.map { it.id }.toSet()
+        val deploymentStatuses =
+            if ( deployedGroupIds.isEmpty() ) emptyMap()
+            else getDeploymentStatusList( deployedGroupIds ).associateBy { it.studyDeploymentId }
+
+        // Get participant group status for deployed groups.
+        val deployedGroupStatuses = deployedGroups.map { group ->
+            val deploymentStatus = requireNotNull( deploymentStatuses[ group.id ] )
+                { "No study deployment status returned for the requested ID: \"${group.id}\"." }
+            ParticipantGroupStatus.InDeployment.fromDeploymentStatus(
+                getParticipantsFor( group ),
+                group.roleAssignments,
+                deploymentStatus,
+                group.name
+            )
+        }
+
+        return stagedGroupStatuses + deployedGroupStatuses
     }
+
+    /**
+     * Get the [ParticipantGroupStatus] for the participant group with [groupId] in this recruitment.
+     * If the participant group is deployed, the matching [StudyDeploymentStatus] is retrieved using
+     * [getDeploymentStatus].
+     *
+     * @throws IllegalArgumentException when:
+     * - [groupId] is not part of this recruitment
+     * - [getDeploymentStatus] returns a [StudyDeploymentStatus] which doesn't match the requested ID
+     */
+    suspend fun getParticipantGroupStatus(
+        groupId: UUID,
+        getDeploymentStatus: (UUID) -> StudyDeploymentStatus
+    ): ParticipantGroupStatus =
+        getParticipantGroupStatusList( setOf( groupId ) )
+            { deploymentIds -> listOf( getDeploymentStatus( deploymentIds.single() ) ) }.single()
+
+    /**
+     * Get the participants for the participant [group].
+     */
+    private fun getParticipantsFor( group: StagedParticipantGroup ): Set<Participant> =
+        group.participantIds.map { id -> _participants.first { it.id == id } }.toSet()
 
     /**
      * Get an immutable snapshot of the current state of this [Recruitment] using the specified snapshot [version].

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryParticipantRepository.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/InMemoryParticipantRepository.kt
@@ -29,6 +29,14 @@ class InMemoryParticipantRepository : ParticipantRepository
         recruitments[ studyId ]?.let { Recruitment.fromSnapshot( it ) }
 
     /**
+     * Returns the [Recruitment] which contains the participant group with the specified [groupId],
+     * or null when no recruitment containing the specified participant group exists.
+     */
+    override suspend fun getRecruitmentWithParticipantGroup( groupId: UUID ): Recruitment? =
+        recruitments.values.firstOrNull { groupId in it.participantGroups.keys }
+            ?.let { Recruitment.fromSnapshot( it ) }
+
+    /**
      * Update a [Recruitment] which is already stored in this repository.
      *
      * @throws IllegalArgumentException when no previous version of this recruitment is stored in the repository.

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceDecorator.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceDecorator.kt
@@ -33,11 +33,29 @@ class RecruitmentServiceDecorator(
     override suspend fun getParticipants( studyId: UUID ) =
         invoke( RecruitmentServiceRequest.GetParticipants( studyId ) )
 
+    @Deprecated(
+        "Use CreateParticipantGroup and InviteParticipantGroup instead",
+        ReplaceWith(
+            "inviteParticipantGroup( createParticipantGroup( UUID.randomUUID(), group, studyId, name ).id )",
+            "dk.cachet.carp.common.application.UUID"
+        )
+    )
+    @Suppress( "DEPRECATION" )
     override suspend fun inviteNewParticipantGroup(
         studyId: UUID,
         group: Set<AssignedParticipantRoles>,
         name: String?
     ) = invoke( RecruitmentServiceRequest.InviteNewParticipantGroup( studyId, group, name ) )
+
+    override suspend fun createParticipantGroup(
+        groupId: UUID,
+        group: Set<AssignedParticipantRoles>,
+        studyId: UUID,
+        name: String?
+    ) = invoke( RecruitmentServiceRequest.CreateParticipantGroup( groupId, group, studyId, name ) )
+
+    override suspend fun inviteParticipantGroup( groupId: UUID ) =
+        invoke( RecruitmentServiceRequest.InviteParticipantGroup( groupId ) )
 
     override suspend fun getParticipantGroupStatusList( studyId: UUID ) =
         invoke( RecruitmentServiceRequest.GetParticipantGroupStatusList( studyId ) )
@@ -49,6 +67,7 @@ class RecruitmentServiceDecorator(
 
 object RecruitmentServiceInvoker : ApplicationServiceInvoker<RecruitmentService, RecruitmentServiceRequest<*>>
 {
+    @Suppress( "DEPRECATION" )
     override suspend fun RecruitmentServiceRequest<*>.invoke( service: RecruitmentService ): Any =
         when ( this )
         {
@@ -58,6 +77,9 @@ object RecruitmentServiceInvoker : ApplicationServiceInvoker<RecruitmentService,
             is RecruitmentServiceRequest.GetParticipants -> service.getParticipants( studyId )
             is RecruitmentServiceRequest.InviteNewParticipantGroup ->
                 service.inviteNewParticipantGroup( studyId, group, name )
+            is RecruitmentServiceRequest.CreateParticipantGroup ->
+                service.createParticipantGroup(groupId, group, studyId, name )
+            is RecruitmentServiceRequest.InviteParticipantGroup -> service.inviteParticipantGroup( groupId )
             is RecruitmentServiceRequest.GetParticipantGroupStatusList ->
                 service.getParticipantGroupStatusList( studyId )
             is RecruitmentServiceRequest.StopParticipantGroup -> service.stopParticipantGroup( studyId, groupId )

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequest.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceRequest.kt
@@ -65,12 +65,31 @@ sealed class RecruitmentServiceRequest<out TReturn> : ApplicationServiceRequest<
     }
 
     @Serializable
+    @Deprecated( "Use CreateParticipantGroup and InviteParticipantGroup instead." )
     data class InviteNewParticipantGroup(
         val studyId: UUID,
         val group: Set<AssignedParticipantRoles>,
         val name: String? = null
-    ) :
-        RecruitmentServiceRequest<ParticipantGroupStatus>()
+    ) : RecruitmentServiceRequest<ParticipantGroupStatus>()
+    {
+        override fun getResponseSerializer() = serializer<ParticipantGroupStatus>()
+    }
+
+    @Serializable
+    data class CreateParticipantGroup(
+        val groupId: UUID,
+        val group: Set<AssignedParticipantRoles>,
+        val studyId: UUID,
+        val name: String? = null
+    ) : RecruitmentServiceRequest<ParticipantGroupStatus>()
+    {
+        override fun getResponseSerializer() = serializer<ParticipantGroupStatus>()
+    }
+
+    @Serializable
+    data class InviteParticipantGroup(
+        val groupId: UUID
+    ) : RecruitmentServiceRequest<ParticipantGroupStatus>()
     {
         override fun getResponseSerializer() = serializer<ParticipantGroupStatus>()
     }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/StudiesCodeSamples.kt
@@ -61,7 +61,12 @@ class StudiesCodeSamples
             val participation = AssignedParticipantRoles( participant.id, AssignedTo.All )
             val participantGroup = setOf( participation )
 
-            val groupStatus: ParticipantGroupStatus = recruitmentService.inviteNewParticipantGroup( studyId, participantGroup )
+            val groupId = UUID.randomUUID()
+            var groupStatus: ParticipantGroupStatus =
+                recruitmentService.createParticipantGroup( groupId, participantGroup, studyId )
+            val isStaged = groupStatus is ParticipantGroupStatus.Staged // True.
+
+            groupStatus = recruitmentService.inviteParticipantGroup( groupId )
             val isInvited = groupStatus is ParticipantGroupStatus.Invited // True.
         }
     }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/HostsIntegrationTest.kt
@@ -96,7 +96,12 @@ class HostsIntegrationTest
 
         // Call succeeding means recruitment is ready for deployment.
         val assignRoles = setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
-        recruitmentService.inviteNewParticipantGroup( study.studyId, assignRoles )
+        val group = recruitmentService.createParticipantGroup(
+            groupId = UUID.randomUUID(),
+            group = assignRoles,
+            study.studyId
+        )
+        recruitmentService.inviteParticipantGroup( group.id )
 
         assertEquals( study.studyId, studyGoneLive?.study?.studyId )
     }
@@ -108,8 +113,12 @@ class HostsIntegrationTest
         // Add participant and deploy participant group.
         val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val assignRoles = AssignedParticipantRoles( participant.id, AssignedTo.All )
-        val group = recruitmentService.inviteNewParticipantGroup( studyId, setOf( assignRoles ) )
-        val deploymentId = group.id
+        val group = recruitmentService.createParticipantGroup(
+            groupId = UUID.randomUUID(),
+            group = setOf( assignRoles ),
+            studyId
+        )
+        recruitmentService.inviteParticipantGroup( group.id )
 
         var studyRemovedEvent: StudyService.Event.StudyRemoved? = null
         eventBus.registerHandler( StudyService::class, StudyService.Event.StudyRemoved::class, this ) { studyRemovedEvent = it }
@@ -120,13 +129,13 @@ class HostsIntegrationTest
         studyService.remove( studyId )
 
         assertEquals( studyId, studyRemovedEvent?.studyId )
-        assertEquals( deploymentId, deploymentRemovedEvent?.studyDeploymentId )
+        assertEquals( group.id, deploymentRemovedEvent?.studyDeploymentId )
 
          // Data related to study no longer exists.
         assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipantGroupStatusList( studyId ) }
         assertFailsWith<IllegalArgumentException> { recruitmentService.getParticipants( studyId ) }
-        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatus( deploymentId ) }
-        assertFailsWith<IllegalArgumentException> { participationService.getParticipantData( deploymentId ) }
+        assertFailsWith<IllegalArgumentException> { deploymentService.getStudyDeploymentStatus( group.id ) }
+        assertFailsWith<IllegalArgumentException> { participationService.getParticipantData( group.id ) }
     }
 
     @Test

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
@@ -323,6 +323,22 @@ interface RecruitmentServiceTest
         assertFailsWith<IllegalArgumentException> { recruitmentService.stopParticipantGroup( studyId, unknownId ) }
     }
 
+    @Test
+    fun stopParticipantGroup_fails_when_group_belongs_to_other_study() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, _) = createLiveStudy( studyService )
+        val (otherStudyId, _) = createLiveStudy( studyService )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val groupStatus = recruitmentService.inviteNewParticipantGroup(
+            studyId,
+            setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            recruitmentService.stopParticipantGroup( otherStudyId, groupStatus.id )
+        }
+    }
+
 
     private suspend fun createLiveStudy( service: StudyService ): Pair<UUID, StudyProtocolSnapshot>
     {

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress( "DEPRECATION" )
+
 package dk.cachet.carp.studies.application
 
 import dk.cachet.carp.common.application.EmailAddress
@@ -268,22 +270,188 @@ interface RecruitmentServiceTest
     }
 
     @Test
+    fun createParticipantGroup_succeeds() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, _) = createLiveStudy( studyService )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val groupName = "Test Group"
+
+        val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
+        val groupStatus = recruitmentService.createParticipantGroup(
+            UUID.randomUUID(),
+            setOf( assignParticipant ),
+            studyId,
+            groupName
+        )
+
+        assertEquals( participant, groupStatus.participants.single() )
+        assertTrue( groupStatus is ParticipantGroupStatus.Staged )
+        assertEquals( groupName, groupStatus.name )
+    }
+
+    @Test
+    fun createParticipantGroup_fails_for_unknown_studyId() = runTest {
+        val (recruitmentService, _) = createSUT()
+        val assignParticipant = AssignedParticipantRoles( UUID.randomUUID(), AssignedTo.All )
+
+        assertFailsWith<IllegalArgumentException>
+        {
+            recruitmentService.createParticipantGroup( UUID.randomUUID(), setOf( assignParticipant ), unknownId )
+        }
+    }
+
+    @Test
+    fun createParticipantGroup_fails_for_study_not_ready_for_deployment() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val study = studyService.createStudy( UUID.randomUUID(), "Test" )
+        val participant = recruitmentService.addParticipant( study.studyId, Username( "Test" ) )
+        val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
+
+        assertFailsWith<IllegalStateException>
+        {
+            recruitmentService.createParticipantGroup( UUID.randomUUID(), setOf( assignParticipant ), study.studyId )
+        }
+    }
+
+    @Test
+    fun createParticipantGroup_fails_for_unknown_participants() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, _) = createLiveStudy( studyService )
+
+        val assignParticipant = AssignedParticipantRoles( unknownId, AssignedTo.All )
+        assertFailsWith<IllegalArgumentException>
+        {
+            recruitmentService.createParticipantGroup( UUID.randomUUID(), setOf( assignParticipant ), studyId )
+        }
+    }
+
+    @Test
+    fun createParticipantGroup_fails_for_unknown_participant_roles() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, _) = createLiveStudy( studyService )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+
+        val assignParticipant = AssignedParticipantRoles(
+            participant.id,
+            AssignedTo.Roles( setOf( "Unknown role" ) )
+        )
+        assertFailsWith<IllegalArgumentException>
+        {
+            recruitmentService.createParticipantGroup( UUID.randomUUID(), setOf( assignParticipant ), studyId )
+        }
+    }
+
+    @Test
+    fun createParticipantGroup_for_multiple_groups_with_same_name_succeeds() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, _) = createLiveStudy( studyService )
+        val sameName = "Same group"
+
+        val p1 = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val assignedP1 = AssignedParticipantRoles( p1.id, AssignedTo.All )
+        recruitmentService.createParticipantGroup( UUID.randomUUID(), setOf( assignedP1 ), studyId, sameName )
+
+        val p2 = recruitmentService.addParticipant( studyId, EmailAddress( "test2@test.com" ) )
+        val assignedP2 = AssignedParticipantRoles( p2.id, AssignedTo.All )
+        recruitmentService.createParticipantGroup( UUID.randomUUID(), setOf( assignedP2 ), studyId, sameName )
+
+        val participantGroups = recruitmentService.getParticipantGroupStatusList( studyId )
+        assertNotEquals( participantGroups[ 0 ].id, participantGroups[ 1 ].id )
+        assertEquals( participantGroups[ 0 ].name, participantGroups[ 1 ].name )
+    }
+
+    @Test
+    fun createParticipantGroup_with_existing_groupId_fails() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, _) = createLiveStudy( studyService )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
+        val groupId = UUID.randomUUID()
+        recruitmentService.createParticipantGroup( groupId, setOf( assignParticipant ), studyId, "Group 1" )
+
+        assertFailsWith<IllegalArgumentException> {
+            recruitmentService.createParticipantGroup( groupId, setOf( assignParticipant ), studyId, "Group 2" )
+        }
+    }
+
+    @Test
+    fun inviteParticipantGroup_succeeds() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, _) = createLiveStudy( studyService )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val groupName = "Test group"
+        val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
+        val groupStatus = recruitmentService.createParticipantGroup(
+            UUID.randomUUID(),
+            setOf( assignParticipant ),
+            studyId,
+            groupName
+        )
+
+        val invitedGroupStatus = recruitmentService.inviteParticipantGroup( groupStatus.id )
+
+        assertEquals( participant, invitedGroupStatus.participants.single() )
+        assertTrue { invitedGroupStatus is ParticipantGroupStatus.Invited }
+    }
+
+    @Test
+    fun inviteParticipantGroup_fails_for_unknown_groupId() = runTest {
+        val (recruitmentService, _) = createSUT()
+
+        assertFailsWith<IllegalArgumentException> { recruitmentService.inviteParticipantGroup( unknownId ) }
+    }
+
+    @Test
+    fun inviteParticipantGroup_fails_when_not_all_participant_roles_assigned() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, protocol) = createLiveStudy( studyService ) // Contains more than one role.
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+
+        val role = protocol.participantRoles.first().role
+        val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.Roles( setOf( role ) ) )
+        val status =
+            recruitmentService.createParticipantGroup( UUID.randomUUID(), setOf( assignParticipant ), studyId )
+        assertFailsWith<IllegalArgumentException> { recruitmentService.inviteParticipantGroup( status.id ) }
+    }
+
+    @Test
+    fun inviteParticipantGroup_for_already_deployed_group_fails() = runTest {
+        val (recruitmentService, studyService) = createSUT()
+        val (studyId, _) = createLiveStudy( studyService )
+        val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
+        val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
+        val groupStatus =
+            recruitmentService.createParticipantGroup( UUID.randomUUID(), setOf( assignParticipant ), studyId )
+        recruitmentService.inviteParticipantGroup( groupStatus.id )
+
+        // Deploy the same group a second time.
+        assertFailsWith<IllegalStateException> { recruitmentService.inviteParticipantGroup( groupStatus.id ) }
+    }
+
+    @Test
     fun getParticipantGroupStatusList_returns_multiple_deployments() = runTest {
         val (recruitmentService, studyService) = createSUT()
         val (studyId, _) = createLiveStudy( studyService )
 
         val p1 = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val assignedP1 = AssignedParticipantRoles( p1.id, AssignedTo.All )
-        recruitmentService.inviteNewParticipantGroup( studyId, setOf( assignedP1 ) )
+        val stagedGroupId = UUID.randomUUID()
+        recruitmentService.createParticipantGroup( stagedGroupId, setOf( assignedP1 ), studyId )
 
         val p2 = recruitmentService.addParticipant( studyId, EmailAddress( "test2@test.com" ) )
         val assignedP2 = AssignedParticipantRoles( p2.id, AssignedTo.All )
-        recruitmentService.inviteNewParticipantGroup( studyId, setOf( assignedP2 ) )
+        val invitedGroupId = UUID.randomUUID()
+        recruitmentService.createParticipantGroup( invitedGroupId, setOf( assignedP2 ), studyId )
+        recruitmentService.inviteParticipantGroup( invitedGroupId )
 
         val participantGroups = recruitmentService.getParticipantGroupStatusList( studyId )
         assertEquals( 2, participantGroups.size )
-        val deployedParticipants = participantGroups.flatMap { it.participants }.toSet()
-        assertEquals( setOf( p1, p2 ), deployedParticipants )
+        val stagedGroup = participantGroups.single { it.id == stagedGroupId }
+        assertTrue( stagedGroup is ParticipantGroupStatus.Staged )
+        assertEquals( p1, stagedGroup.participants.single() )
+        val invitedGroup = participantGroups.single { it.id == invitedGroupId }
+        assertTrue( invitedGroup is ParticipantGroupStatus.Invited )
+        assertEquals( p2, invitedGroup.participants.single() )
     }
 
     @Test
@@ -299,7 +467,12 @@ interface RecruitmentServiceTest
         val (studyId, _) = createLiveStudy( studyService )
         val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
         val assignParticipant = AssignedParticipantRoles( participant.id, AssignedTo.All )
-        val groupStatus = recruitmentService.inviteNewParticipantGroup( studyId, setOf( assignParticipant ) )
+        val stagedGroup = recruitmentService.createParticipantGroup(
+            UUID.randomUUID(),
+            setOf( assignParticipant ),
+            studyId
+        )
+        val groupStatus = recruitmentService.inviteParticipantGroup( stagedGroup.id )
 
         val stoppedGroupStatus = recruitmentService.stopParticipantGroup( studyId, groupStatus.id )
         assertTrue( stoppedGroupStatus is ParticipantGroupStatus.Stopped )
@@ -329,10 +502,12 @@ interface RecruitmentServiceTest
         val (studyId, _) = createLiveStudy( studyService )
         val (otherStudyId, _) = createLiveStudy( studyService )
         val participant = recruitmentService.addParticipant( studyId, EmailAddress( "test@test.com" ) )
-        val groupStatus = recruitmentService.inviteNewParticipantGroup(
-            studyId,
-            setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
+        val stagedGroup = recruitmentService.createParticipantGroup(
+            UUID.randomUUID(),
+            setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) ),
+            studyId
         )
+        val groupStatus = recruitmentService.inviteParticipantGroup( stagedGroup.id )
 
         assertFailsWith<IllegalArgumentException> {
             recruitmentService.stopParticipantGroup( otherStudyId, groupStatus.id )

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/ParticipantRepositoryTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/ParticipantRepositoryTest.kt
@@ -1,6 +1,7 @@
 package dk.cachet.carp.studies.domain.users
 
 import dk.cachet.carp.common.application.UUID
+import dk.cachet.carp.studies.domain.createComplexRecruitment
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
@@ -40,6 +41,26 @@ interface ParticipantRepositoryTest
 
         val unknownId = UUID.randomUUID()
         assertNull( repo.getRecruitment( unknownId ) )
+    }
+
+    @Test
+    fun getRecruitmentWithParticipantGroup_returns_matching_recruitment() = runTest {
+        val repo = createRepository()
+        val recruitment = createComplexRecruitment()
+        repo.addRecruitment( recruitment )
+        val groupId = recruitment.participantGroups.keys.first()
+
+        val retrieved = repo.getRecruitmentWithParticipantGroup( groupId )
+
+        assertEquals( recruitment.getSnapshot(), retrieved?.getSnapshot() )
+    }
+
+    @Test
+    fun getRecruitmentWithParticipantGroup_returns_null_when_not_found() = runTest {
+        val repo = createRepository()
+
+        val unknownId = UUID.randomUUID()
+        assertNull( repo.getRecruitmentWithParticipantGroup( unknownId ) )
     }
 
     @Test

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/domain/users/RecruitmentTest.kt
@@ -9,6 +9,8 @@ import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSinglePrimaryDeviceProtocol
 import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
+import dk.cachet.carp.studies.application.users.ParticipantGroupStatus
+import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.*
 
@@ -145,33 +147,135 @@ class RecruitmentTest
     }
 
     @Test
-    fun getParticipantGroupStatus_succeeds()
-    {
-        val recruitment = Recruitment( studyId )
+    fun getParticipantGroupStatus_for_deployed_group_succeeds() = runTest {
+        val recruitment = createReadyRecruitment()
         val participant = recruitment.addParticipant( participantEmail )
-        val roleAssignment = setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
-        val protocol = createEmptyProtocol()
-        recruitment.lockInStudy( protocol.getSnapshot(), StudyInvitation( "Some study" ) )
-        val group = recruitment.addParticipantGroup( roleAssignment )
+        val group = recruitment.addParticipantGroup(
+            setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) ),
+            "Test Group"
+        )
+        group.markAsDeployed()
+        val deploymentStatus =
+            StudyDeploymentStatus.DeployingDevices(
+                Clock.System.now(),
+                group.id,
+                emptyList(),
+                emptyList(),
+                null
+            )
 
-        val stubDeploymentStatus =
-            StudyDeploymentStatus.DeployingDevices( Clock.System.now(), group.id, emptyList(), emptyList(), null )
-        val groupStatus = recruitment.getParticipantGroupStatus( stubDeploymentStatus )
+        val groupStatus = recruitment.getParticipantGroupStatus( group.id ) { requestedId ->
+            assertEquals( group.id, requestedId )
+            deploymentStatus
+        }
 
-        assertEquals( group.id, groupStatus.id )
-        assertEquals( setOf( participant ), groupStatus.participants )
+        val expected = ParticipantGroupStatus.Invited(
+            group.id,
+            setOf( participant ),
+            group.roleAssignments,
+            deploymentStatus.createdOn,
+            deploymentStatus,
+            group.name
+        )
+        assertEquals( expected, groupStatus )
     }
 
     @Test
-    fun getParticipantGroupStatus_fails_for_unknown_studyDeploymentId()
-    {
-        val recruitment = Recruitment( studyId )
+    fun getParticipantGroupStatus_for_staged_group_succeeds() = runTest {
+        val recruitment = createReadyRecruitment()
+        val participant = recruitment.addParticipant( participantEmail )
+        val group = recruitment.addParticipantGroup(
+            setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
+        )
+
+        val status = recruitment.getParticipantGroupStatus( group.id ) {
+            error( "Should not request deployment status for staged groups." )
+        }
+
+        val expected = ParticipantGroupStatus.Staged(
+            group.id,
+            setOf( participant ),
+            group.roleAssignments,
+            group.name
+        )
+        assertEquals( expected, status )
+    }
+
+    @Test
+    fun getParticipantGroupStatusList_returns_statuses_for_staged_and_deployed_groups() = runTest {
+        val recruitment = createReadyRecruitment()
+        val participant1 = recruitment.addParticipant( participantEmail )
+        val participant2 = recruitment.addParticipant( EmailAddress( "test2@test.com" ) )
+        val assignedRoles1 = AssignedParticipantRoles( participant1.id, AssignedTo.All )
+        val assignedRoles2 = AssignedParticipantRoles( participant2.id, AssignedTo.All )
+        val deployedGroup = recruitment.addParticipantGroup( setOf( assignedRoles1 ), "Deployed Group" )
+        val stagedGroup = recruitment.addParticipantGroup( setOf( assignedRoles2 ), "Staged Group" )
+        deployedGroup.markAsDeployed()
+        val deploymentStatus =
+            StudyDeploymentStatus.DeployingDevices(
+                Clock.System.now(),
+                deployedGroup.id,
+                emptyList(),
+                emptyList(),
+                null
+            )
+
+        val statuses = recruitment.getParticipantGroupStatusList(
+            setOf( stagedGroup.id, deployedGroup.id )
+        ) { ids ->
+            assertEquals( setOf( deployedGroup.id ), ids )
+            listOf( deploymentStatus )
+        }
+
+        val expectedStatuses = setOf(
+            ParticipantGroupStatus.Staged(
+                stagedGroup.id,
+                setOf( participant2 ),
+                stagedGroup.roleAssignments,
+                stagedGroup.name
+            ),
+            ParticipantGroupStatus.Invited(
+                deployedGroup.id,
+                setOf( participant1 ),
+                deployedGroup.roleAssignments,
+                deploymentStatus.createdOn,
+                deploymentStatus,
+                deployedGroup.name
+            )
+        )
+        assertEquals( expectedStatuses, statuses.toSet() )
+    }
+
+    @Test
+    fun getParticipantGroupStatus_fails_for_unknown_groupId() = runTest {
+        val recruitment = createReadyRecruitment()
 
         val unknownId = UUID.randomUUID()
-        val stubDeploymentStatus =
-            StudyDeploymentStatus.DeployingDevices( Clock.System.now(), unknownId, emptyList(), emptyList(), null )
         assertFailsWith<IllegalArgumentException> {
-            recruitment.getParticipantGroupStatus( stubDeploymentStatus )
+            recruitment.getParticipantGroupStatus( unknownId ) { error( "Should not be called." ) }
         }
+    }
+
+    @Test
+    fun getParticipantGroupStatusList_fails_when_deployment_status_is_missing() = runTest {
+        val recruitment = createReadyRecruitment()
+        val participant = recruitment.addParticipant( participantEmail )
+        val group = recruitment.addParticipantGroup(
+            setOf( AssignedParticipantRoles( participant.id, AssignedTo.All ) )
+        )
+        group.markAsDeployed()
+
+        assertFailsWith<IllegalArgumentException> {
+            recruitment.getParticipantGroupStatusList( setOf( group.id ) ) { emptyList() }
+        }
+    }
+
+
+    private fun createReadyRecruitment(): Recruitment
+    {
+        val recruitment = Recruitment( UUID.randomUUID() )
+        val protocol = createSinglePrimaryDeviceProtocol().getSnapshot()
+        recruitment.lockInStudy( protocol, StudyInvitation( "Study" ) )
+        return recruitment
     }
 }

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceInfrastructureTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/RecruitmentServiceInfrastructureTest.kt
@@ -24,7 +24,10 @@ class RecruitmentServiceRequestsTest : ApplicationServiceRequestsTest<Recruitmen
             RecruitmentServiceRequest.AddParticipantByUsername( studyId, Username( "test" ) ),
             RecruitmentServiceRequest.GetParticipant( studyId, UUID.randomUUID() ),
             RecruitmentServiceRequest.GetParticipants( studyId ),
+            @Suppress( "DEPRECATION" )
             RecruitmentServiceRequest.InviteNewParticipantGroup( studyId, setOf(), "test group" ),
+            RecruitmentServiceRequest.CreateParticipantGroup( UUID.randomUUID(), setOf(), studyId, "test group" ),
+            RecruitmentServiceRequest.InviteParticipantGroup( UUID.randomUUID() ),
             RecruitmentServiceRequest.GetParticipantGroupStatusList( studyId ),
             RecruitmentServiceRequest.StopParticipantGroup( studyId, UUID.randomUUID() )
         )

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_fails_for_study_not_ready_for_deployment.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_fails_for_study_not_ready_for_deployment.json
@@ -1,0 +1,57 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByUsername",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "username": "Test"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "b466f171-fba7-4c15-a5c9-a4b4d0d12bea",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.UsernameAccountIdentity",
+                "username": "Test"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
+            "apiVersion": "1.3",
+            "groupId": "2eb14104-3305-4a37-b01f-649f90400027",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalStateException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_fails_for_unknown_participant_roles.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_fails_for_unknown_participant_roles.json
@@ -1,0 +1,107 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "a3a34fca-ee6e-4832-ab59-c881d39a6f75",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "a3a34fca-ee6e-4832-ab59-c881d39a6f75",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "0bfb9e22-646b-4cf1-8a27-33be57c607d2",
+                        "createdOn": "2025-11-08T08:42:51.125779Z",
+                        "version": 0,
+                        "ownerId": "bd8c4a0e-3df6-4e79-9734-3609602fe8df",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
+            "apiVersion": "1.3",
+            "groupId": "f065b7c5-8025-4f41-98e7-d55efdc23df8",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Unknown role"
+                        ]
+                    }
+                }
+            ],
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_fails_for_unknown_participants.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_fails_for_unknown_participants.json
@@ -1,0 +1,86 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "e7f202d4-dd7a-4e11-bf39-08c01c90746f",
+            "group": [
+                {
+                    "participantId": "e5642231-ea5b-4a64-991a-4a1614150e80",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "9c4f073e-16a3-4193-a942-f32278896bfc",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "9c4f073e-16a3-4193-a942-f32278896bfc",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "ac6477bb-7d0f-4901-9a0a-9ef113fadc36",
+                        "createdOn": "2025-11-01T13:13:07.864034Z",
+                        "version": 0,
+                        "ownerId": "00f13222-6476-463d-bc82-195d162e77c0",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_fails_for_unknown_studyId.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_fails_for_unknown_studyId.json
@@ -1,0 +1,22 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "e5642231-ea5b-4a64-991a-4a1614150e80",
+            "groupId": "fae35392-e8e3-46a4-af9e-b0b3681da6a1",
+            "group": [
+                {
+                    "participantId": "b85f8cc8-b0d0-4eb5-a183-06d02de467ae",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_for_multiple_groups_with_same_name_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_for_multiple_groups_with_same_name_succeeds.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e3eabc2f-144e-4845-8ca8-b5331389f9a2",
+                    "ownerId": "bb0e933e-f91b-4c6a-8ac3-eef954f117d8",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e3eabc2f-144e-4845-8ca8-b5331389f9a2",
+                    "ownerId": "bb0e933e-f91b-4c6a-8ac3-eef954f117d8",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "3e69f528-8d37-4c48-9aae-247b7920bf35",
-                        "createdOn": "2025-12-18T19:11:37.739395700Z",
+                        "id": "394abfb7-c126-4107-a90e-6d3159e94a7f",
+                        "createdOn": "2025-11-01T13:13:07.988910Z",
                         "version": 0,
-                        "ownerId": "c6007643-1978-4cfb-80e4-6a8a2d2cd3fc",
+                        "ownerId": "3dd38399-7e37-4207-b988-5c9aa987fd84",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -86,7 +86,8 @@
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
             "apiVersion": "1.3",
-            "groupId": "3ac93aa6-e3e6-4a3d-b6dd-28ea78fa2583",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "7e39f0a6-0313-4603-ad48-f0875a39a1a5",
             "group": [
                 {
                     "participantId": "00000000-0000-0000-0000-000000000002",
@@ -95,13 +96,13 @@
                     }
                 }
             ],
-            "studyId": "00000000-0000-0000-0000-000000000001"
+            "name": "Same Group"
         },
         "precedingEvents": [],
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
-            "id": "3ac93aa6-e3e6-4a3d-b6dd-28ea78fa2583",
+            "id": "7e39f0a6-0313-4603-ad48-f0875a39a1a5",
             "participants": [
                 {
                     "accountIdentity": {
@@ -118,7 +119,8 @@
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     }
                 }
-            ]
+            ],
+            "name": "Same Group"
         }
     },
     {
@@ -144,7 +146,8 @@
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
             "apiVersion": "1.3",
-            "groupId": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "9252b9ec-60c4-426e-ae0c-e5d28d23869d",
             "group": [
                 {
                     "participantId": "00000000-0000-0000-0000-000000000003",
@@ -153,44 +156,13 @@
                     }
                 }
             ],
-            "studyId": "00000000-0000-0000-0000-000000000001"
+            "name": "Same Group"
         },
         "precedingEvents": [],
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
-            "id": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
-            "participants": [
-                {
-                    "accountIdentity": {
-                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
-                        "emailAddress": "test2@test.com"
-                    },
-                    "id": "00000000-0000-0000-0000-000000000003"
-                }
-            ],
-            "assignedParticipantRoles": [
-                {
-                    "participantId": "00000000-0000-0000-0000-000000000003",
-                    "assignedRoles": {
-                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                    }
-                }
-            ]
-        }
-    },
-    {
-        "outcome": "Succeeded",
-        "request": {
-            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteParticipantGroup",
-            "apiVersion": "1.3",
-            "groupId": "54b980af-2e4b-4524-a540-c9cfa51d81c6"
-        },
-        "precedingEvents": [],
-        "publishedEvents": [],
-        "response": {
-            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
-            "id": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
+            "id": "9252b9ec-60c4-426e-ae0c-e5d28d23869d",
             "participants": [
                 {
                     "accountIdentity": {
@@ -208,41 +180,7 @@
                     }
                 }
             ],
-            "invitedOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentStatus": {
-                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
-                "createdOn": "1970-01-01T00:00:00Z",
-                "studyDeploymentId": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
-                "deviceStatusList": [
-                    {
-                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
-                        "device": {
-                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
-                            "isPrimaryDevice": true,
-                            "roleName": "User's phone"
-                        },
-                        "canBeDeployed": true,
-                        "remainingDevicesToRegisterToObtainDeployment": [
-                            "User's phone"
-                        ],
-                        "remainingDevicesToRegisterBeforeDeployment": [
-                            "User's phone"
-                        ]
-                    }
-                ],
-                "participantStatusList": [
-                    {
-                        "participantId": "00000000-0000-0000-0000-000000000003",
-                        "assignedParticipantRoles": {
-                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                        },
-                        "assignedPrimaryDeviceRoleNames": [
-                            "User's phone"
-                        ]
-                    }
-                ],
-                "startedOn": null
-            }
+            "name": "Same Group"
         }
     },
     {
@@ -257,7 +195,7 @@
         "response": [
             {
                 "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
-                "id": "3ac93aa6-e3e6-4a3d-b6dd-28ea78fa2583",
+                "id": "7e39f0a6-0313-4603-ad48-f0875a39a1a5",
                 "participants": [
                     {
                         "accountIdentity": {
@@ -274,11 +212,12 @@
                             "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                         }
                     }
-                ]
+                ],
+                "name": "Same Group"
             },
             {
-                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
-                "id": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
+                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
+                "id": "9252b9ec-60c4-426e-ae0c-e5d28d23869d",
                 "participants": [
                     {
                         "accountIdentity": {
@@ -296,41 +235,7 @@
                         }
                     }
                 ],
-                "invitedOn": "1970-01-01T00:00:00Z",
-                "studyDeploymentStatus": {
-                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
-                    "createdOn": "1970-01-01T00:00:00Z",
-                    "studyDeploymentId": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
-                    "deviceStatusList": [
-                        {
-                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
-                            "device": {
-                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
-                                "isPrimaryDevice": true,
-                                "roleName": "User's phone"
-                            },
-                            "canBeDeployed": true,
-                            "remainingDevicesToRegisterToObtainDeployment": [
-                                "User's phone"
-                            ],
-                            "remainingDevicesToRegisterBeforeDeployment": [
-                                "User's phone"
-                            ]
-                        }
-                    ],
-                    "participantStatusList": [
-                        {
-                            "participantId": "00000000-0000-0000-0000-000000000003",
-                            "assignedParticipantRoles": {
-                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                            },
-                            "assignedPrimaryDeviceRoleNames": [
-                                "User's phone"
-                            ]
-                        }
-                    ],
-                    "startedOn": null
-                }
+                "name": "Same Group"
             }
         ]
     }

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_succeeds.json
@@ -1,0 +1,126 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "e242263c-66e6-4a41-ba28-743fcc893ac5",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "e242263c-66e6-4a41-ba28-743fcc893ac5",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "536b7f87-100c-4fae-9f34-b0ef7445f812",
+                        "createdOn": "2025-12-18T18:25:02.696394200Z",
+                        "version": 0,
+                        "ownerId": "71fdb370-7db7-4509-b52d-5972ec342d28",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
+            "apiVersion": "1.3",
+            "groupId": "65ba4a06-c874-43de-b8a5-bcf956cb4765",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "name": "Test Group"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
+            "id": "65ba4a06-c874-43de-b8a5-bcf956cb4765",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
+            "name": "Test Group"
+        }
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_with_existing_groupId_fails.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/createParticipantGroup_with_existing_groupId_fails.json
@@ -1,0 +1,147 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "cf3e12b6-16fa-428a-a18d-0645b8fc8291",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "cf3e12b6-16fa-428a-a18d-0645b8fc8291",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "15f7b7aa-ae80-4acc-b90f-afa71cddcb70",
+                        "createdOn": "2025-11-04T20:52:34.468335Z",
+                        "version": 0,
+                        "ownerId": "c9c34be8-822a-4f4d-bca7-2063ecdbdd19",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "34c9e113-2fa8-40fa-886d-22087a6a394f",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
+            "name": "Group"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
+            "id": "34c9e113-2fa8-40fa-886d-22087a6a394f",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
+            "name": "Group"
+        }
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "groupId": "34c9e113-2fa8-40fa-886d-22087a6a394f",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
+            "name": "Group"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_same_participant_different_roles_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_same_participant_different_roles_succeeds.json
@@ -1,0 +1,342 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "0699426b-42be-4c1a-b972-e70c0d67f350",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "0699426b-42be-4c1a-b972-e70c0d67f350",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "f16bba8b-c039-468c-a002-41a07a0eada9",
+                        "createdOn": "2025-12-12T10:06:33.393614Z",
+                        "version": 0,
+                        "ownerId": "6ec3605e-e3fd-4b08-b16a-c3529023d82f",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test2@test.com"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test2@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000003"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role"
+                        ]
+                    }
+                },
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000003",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role 2"
+                        ]
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000004",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                },
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test2@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000003"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role"
+                        ]
+                    }
+                },
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000003",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role 2"
+                        ]
+                    }
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000004",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                            "roleNames": [
+                                "Test role"
+                            ]
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    },
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000003",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                            "roleNames": [
+                                "Test role 2"
+                            ]
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role 2"
+                        ]
+                    }
+                },
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000003",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role"
+                        ]
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000005",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                },
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test2@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000003"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role 2"
+                        ]
+                    }
+                },
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000003",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role"
+                        ]
+                    }
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000005",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000002",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                            "roleNames": [
+                                "Test role 2"
+                            ]
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    },
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000003",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                            "roleNames": [
+                                "Test role"
+                            ]
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_same_participant_different_roles_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteNewParticipantGroup_for_same_participant_different_roles_succeeds.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "0699426b-42be-4c1a-b972-e70c0d67f350",
+                    "ownerId": "82d18033-8ba0-4714-9ffe-92fcacc28779",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "0699426b-42be-4c1a-b972-e70c0d67f350",
+                    "ownerId": "82d18033-8ba0-4714-9ffe-92fcacc28779",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "f16bba8b-c039-468c-a002-41a07a0eada9",
-                        "createdOn": "2025-12-12T10:06:33.393614Z",
+                        "id": "5ce36ec2-705c-420f-aaac-6f1645f88f1b",
+                        "createdOn": "2025-10-22T13:50:57.041629Z",
                         "version": 0,
-                        "ownerId": "6ec3605e-e3fd-4b08-b16a-c3529023d82f",
+                        "ownerId": "c3ae7abd-8a05-4cc6-9e5a-5a3df7a6205b",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteParticipantGroup_fails_for_unknown_groupId.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteParticipantGroup_fails_for_unknown_groupId.json
@@ -1,0 +1,13 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteParticipantGroup",
+            "apiVersion": "1.3",
+            "groupId": "01b49fd1-9a00-487b-8e65-ea8ba46265d3"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteParticipantGroup_fails_when_not_all_participant_roles_assigned.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteParticipantGroup_fails_when_not_all_participant_roles_assigned.json
@@ -1,0 +1,141 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "e9d3f207-9a1a-459f-b39b-7b232c4e0c6f",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "e9d3f207-9a1a-459f-b39b-7b232c4e0c6f",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "b424f93c-bcc2-4361-adbf-e11684ecaac9",
+                        "createdOn": "2025-11-10T10:53:51.014294Z",
+                        "version": 0,
+                        "ownerId": "ecd8d122-1c50-4c32-a9b9-e7babc689623",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000002"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
+            "apiVersion": "1.3",
+            "groupId": "ee109be7-64a6-42ba-8f4a-1b1257fc3ead",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role"
+                        ]
+                    }
+                }
+            ],
+            "studyId": "00000000-0000-0000-0000-000000000001"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
+            "id": "ee109be7-64a6-42ba-8f4a-1b1257fc3ead",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000002"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000002",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.Roles",
+                        "roleNames": [
+                            "Test role"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteParticipantGroup",
+            "apiVersion": "1.3",
+            "groupId": "ee109be7-64a6-42ba-8f4a-1b1257fc3ead"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteParticipantGroup_for_already_deployed_group_fails.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteParticipantGroup_for_already_deployed_group_fails.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e3eabc2f-144e-4845-8ca8-b5331389f9a2",
+                    "ownerId": "c7621863-f461-465a-9d21-038842adeabc",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e3eabc2f-144e-4845-8ca8-b5331389f9a2",
+                    "ownerId": "c7621863-f461-465a-9d21-038842adeabc",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "3e69f528-8d37-4c48-9aae-247b7920bf35",
-                        "createdOn": "2025-12-18T19:11:37.739395700Z",
+                        "id": "5b0524dd-8d0d-44b4-a647-f621e217c79f",
+                        "createdOn": "2025-12-18T18:59:20.611786700Z",
                         "version": 0,
-                        "ownerId": "c6007643-1978-4cfb-80e4-6a8a2d2cd3fc",
+                        "ownerId": "fd0c8f02-9b45-4f6a-bb7c-0558ab221ac9",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -86,7 +86,7 @@
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
             "apiVersion": "1.3",
-            "groupId": "3ac93aa6-e3e6-4a3d-b6dd-28ea78fa2583",
+            "groupId": "1a6f4d8d-3508-40a1-a0ce-0f1b877ad0b0",
             "group": [
                 {
                     "participantId": "00000000-0000-0000-0000-000000000002",
@@ -101,7 +101,7 @@
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
-            "id": "3ac93aa6-e3e6-4a3d-b6dd-28ea78fa2583",
+            "id": "1a6f4d8d-3508-40a1-a0ce-0f1b877ad0b0",
             "participants": [
                 {
                     "accountIdentity": {
@@ -124,85 +124,27 @@
     {
         "outcome": "Succeeded",
         "request": {
-            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
-            "apiVersion": "1.3",
-            "studyId": "00000000-0000-0000-0000-000000000001",
-            "email": "test2@test.com"
-        },
-        "precedingEvents": [],
-        "publishedEvents": [],
-        "response": {
-            "accountIdentity": {
-                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
-                "emailAddress": "test2@test.com"
-            },
-            "id": "00000000-0000-0000-0000-000000000003"
-        }
-    },
-    {
-        "outcome": "Succeeded",
-        "request": {
-            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
-            "apiVersion": "1.3",
-            "groupId": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
-            "group": [
-                {
-                    "participantId": "00000000-0000-0000-0000-000000000003",
-                    "assignedRoles": {
-                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                    }
-                }
-            ],
-            "studyId": "00000000-0000-0000-0000-000000000001"
-        },
-        "precedingEvents": [],
-        "publishedEvents": [],
-        "response": {
-            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
-            "id": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
-            "participants": [
-                {
-                    "accountIdentity": {
-                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
-                        "emailAddress": "test2@test.com"
-                    },
-                    "id": "00000000-0000-0000-0000-000000000003"
-                }
-            ],
-            "assignedParticipantRoles": [
-                {
-                    "participantId": "00000000-0000-0000-0000-000000000003",
-                    "assignedRoles": {
-                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                    }
-                }
-            ]
-        }
-    },
-    {
-        "outcome": "Succeeded",
-        "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteParticipantGroup",
             "apiVersion": "1.3",
-            "groupId": "54b980af-2e4b-4524-a540-c9cfa51d81c6"
+            "groupId": "1a6f4d8d-3508-40a1-a0ce-0f1b877ad0b0"
         },
         "precedingEvents": [],
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
-            "id": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
+            "id": "1a6f4d8d-3508-40a1-a0ce-0f1b877ad0b0",
             "participants": [
                 {
                     "accountIdentity": {
                         "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
-                        "emailAddress": "test2@test.com"
+                        "emailAddress": "test@test.com"
                     },
-                    "id": "00000000-0000-0000-0000-000000000003"
+                    "id": "00000000-0000-0000-0000-000000000002"
                 }
             ],
             "assignedParticipantRoles": [
                 {
-                    "participantId": "00000000-0000-0000-0000-000000000003",
+                    "participantId": "00000000-0000-0000-0000-000000000002",
                     "assignedRoles": {
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     }
@@ -212,7 +154,7 @@
             "studyDeploymentStatus": {
                 "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
                 "createdOn": "1970-01-01T00:00:00Z",
-                "studyDeploymentId": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
+                "studyDeploymentId": "1a6f4d8d-3508-40a1-a0ce-0f1b877ad0b0",
                 "deviceStatusList": [
                     {
                         "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -232,7 +174,7 @@
                 ],
                 "participantStatusList": [
                     {
-                        "participantId": "00000000-0000-0000-0000-000000000003",
+                        "participantId": "00000000-0000-0000-0000-000000000002",
                         "assignedParticipantRoles": {
                             "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                         },
@@ -246,92 +188,14 @@
         }
     },
     {
-        "outcome": "Succeeded",
+        "outcome": "Failed",
         "request": {
-            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.GetParticipantGroupStatusList",
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteParticipantGroup",
             "apiVersion": "1.3",
-            "studyId": "00000000-0000-0000-0000-000000000001"
+            "groupId": "1a6f4d8d-3508-40a1-a0ce-0f1b877ad0b0"
         },
         "precedingEvents": [],
         "publishedEvents": [],
-        "response": [
-            {
-                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
-                "id": "3ac93aa6-e3e6-4a3d-b6dd-28ea78fa2583",
-                "participants": [
-                    {
-                        "accountIdentity": {
-                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
-                            "emailAddress": "test@test.com"
-                        },
-                        "id": "00000000-0000-0000-0000-000000000002"
-                    }
-                ],
-                "assignedParticipantRoles": [
-                    {
-                        "participantId": "00000000-0000-0000-0000-000000000002",
-                        "assignedRoles": {
-                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                        }
-                    }
-                ]
-            },
-            {
-                "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
-                "id": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
-                "participants": [
-                    {
-                        "accountIdentity": {
-                            "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
-                            "emailAddress": "test2@test.com"
-                        },
-                        "id": "00000000-0000-0000-0000-000000000003"
-                    }
-                ],
-                "assignedParticipantRoles": [
-                    {
-                        "participantId": "00000000-0000-0000-0000-000000000003",
-                        "assignedRoles": {
-                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                        }
-                    }
-                ],
-                "invitedOn": "1970-01-01T00:00:00Z",
-                "studyDeploymentStatus": {
-                    "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
-                    "createdOn": "1970-01-01T00:00:00Z",
-                    "studyDeploymentId": "54b980af-2e4b-4524-a540-c9cfa51d81c6",
-                    "deviceStatusList": [
-                        {
-                            "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
-                            "device": {
-                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
-                                "isPrimaryDevice": true,
-                                "roleName": "User's phone"
-                            },
-                            "canBeDeployed": true,
-                            "remainingDevicesToRegisterToObtainDeployment": [
-                                "User's phone"
-                            ],
-                            "remainingDevicesToRegisterBeforeDeployment": [
-                                "User's phone"
-                            ]
-                        }
-                    ],
-                    "participantStatusList": [
-                        {
-                            "participantId": "00000000-0000-0000-0000-000000000003",
-                            "assignedParticipantRoles": {
-                                "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                            },
-                            "assignedPrimaryDeviceRoleNames": [
-                                "User's phone"
-                            ]
-                        }
-                    ],
-                    "startedOn": null
-                }
-            }
-        ]
+        "exceptionType": "IllegalStateException"
     }
 ]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteParticipantGroup_succeeds.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/inviteParticipantGroup_succeeds.json
@@ -14,7 +14,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e4272f4b-ce14-4658-a29e-c9269d37095e",
+                    "ownerId": "0bb1339d-feb2-44b0-9e06-b4b7635bcfec",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -30,7 +30,7 @@
                 "apiVersion": "1.1",
                 "study": {
                     "studyId": "00000000-0000-0000-0000-000000000001",
-                    "ownerId": "e4272f4b-ce14-4658-a29e-c9269d37095e",
+                    "ownerId": "0bb1339d-feb2-44b0-9e06-b4b7635bcfec",
                     "name": "Test",
                     "createdOn": "1970-01-01T00:00:00Z",
                     "description": null,
@@ -38,10 +38,10 @@
                         "name": "Test"
                     },
                     "protocolSnapshot": {
-                        "id": "50f0a5b1-b637-4671-98c1-f7f2c78e6105",
-                        "createdOn": "2025-11-10T10:53:51.071697Z",
+                        "id": "1295cc0e-a011-4920-a2a6-2c9afe63bdb1",
+                        "createdOn": "2025-12-18T18:52:48.688103900Z",
                         "version": 0,
-                        "ownerId": "4a12ba2e-a317-4bcf-b1e4-ef3bfe7dcb92",
+                        "ownerId": "ce91aa3a-8611-41ed-97e5-d61d8f3921c9",
                         "name": "Test protocol",
                         "primaryDevices": [
                             {
@@ -86,7 +86,7 @@
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup",
             "apiVersion": "1.3",
-            "groupId": "ee4ed008-b6c8-4aa9-a991-c49d597778a3",
+            "groupId": "aabbbf59-b803-4471-9bfc-8e6bc68d89ff",
             "group": [
                 {
                     "participantId": "00000000-0000-0000-0000-000000000002",
@@ -95,13 +95,14 @@
                     }
                 }
             ],
-            "studyId": "00000000-0000-0000-0000-000000000001"
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "name": "Test group"
         },
         "precedingEvents": [],
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Staged",
-            "id": "ee4ed008-b6c8-4aa9-a991-c49d597778a3",
+            "id": "aabbbf59-b803-4471-9bfc-8e6bc68d89ff",
             "participants": [
                 {
                     "accountIdentity": {
@@ -118,7 +119,8 @@
                         "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
                     }
                 }
-            ]
+            ],
+            "name": "Test group"
         }
     },
     {
@@ -126,13 +128,13 @@
         "request": {
             "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteParticipantGroup",
             "apiVersion": "1.3",
-            "groupId": "ee4ed008-b6c8-4aa9-a991-c49d597778a3"
+            "groupId": "aabbbf59-b803-4471-9bfc-8e6bc68d89ff"
         },
         "precedingEvents": [],
         "publishedEvents": [],
         "response": {
             "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
-            "id": "ee4ed008-b6c8-4aa9-a991-c49d597778a3",
+            "id": "aabbbf59-b803-4471-9bfc-8e6bc68d89ff",
             "participants": [
                 {
                     "accountIdentity": {
@@ -154,7 +156,7 @@
             "studyDeploymentStatus": {
                 "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
                 "createdOn": "1970-01-01T00:00:00Z",
-                "studyDeploymentId": "ee4ed008-b6c8-4aa9-a991-c49d597778a3",
+                "studyDeploymentId": "aabbbf59-b803-4471-9bfc-8e6bc68d89ff",
                 "deviceStatusList": [
                     {
                         "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
@@ -184,77 +186,8 @@
                     }
                 ],
                 "startedOn": null
-            }
-        }
-    },
-    {
-        "outcome": "Succeeded",
-        "request": {
-            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup",
-            "apiVersion": "1.3",
-            "studyId": "00000000-0000-0000-0000-000000000001",
-            "groupId": "ee4ed008-b6c8-4aa9-a991-c49d597778a3"
-        },
-        "precedingEvents": [],
-        "publishedEvents": [],
-        "response": {
-            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Stopped",
-            "id": "ee4ed008-b6c8-4aa9-a991-c49d597778a3",
-            "participants": [
-                {
-                    "accountIdentity": {
-                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
-                        "emailAddress": "test@test.com"
-                    },
-                    "id": "00000000-0000-0000-0000-000000000002"
-                }
-            ],
-            "assignedParticipantRoles": [
-                {
-                    "participantId": "00000000-0000-0000-0000-000000000002",
-                    "assignedRoles": {
-                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                    }
-                }
-            ],
-            "invitedOn": "1970-01-01T00:00:00Z",
-            "studyDeploymentStatus": {
-                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Stopped",
-                "createdOn": "1970-01-01T00:00:00Z",
-                "studyDeploymentId": "ee4ed008-b6c8-4aa9-a991-c49d597778a3",
-                "deviceStatusList": [
-                    {
-                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
-                        "device": {
-                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
-                            "isPrimaryDevice": true,
-                            "roleName": "User's phone"
-                        },
-                        "canBeDeployed": true,
-                        "remainingDevicesToRegisterToObtainDeployment": [
-                            "User's phone"
-                        ],
-                        "remainingDevicesToRegisterBeforeDeployment": [
-                            "User's phone"
-                        ]
-                    }
-                ],
-                "participantStatusList": [
-                    {
-                        "participantId": "00000000-0000-0000-0000-000000000002",
-                        "assignedParticipantRoles": {
-                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
-                        },
-                        "assignedPrimaryDeviceRoleNames": [
-                            "User's phone"
-                        ]
-                    }
-                ],
-                "startedOn": null,
-                "stoppedOn": "1970-01-01T00:00:00Z"
             },
-            "startedOn": null,
-            "stoppedOn": "1970-01-01T00:00:00Z"
+            "name": "Test group"
         }
     }
 ]

--- a/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_fails_when_group_belongs_to_other_study.json
+++ b/carp.studies.core/src/commonTest/resources/test-requests/RecruitmentService/1.3/RecruitmentServiceTest/stopParticipantGroup_fails_when_group_belongs_to_other_study.json
@@ -1,0 +1,233 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.AddParticipantByEmailAddress",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "email": "test@test.com"
+        },
+        "precedingEvents": [
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "d4b5f715-cb18-406a-b02a-1fd620a41d4a",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000001",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000001",
+                    "ownerId": "d4b5f715-cb18-406a-b02a-1fd620a41d4a",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "4fcb589b-8785-4ee4-b3d1-20c6113b7e75",
+                        "createdOn": "2025-12-12T10:06:33.485026Z",
+                        "version": 0,
+                        "ownerId": "8a85dd0e-2bd4-4a4a-8820-d6ecd11f71fb",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyCreated",
+                "aggregateId": "00000000-0000-0000-0000-000000000002",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000002",
+                    "ownerId": "6b03a95e-4f3a-48b2-bcb3-799b3e14161a",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": null
+                }
+            },
+            {
+                "__type": "dk.cachet.carp.studies.application.StudyService.Event.StudyGoneLive",
+                "aggregateId": "00000000-0000-0000-0000-000000000002",
+                "apiVersion": "1.1",
+                "study": {
+                    "studyId": "00000000-0000-0000-0000-000000000002",
+                    "ownerId": "6b03a95e-4f3a-48b2-bcb3-799b3e14161a",
+                    "name": "Test",
+                    "createdOn": "1970-01-01T00:00:00Z",
+                    "description": null,
+                    "invitation": {
+                        "name": "Test"
+                    },
+                    "protocolSnapshot": {
+                        "id": "f2217195-f6dc-4715-ae09-3ab1d942fe69",
+                        "createdOn": "2025-12-12T10:06:33.486119Z",
+                        "version": 0,
+                        "ownerId": "affae873-16f8-474f-8059-6fadb242434b",
+                        "name": "Test protocol",
+                        "primaryDevices": [
+                            {
+                                "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                                "isPrimaryDevice": true,
+                                "roleName": "User's phone"
+                            }
+                        ],
+                        "participantRoles": [
+                            {
+                                "role": "Test role",
+                                "isOptional": false
+                            },
+                            {
+                                "role": "Test role 2",
+                                "isOptional": false
+                            }
+                        ],
+                        "expectedParticipantData": [
+                            {
+                                "attribute": {
+                                    "__type": "dk.cachet.carp.common.application.users.ParticipantAttribute.DefaultParticipantAttribute",
+                                    "inputDataType": "dk.cachet.carp.input.sex"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "publishedEvents": [],
+        "response": {
+            "accountIdentity": {
+                "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                "emailAddress": "test@test.com"
+            },
+            "id": "00000000-0000-0000-0000-000000000003"
+        }
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteNewParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000001",
+            "group": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000003",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {
+            "__type": "dk.cachet.carp.studies.application.users.ParticipantGroupStatus.Invited",
+            "id": "00000000-0000-0000-0000-000000000004",
+            "participants": [
+                {
+                    "accountIdentity": {
+                        "__type": "dk.cachet.carp.common.application.users.EmailAccountIdentity",
+                        "emailAddress": "test@test.com"
+                    },
+                    "id": "00000000-0000-0000-0000-000000000003"
+                }
+            ],
+            "assignedParticipantRoles": [
+                {
+                    "participantId": "00000000-0000-0000-0000-000000000003",
+                    "assignedRoles": {
+                        "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                    }
+                }
+            ],
+            "invitedOn": "1970-01-01T00:00:00Z",
+            "studyDeploymentStatus": {
+                "__type": "dk.cachet.carp.deployments.application.StudyDeploymentStatus.Invited",
+                "createdOn": "1970-01-01T00:00:00Z",
+                "studyDeploymentId": "00000000-0000-0000-0000-000000000004",
+                "deviceStatusList": [
+                    {
+                        "__type": "dk.cachet.carp.deployments.application.DeviceDeploymentStatus.Unregistered",
+                        "device": {
+                            "__type": "dk.cachet.carp.common.application.devices.Smartphone",
+                            "isPrimaryDevice": true,
+                            "roleName": "User's phone"
+                        },
+                        "canBeDeployed": true,
+                        "remainingDevicesToRegisterToObtainDeployment": [
+                            "User's phone"
+                        ],
+                        "remainingDevicesToRegisterBeforeDeployment": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "participantStatusList": [
+                    {
+                        "participantId": "00000000-0000-0000-0000-000000000003",
+                        "assignedParticipantRoles": {
+                            "__type": "dk.cachet.carp.common.application.users.AssignedTo.All"
+                        },
+                        "assignedPrimaryDeviceRoleNames": [
+                            "User's phone"
+                        ]
+                    }
+                ],
+                "startedOn": null
+            }
+        }
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.StopParticipantGroup",
+            "apiVersion": "1.3",
+            "studyId": "00000000-0000-0000-0000-000000000002",
+            "groupId": "00000000-0000-0000-0000-000000000004"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/docs/carp-studies.md
+++ b/docs/carp-studies.md
@@ -56,5 +56,5 @@ Allows setting recruitment goals, adding participants to studies, and creating d
 | `getParticipant` | Returns the participant with a specified ID for a study. | manage study: `studyId` | |
 | `getParticipants` | Get all participants for a study. | manage study: `studyId` | |
 | `inviteNewParticipantGroup` | Create and instantly invite a group of previously added participants to a study. | manage study: `studyId` | |
-| `getParticipantGroupStatusList` | Get the status of all deployed participant groups in a study. | manage study: `studyId` | |
+| `getParticipantGroupStatusList` | Get the status of all participant groups in a study. | manage study: `studyId` | |
 | `stopParticipantGroup` | Stop the study deployment in a study of a participant group. No further changes to this deployment will be allowed and no more data will be collected. | manage study: `studyId` | |

--- a/docs/carp-studies.md
+++ b/docs/carp-studies.md
@@ -17,7 +17,7 @@ which reflects the underlying state machine:
 
 ![Participant group state machine](https://i.imgur.com/VIv3HKk.png)
 
-Note: `createParticipantGroup` and `inviteParticipantGroup` are envisioned new endpoints currently not yet available.
+Note: The legacy `inviteNewParticipantGroup` is still available to create and invite in one step, but planned to be removed in the future.
 
 Once a participant group is `InDeployment`, the state of the underlying `studyDeploymentStatus` determines the concrete `ParticipantGroupStatus`.
 Calling `RecruitmentService.stopParticipantGroup()` will stop the underlying deployment, but the deployment can also be stopped by participants in the study.
@@ -55,6 +55,8 @@ Allows setting recruitment goals, adding participants to studies, and creating d
 | `addParticipant` | Add a participant identified by a specified email address or username to a study. | manage study: `studyId` | |
 | `getParticipant` | Returns the participant with a specified ID for a study. | manage study: `studyId` | |
 | `getParticipants` | Get all participants for a study. | manage study: `studyId` | |
-| `inviteNewParticipantGroup` | Create and instantly invite a group of previously added participants to a study. | manage study: `studyId` | |
+| `inviteNewParticipantGroup` | (Deprecated) Create and instantly invite a group of previously added participants to a study. | manage study: `studyId` | |
+| `createParticipantGroup` | Prepare a group of previously added participants for deployment without inviting them yet. | manage study: `studyId` | |
+| `inviteParticipantGroup` | Invite a previously prepared participant group to start participating in the study. | manage study: `studyId` | |
 | `getParticipantGroupStatusList` | Get the status of all participant groups in a study. | manage study: `studyId` | |
 | `stopParticipantGroup` | Stop the study deployment in a study of a participant group. No further changes to this deployment will be allowed and no more data will be collected. | manage study: `studyId` | |

--- a/rpc/schemas/studies/RecruitmentService/RecruitmentServiceRequest.json
+++ b/rpc/schemas/studies/RecruitmentService/RecruitmentServiceRequest.json
@@ -6,6 +6,8 @@
     { "$ref": "#GetParticipant" },
     { "$ref": "#GetParticipants" },
     { "$ref": "#InviteNewParticipantGroup" },
+    { "$ref": "#CreateParticipantGroup" },
+    { "$ref": "#InviteParticipantGroup" },
     { "$ref": "#GetParticipantGroupStatusList" },
     { "$ref": "#StopParticipantGroup" }
   ],
@@ -92,6 +94,42 @@
       "additionalProperties": false,
       "Response": {
         "$anchor": "InviteNewParticipantGroup-Response",
+        "$ref": "../users/ParticipantGroupStatus.json"
+      }
+    },
+    "CreateParticipantGroup": {
+      "$anchor": "CreateParticipantGroup",
+      "type": "object",
+      "properties": {
+        "__type": { "const": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.CreateParticipantGroup" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
+        "groupId": { "type": "string", "format": "uuid" },
+        "group": {
+          "type": "array",
+          "items": { "$ref": "../users/AssignedParticipantRoles.json" }
+        },
+        "studyId": { "type": "string", "format": "uuid" },
+        "name": { "type": [ "string", "null" ] }
+      },
+      "required": [ "__type", "apiVersion", "groupId", "group", "studyId" ],
+      "additionalProperties": false,
+      "Response": {
+        "$anchor": "CreateParticipantGroup-Response",
+        "$ref": "../users/ParticipantGroupStatus.json"
+      }
+    },
+    "InviteParticipantGroup": {
+      "$anchor": "InviteParticipantGroup",
+      "type": "object",
+      "properties": {
+        "__type": { "const": "dk.cachet.carp.studies.infrastructure.RecruitmentServiceRequest.InviteParticipantGroup" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
+        "groupId": { "type": "string", "format": "uuid" }
+      },
+      "required": [ "__type", "apiVersion", "groupId" ],
+      "additionalProperties": false,
+      "Response": {
+        "$anchor": "InviteParticipantGroup-Response",
         "$ref": "../users/ParticipantGroupStatus.json"
       }
     },

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -397,6 +397,31 @@ private val exampleRequests: Map<KFunction<*>, LoggedRequest.Succeeded<*>> = map
             deploymentName
         )
     ),
+    RecruitmentService::createParticipantGroup to example(
+        request = RecruitmentServiceRequest.CreateParticipantGroup(
+            deploymentId,
+            setOf( AssignedParticipantRoles( participantId, participantAssignedRoles ) ),
+            studyId,
+            deploymentName
+        ),
+        response = ParticipantGroupStatus.Staged(
+            deploymentId,
+            participants,
+            setOf( AssignedParticipantRoles( participantId, participantAssignedRoles ) ),
+            deploymentName
+        )
+    ),
+    RecruitmentService::inviteParticipantGroup to example(
+        request = RecruitmentServiceRequest.InviteParticipantGroup( deploymentId ),
+        response = ParticipantGroupStatus.Invited(
+            deploymentId,
+            participants,
+            roleAssignment,
+            participantGroupInvitedOn,
+            invitedDeploymentStatus,
+            deploymentName
+        )
+    ),
     RecruitmentService::getParticipantGroupStatusList to example(
         request = RecruitmentServiceRequest.GetParticipantGroupStatusList( studyId ),
         response = listOf(

--- a/typescript-declarations/tests/carp-studies-test.ts
+++ b/typescript-declarations/tests/carp-studies-test.ts
@@ -95,16 +95,19 @@ describe( "carp-studies-core", () => {
 
 
     describe( "RecruitmentServiceRequest", () => {
-        it( "can serialize DeployParticipantGroup", () => {
+        it( "can serialize CreateParticipantGroup", () => {
+            const groupId = UUID.Companion.randomUUID()
+            const studyId = UUID.Companion.randomUUID()
             const assignedRoles = new Set( [ new AssignedParticipantRoles( UUID.Companion.randomUUID(), AssignedTo.All ) ] );
-            const deployGroup = new RecruitmentServiceRequest.InviteNewParticipantGroup(
-                UUID.Companion.randomUUID(),
+            const createGroup = new RecruitmentServiceRequest.CreateParticipantGroup(
+                groupId,
                 KtSet.fromJsSet( assignedRoles ),
+                studyId,
                 "Test group"
             )
 
             const serializer = RecruitmentServiceRequest.Serializer
-            const serialized = JSON.encodeToString( serializer, deployGroup )
+            const serialized = JSON.encodeToString( serializer, createGroup )
             expect( serialized ).is.not.undefined
         } )
 


### PR DESCRIPTION
… to RecruitmentService

Also marks `InviteNewParticipantGroup` Endpoint and related method as deprecated, and replace their usage with new create and invite method respectively.

----------
- I did not include `connectedDevicePreregistration` here, as I think it should be a separate issue/commit.
- I did not include 'add `UpdateParticipantGroup` endpoint' in this PR, to keep thing clean here.

Qs:
- Should test cases related to `inviteNewParticipant` be removed? as its functionalities are now in create and invite, respectively and we have coverage for them. So some suppress can be removed. ( Kotlin compiler fails it even the deprecation level is warning )


---
TODO(not for this PR):
1. Update 'stopParticipantGroup' parameter in the order from the most relevant one to secondary ones.
2. Create an issue to keep all creation endpoint consistent: let user pass IDs.
3. Create new endpoint `UpdateParticipantGroup`
4. Rename `StagedParticipantGroup `