### PR TITLE
Add GetDataStreamsStatus endpoints to DataStreamService

### DIFF
--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamBatch.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamBatch.kt
@@ -102,11 +102,11 @@ class MutableDataStreamBatch : DataStreamBatch
                 // This might seem like premature optimization, but currently it is the only concrete class.
                 // We expect many sequences for one data type to be common, e.g., RR intervals have many sync points.
                 batch.sequenceMap
-                    .mapValues { it.value.last() }
-                    .all { (dataStream, lastSequence) ->
+                    .mapValues { it.value.first() }
+                    .all { (dataStream, firstNewSequence) ->
                         val lastStoredSequence = sequenceMap[ dataStream ]?.last()
                         if ( lastStoredSequence == null ) true
-                        else lastStoredSequence.range.last < lastSequence.range.first
+                        else lastStoredSequence.range.last < firstNewSequence.range.first
                     }
             else ->
                 batch.sequences.all { sequence ->

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamService.kt
@@ -61,6 +61,13 @@ interface DataStreamService : ApplicationService<DataStreamService, DataStreamSe
     ): DataStreamBatch
 
     /**
+     * Retrieve status for each configured data stream in [studyDeploymentId].
+     *
+     * @throws IllegalArgumentException when no data streams were ever opened for [studyDeploymentId].
+     */
+    suspend fun getDataStreamsStatus( studyDeploymentId: UUID ): List<DataStreamStatus>
+
+    /**
      * Stop accepting incoming data for all data streams for each of the [studyDeploymentIds].
      *
      * @throws IllegalArgumentException when no data streams were ever opened for any of the [studyDeploymentIds].

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamStatus.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/application/DataStreamStatus.kt
@@ -1,0 +1,25 @@
+@file:Suppress( "NON_EXPORTABLE_TYPE" )
+
+package dk.cachet.carp.data.application
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+
+/**
+ * Status of a [dataStream] in a study deployment.
+ */
+@Serializable
+@JsExport
+data class DataStreamStatus(
+    val dataStream: DataStreamId,
+    /**
+     * The sequence number of the last received measurement for this [dataStream],
+     * or `null` when no data has been received yet.
+     */
+    val lastSequenceId: Long?,
+    /**
+     * Determines whether this [dataStream] currently accepts incoming data.
+     */
+    val isOpen: Boolean
+)

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceDecorator.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceDecorator.kt
@@ -7,6 +7,7 @@ import dk.cachet.carp.common.infrastructure.services.Command
 import dk.cachet.carp.data.application.DataStreamBatch
 import dk.cachet.carp.data.application.DataStreamId
 import dk.cachet.carp.data.application.DataStreamService
+import dk.cachet.carp.data.application.DataStreamStatus
 import dk.cachet.carp.data.application.DataStreamsConfiguration
 
 
@@ -32,6 +33,9 @@ class DataStreamServiceDecorator(
         toSequenceIdInclusive: Long?
     ) = invoke( DataStreamServiceRequest.GetDataStream( dataStream, fromSequenceId, toSequenceIdInclusive ) )
 
+    override suspend fun getDataStreamsStatus( studyDeploymentId: UUID ): List<DataStreamStatus> =
+        invoke( DataStreamServiceRequest.GetDataStreamsStatus( studyDeploymentId ) )
+
     override suspend fun closeDataStreams( studyDeploymentIds: Set<UUID> ) =
         invoke( DataStreamServiceRequest.CloseDataStreams( studyDeploymentIds ) )
 
@@ -49,6 +53,7 @@ object DataStreamServiceInvoker : ApplicationServiceInvoker<DataStreamService, D
             is DataStreamServiceRequest.AppendToDataStreams -> service.appendToDataStreams( studyDeploymentId, batch )
             is DataStreamServiceRequest.GetDataStream ->
                 service.getDataStream( dataStream, fromSequenceId, toSequenceIdInclusive )
+            is DataStreamServiceRequest.GetDataStreamsStatus -> service.getDataStreamsStatus( studyDeploymentId )
             is DataStreamServiceRequest.CloseDataStreams -> service.closeDataStreams( studyDeploymentIds )
             is DataStreamServiceRequest.RemoveDataStreams -> service.removeDataStreams( studyDeploymentIds )
         }

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceRequest.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceRequest.kt
@@ -8,6 +8,7 @@ import dk.cachet.carp.data.application.DataStreamBatch
 import dk.cachet.carp.data.application.DataStreamBatchSerializer
 import dk.cachet.carp.data.application.DataStreamId
 import dk.cachet.carp.data.application.DataStreamService
+import dk.cachet.carp.data.application.DataStreamStatus
 import dk.cachet.carp.data.application.DataStreamsConfiguration
 import kotlinx.serialization.*
 import kotlin.js.JsExport
@@ -51,6 +52,13 @@ sealed class DataStreamServiceRequest<out TReturn> : ApplicationServiceRequest<D
     ) : DataStreamServiceRequest<DataStreamBatch>()
     {
         override fun getResponseSerializer() = DataStreamBatchSerializer
+    }
+
+    @Serializable
+    data class GetDataStreamsStatus( val studyDeploymentId: UUID ) :
+        DataStreamServiceRequest<List<DataStreamStatus>>()
+    {
+        override fun getResponseSerializer() = serializer<List<DataStreamStatus>>()
     }
 
     @Serializable

--- a/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/InMemoryDataStreamService.kt
+++ b/carp.data.core/src/commonMain/kotlin/dk/cachet/carp/data/infrastructure/InMemoryDataStreamService.kt
@@ -7,6 +7,7 @@ import dk.cachet.carp.common.domain.ExtractUniqueKeyMap
 import dk.cachet.carp.data.application.DataStreamBatch
 import dk.cachet.carp.data.application.DataStreamId
 import dk.cachet.carp.data.application.DataStreamService
+import dk.cachet.carp.data.application.DataStreamStatus
 import dk.cachet.carp.data.application.DataStreamsConfiguration
 import dk.cachet.carp.data.application.MutableDataStreamBatch
 import dk.cachet.carp.data.application.MutableDataStreamSequence
@@ -27,6 +28,7 @@ class InMemoryDataStreamService : DataStreamService
         }
     private val stoppedStudyDeploymentIds: MutableSet<UUID> = mutableSetOf()
     private val dataStreams: MutableDataStreamBatch = MutableDataStreamBatch()
+    private val lastSequenceIdByDataStream: MutableMap<DataStreamId, Long?> = mutableMapOf()
 
 
     /**
@@ -37,6 +39,9 @@ class InMemoryDataStreamService : DataStreamService
     override suspend fun openDataStreams( configuration: DataStreamsConfiguration )
     {
         configuredDataStreams.tryAddIfKeyIsNew( configuration )
+        configuration.expectedDataStreamIds.forEach { dataStreamId ->
+            lastSequenceIdByDataStream[ dataStreamId ] = null
+        }
     }
 
     /**
@@ -63,6 +68,13 @@ class InMemoryDataStreamService : DataStreamService
             { "Data streams for this study deployment have been closed." }
 
         dataStreams.appendBatch( batch )
+
+        // Update last sequence ID for all streams with new data.
+        batch.sequences
+            .groupBy { it.dataStream }
+            .forEach { (dataStreamId, dataStreamSequences) ->
+                lastSequenceIdByDataStream[ dataStreamId ] = dataStreamSequences.last().range.last
+            }
     }
 
     /**
@@ -112,6 +124,23 @@ class InMemoryDataStreamService : DataStreamService
     }
 
     /**
+     * Retrieve status for each configured data stream in [studyDeploymentId].
+     *
+     * @throws IllegalArgumentException when no data streams were ever opened for [studyDeploymentId].
+     */
+    override suspend fun getDataStreamsStatus( studyDeploymentId: UUID ): List<DataStreamStatus>
+    {
+        val configuration: DataStreamsConfiguration? = configuredDataStreams[ studyDeploymentId ]
+        requireNotNull( configuration ) { "No data streams configured for this study deployment." }
+
+        val isOpen = studyDeploymentId !in stoppedStudyDeploymentIds
+        return configuration.expectedDataStreamIds.map { dataStream ->
+            val lastSequenceId: Long? = lastSequenceIdByDataStream[ dataStream ]
+            DataStreamStatus( dataStream, lastSequenceId, isOpen )
+        }
+    }
+
+    /**
      * Stop accepting incoming data for all data streams for each of the [studyDeploymentIds].
      *
      * @throws IllegalArgumentException when no data streams were ever opened for any of the [studyDeploymentIds].
@@ -134,9 +163,15 @@ class InMemoryDataStreamService : DataStreamService
     {
         stoppedStudyDeploymentIds.removeAll( studyDeploymentIds )
 
-        return studyDeploymentIds.mapNotNull { toRemove ->
+        val removedStudyDeploymentIds = studyDeploymentIds.mapNotNull { toRemove ->
             if ( configuredDataStreams.removeKey( toRemove ) ) toRemove
             else null
         }.toSet()
+
+        lastSequenceIdByDataStream.keys.removeAll { dataStreamId ->
+            dataStreamId.studyDeploymentId in removedStudyDeploymentIds
+        }
+
+        return removedStudyDeploymentIds
     }
 }

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/CreateTestObjects.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/CreateTestObjects.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.data.application
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.toEpochMicroseconds
+import dk.cachet.carp.common.infrastructure.test.StubDataPoint
 import dk.cachet.carp.data.infrastructure.dataStreamId
 import dk.cachet.carp.data.infrastructure.measurement
 import kotlinx.datetime.Clock
@@ -13,6 +14,7 @@ val now = Clock.System.now()
 val stubSyncPoint = SyncPoint( now, now.toEpochMicroseconds() )
 val stubTriggerIds = listOf( 1 )
 const val stubSequenceDeviceRoleName = "Device"
+val stubDataPointStream = dataStreamId<StubDataPoint>( stubDeploymentId, stubSequenceDeviceRoleName )
 
 /**
  * Create a [DataStreamSequence], always using the same data stream identifiers, except for the data type defined by [T].

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/DataStreamSequenceTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/DataStreamSequenceTest.kt
@@ -9,9 +9,6 @@ import dk.cachet.carp.data.infrastructure.measurement
 import kotlin.test.*
 
 
-private val stubDataPointStream = dataStreamId<StubDataPoint>( UUID.randomUUID(), "Device" )
-
-
 /**
  * Tests for implementations of [DataStreamSequence].
  */

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/DataStreamServiceTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/DataStreamServiceTest.kt
@@ -129,6 +129,59 @@ interface DataStreamServiceTest
     }
 
     @Test
+    fun getDataStreamsStatus_returns_all_expected_streams() = runTest {
+        val service = createService()
+        val dataPointStream = dataStreamId<StubDataPoint>( stubDeploymentId, stubSequenceDeviceRoleName )
+        val dataTimeSpanStream = dataStreamId<StubDataTimeSpan>( stubDeploymentId, stubSequenceDeviceRoleName )
+        val expectedStreams = setOf(
+            DataStreamsConfiguration.ExpectedDataStream.fromDataStreamId( dataPointStream ),
+            DataStreamsConfiguration.ExpectedDataStream.fromDataStreamId( dataTimeSpanStream )
+        )
+        service.openDataStreams( DataStreamsConfiguration( stubDeploymentId, expectedStreams ) )
+
+        val batch = MutableDataStreamBatch().apply {
+            appendSequence( createStubSequence( 0, StubDataPoint(), StubDataPoint() ) )
+        }
+        service.appendToDataStreams( stubDeploymentId, batch )
+
+        val expectedStatus = setOf(
+            DataStreamStatus( dataPointStream, lastSequenceId = 1, isOpen = true ),
+            DataStreamStatus( dataTimeSpanStream, lastSequenceId = null, isOpen = true )
+        )
+        val retrievedStatus = service.getDataStreamsStatus( stubDeploymentId )
+        assertEquals( expectedStatus, retrievedStatus.toSet() )
+    }
+
+    @Test
+    fun getDataStreamsStatus_fails_for_unopened_deployment() = runTest {
+        val service = createService()
+
+        assertFailsWith<IllegalArgumentException> { service.getDataStreamsStatus( stubDeploymentId ) }
+    }
+
+    @Test
+    fun getDataStreamsStatus_for_closed_dataStreamIds_succeeds() = runTest {
+        val service = createServiceWithOpenStubDataPointStream()
+        val batch = MutableDataStreamBatch().apply {
+            appendSequence( createStubSequence( 0, StubDataPoint(), StubDataPoint() ) )
+        }
+        service.appendToDataStreams( stubDeploymentId, batch )
+        service.closeDataStreams( setOf( stubDeploymentId ) )
+
+        val expectedStatus = DataStreamStatus( stubDataPointStream, lastSequenceId = 1, isOpen = false )
+        val lastSequenceIds = service.getDataStreamsStatus( stubDeploymentId )
+        assertEquals( expectedStatus, lastSequenceIds.singleOrNull() )
+    }
+
+    @Test
+    fun getDataStreamsStatus_for_removed_dataStreamIds_fails() = runTest {
+        val service = createServiceWithOpenStubDataPointStream()
+        service.removeDataStreams( setOf( stubDeploymentId ) )
+
+        assertFailsWith<IllegalArgumentException> { service.getDataStreamsStatus( stubDeploymentId ) }
+    }
+
+    @Test
     fun closeDataStreams_succeeds() = runTest {
         val service = createServiceWithOpenStubDataPointStream()
 

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/MutableDataStreamBatchTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/application/MutableDataStreamBatchTest.kt
@@ -191,6 +191,7 @@ class MutableDataStreamBatchTest
         val appendBatch = MutableDataStreamBatch().apply {
             appendSequence( createStubSequence( 0, stubDataTimeSpan ) )
             appendSequence( createStubSequence( 0, stubDataPoint ) ) // Overlaps.
+            appendSequence( createStubSequence( 2, stubDataPoint ) )
         }
 
         assertFailsWith<IllegalArgumentException> { batch.appendBatch( appendBatch ) }

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceInfrastructureTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/DataStreamServiceInfrastructureTest.kt
@@ -25,6 +25,7 @@ class DataStreamServiceRequestsTest : ApplicationServiceRequestsTest<DataStreamS
                 DataStreamId( UUID.randomUUID(), "Device", DataType( "some", "type" ) ),
                 0
             ),
+            DataStreamServiceRequest.GetDataStreamsStatus( UUID.randomUUID() ),
             DataStreamServiceRequest.CloseDataStreams( setOf( UUID.randomUUID() ) ),
             DataStreamServiceRequest.RemoveDataStreams( setOf( UUID.randomUUID() ) )
         )

--- a/carp.data.core/src/commonTest/resources/test-requests/DataStreamService/1.1/DataStreamServiceTest/getDataStreamsStatus_fails_for_unopened_deployment.json
+++ b/carp.data.core/src/commonTest/resources/test-requests/DataStreamService/1.1/DataStreamServiceTest/getDataStreamsStatus_fails_for_unopened_deployment.json
@@ -1,0 +1,13 @@
+[
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.GetDataStreamsStatus",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.data.core/src/commonTest/resources/test-requests/DataStreamService/1.1/DataStreamServiceTest/getDataStreamsStatus_for_closed_dataStreamIds_succeeds.json
+++ b/carp.data.core/src/commonTest/resources/test-requests/DataStreamService/1.1/DataStreamServiceTest/getDataStreamsStatus_for_closed_dataStreamIds_succeeds.json
@@ -1,0 +1,100 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.OpenDataStreams",
+            "apiVersion": "1.1",
+            "configuration": {
+                "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+                "expectedDataStreams": [
+                    {
+                        "deviceRoleName": "Device",
+                        "dataType": "dk.cachet.carp.stubpoint"
+                    }
+                ]
+            }
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {}
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.AppendToDataStreams",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+            "batch": [
+                {
+                    "dataStream": {
+                        "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+                        "deviceRoleName": "Device",
+                        "dataType": "dk.cachet.carp.stubpoint"
+                    },
+                    "firstSequenceId": 0,
+                    "measurements": [
+                        {
+                            "sensorStartTime": 0,
+                            "data": {
+                                "__type": "dk.cachet.carp.stubpoint",
+                                "data": "Stub"
+                            }
+                        },
+                        {
+                            "sensorStartTime": 0,
+                            "data": {
+                                "__type": "dk.cachet.carp.stubpoint",
+                                "data": "Stub"
+                            }
+                        }
+                    ],
+                    "triggerIds": [
+                        1
+                    ],
+                    "syncPoint": {
+                        "synchronizedOn": "2026-03-19T09:36:16.729704Z",
+                        "sensorTimestampAtSyncPoint": 1773912976729704,
+                        "relativeClockSpeed": 1.0
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {}
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.CloseDataStreams",
+            "apiVersion": "1.1",
+            "studyDeploymentIds": [
+                "4d260a37-2959-4512-b307-93be5b171ebb"
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {}
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.GetDataStreamsStatus",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "dataStream": {
+                    "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+                    "deviceRoleName": "Device",
+                    "dataType": "dk.cachet.carp.stubpoint"
+                },
+                "lastSequenceId": 1,
+                "isOpen": false
+            }
+        ]
+    }
+]

--- a/carp.data.core/src/commonTest/resources/test-requests/DataStreamService/1.1/DataStreamServiceTest/getDataStreamsStatus_for_removed_dataStreamIds_fails.json
+++ b/carp.data.core/src/commonTest/resources/test-requests/DataStreamService/1.1/DataStreamServiceTest/getDataStreamsStatus_for_removed_dataStreamIds_fails.json
@@ -1,0 +1,47 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.OpenDataStreams",
+            "apiVersion": "1.1",
+            "configuration": {
+                "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+                "expectedDataStreams": [
+                    {
+                        "deviceRoleName": "Device",
+                        "dataType": "dk.cachet.carp.stubpoint"
+                    }
+                ]
+            }
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {}
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.RemoveDataStreams",
+            "apiVersion": "1.1",
+            "studyDeploymentIds": [
+                "4d260a37-2959-4512-b307-93be5b171ebb"
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            "4d260a37-2959-4512-b307-93be5b171ebb"
+        ]
+    },
+    {
+        "outcome": "Failed",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.GetDataStreamsStatus",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "exceptionType": "IllegalArgumentException"
+    }
+]

--- a/carp.data.core/src/commonTest/resources/test-requests/DataStreamService/1.1/DataStreamServiceTest/getDataStreamsStatus_returns_all_expected_streams.json
+++ b/carp.data.core/src/commonTest/resources/test-requests/DataStreamService/1.1/DataStreamServiceTest/getDataStreamsStatus_returns_all_expected_streams.json
@@ -1,0 +1,100 @@
+[
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.OpenDataStreams",
+            "apiVersion": "1.1",
+            "configuration": {
+                "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+                "expectedDataStreams": [
+                    {
+                        "deviceRoleName": "Device",
+                        "dataType": "dk.cachet.carp.stubpoint"
+                    },
+                    {
+                        "deviceRoleName": "Device",
+                        "dataType": "dk.cachet.carp.stubtimespan"
+                    }
+                ]
+            }
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {}
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.AppendToDataStreams",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+            "batch": [
+                {
+                    "dataStream": {
+                        "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+                        "deviceRoleName": "Device",
+                        "dataType": "dk.cachet.carp.stubpoint"
+                    },
+                    "firstSequenceId": 0,
+                    "measurements": [
+                        {
+                            "sensorStartTime": 0,
+                            "data": {
+                                "__type": "dk.cachet.carp.stubpoint",
+                                "data": "Stub"
+                            }
+                        },
+                        {
+                            "sensorStartTime": 0,
+                            "data": {
+                                "__type": "dk.cachet.carp.stubpoint",
+                                "data": "Stub"
+                            }
+                        }
+                    ],
+                    "triggerIds": [
+                        1
+                    ],
+                    "syncPoint": {
+                        "synchronizedOn": "2026-03-19T09:36:16.729704Z",
+                        "sensorTimestampAtSyncPoint": 1773912976729704,
+                        "relativeClockSpeed": 1.0
+                    }
+                }
+            ]
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": {}
+    },
+    {
+        "outcome": "Succeeded",
+        "request": {
+            "__type": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.GetDataStreamsStatus",
+            "apiVersion": "1.1",
+            "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb"
+        },
+        "precedingEvents": [],
+        "publishedEvents": [],
+        "response": [
+            {
+                "dataStream": {
+                    "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+                    "deviceRoleName": "Device",
+                    "dataType": "dk.cachet.carp.stubpoint"
+                },
+                "lastSequenceId": 1,
+                "isOpen": true
+            },
+            {
+                "dataStream": {
+                    "studyDeploymentId": "4d260a37-2959-4512-b307-93be5b171ebb",
+                    "deviceRoleName": "Device",
+                    "dataType": "dk.cachet.carp.stubtimespan"
+                },
+                "lastSequenceId": null,
+                "isOpen": true
+            }
+        ]
+    }
+]

--- a/docs/carp-data.md
+++ b/docs/carp-data.md
@@ -29,5 +29,6 @@ Store and retrieve [`DataStreamPoint`](../carp.data.core/src/commonMain/kotlin/d
 | `openDataStreams` | Start accepting data for a specific study deployment. | manage deployment: `studyDeploymentId`| |
 | `appendToDataStreams` | Append a batch of data point sequences to corresponding data streams. | in deployment: `studyDeploymentId` |  |
 | `getDataStream` | Retrieve all data points in data stream that fall within the requested range. | in deployment: `dataStream.studyDeploymentId` | |
+| `getDataStreamsStatus` | Retrieve status for each configured data stream in a deployment. | in deployment: `studyDeploymentId` | |
 | `closeDataStreams` | Stop accepting data for specified study deployments. | manage deployment: (all) `studyDeploymentId` | |
 | `removeDataStreams` | Close data streams and remove all data for specified study deployments. | manage deployment: (all) `studyDeploymentId` | | 

--- a/rpc/schemas/data/DataStreamService/DataStreamServiceRequest.json
+++ b/rpc/schemas/data/DataStreamService/DataStreamServiceRequest.json
@@ -4,6 +4,7 @@
     { "$ref": "#OpenDataStreams" },
     { "$ref": "#AppendToDataStreams" },
     { "$ref": "#GetDataStream" },
+    { "$ref": "#GetDataStreamsStatus" },
     { "$ref": "#CloseDataStreams" },
     { "$ref": "#RemoveDataStreams" }
   ],
@@ -55,6 +56,22 @@
       "Response": {
         "$anchor": "GetDataStream-Response",
         "$ref": "../DataStreamBatch.json"
+      }
+    },
+    "GetDataStreamsStatus": {
+      "$anchor": "GetDataStreamsStatus",
+      "type": "object",
+  	  "properties": {
+        "__type": { "const": "dk.cachet.carp.data.infrastructure.DataStreamServiceRequest.GetDataStreamsStatus" },
+        "apiVersion": { "$ref": "#/$defs/ApiVersion" },
+        "studyDeploymentId": { "type": "string", "format": "uuid" }
+      },
+      "required": [ "__type", "apiVersion", "studyDeploymentId" ],
+      "additionalProperties": false,
+      "Response": {
+        "$anchor": "GetDataStreamsStatus-Response",
+        "type": "array",
+        "items": { "$ref": "../DataStreamStatus.json" }
       }
     },
     "CloseDataStreams": {

--- a/rpc/schemas/data/DataStreamStatus.json
+++ b/rpc/schemas/data/DataStreamStatus.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "dataStream": { "$ref": "DataStreamId.json" },
+    "lastSequenceId": { "type": [ "integer", "null" ] },
+    "isOpen": { "type": "boolean" }
+  },
+  "required": [ "dataStream", "lastSequenceId", "isOpen" ],
+  "additionalProperties": false
+}

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -271,6 +271,10 @@ private val phoneDataStreamBatch = MutableDataStreamBatch().apply {
     appendSequence( geoDataSequence )
     appendSequence( stepsDataSequence )
 }
+private val dataStreamSequenceIds = listOf(
+    DataStreamStatus( phoneGeoDataStream, geoDataSequence.range.last, true ),
+    DataStreamStatus( phoneStepsDataStream, stepsDataSequence.range.last, true )
+)
 
 
 private fun <TService : ApplicationService<TService, *>, TResponse> example(
@@ -554,6 +558,10 @@ private val exampleRequests: Map<KFunction<*>, LoggedRequest.Succeeded<*>> = map
     DataStreamService::getDataStream to example(
         request = DataStreamServiceRequest.GetDataStream( phoneGeoDataStream, 0, 100 ),
         response = MutableDataStreamBatch().apply { appendSequence( geoDataSequence ) }
+    ),
+    DataStreamService::getDataStreamsStatus to example(
+        request = DataStreamServiceRequest.GetDataStreamsStatus( deploymentId ),
+        response = dataStreamSequenceIds
     ),
     DataStreamService::closeDataStreams to example(
         request = DataStreamServiceRequest.CloseDataStreams( deploymentIds )


### PR DESCRIPTION
Base on real-life use cases, study normally requires different type of data, therefore I also added `GetLastSequenceIds` which gives all 'lastSequenceId' for a deployment.
(or maybe `GetLastSequenceId` is not needed, only `GetLastSequenceIds` is sufficient?)

I did not add this to `StudyDeploymentService`:
- lastSequenceId is per DataStreamId (deployment + device + dataType), so payload can get large.
- DeploymentServiceHost would need cross-service aggregation from data on every status call, which can add latency and coupling.
- By the use case given in the original issue, the 'lastSequenceId' is needed when the client device loose track of data ( app re-install ), therefore it is not needed with every deployment status call. Though 'lastSequenceId' can represent data collection status for that deployment.

---
Updated:

This PR adds`GetDataStreamsStatus` endpoint for retrieving status information for a study deployment. Currently it contains all `lastSequenceId`s for each `dataStream`, and whether if the `dataSteam` is closed.
