### PR TITLE
 Enforce registrationCreatedOn on device registrations

### DIFF
--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/AltBeacon.kt
@@ -12,6 +12,8 @@ import dk.cachet.carp.common.application.sampling.NoOptionsSamplingScheme
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.application.tasks.TaskConfigurationList
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlin.js.JsExport
 import kotlin.reflect.KClass
@@ -79,7 +81,9 @@ data class AltBeaconDeviceRegistration(
      */
     val referenceRssi: Short,
     override val deviceDisplayName: String? = null, // TODO: We could map known manufacturerId's to display names.
-    override val additionalSpecifications: ApplicationData? = null
+    override val additionalSpecifications: ApplicationData? = null,
+    @Required
+    override val registrationCreatedOn: Instant = Clock.System.now()
 ) : DeviceRegistration()
 {
     companion object

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLESerialNumberDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/BLESerialNumberDeviceRegistration.kt
@@ -1,7 +1,11 @@
+@file:Suppress( "NON_EXPORTABLE_TYPE" )
+
 package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlin.js.JsExport
 
@@ -16,7 +20,9 @@ import kotlin.js.JsExport
 data class BLESerialNumberDeviceRegistration(
     val serialNumber: String,
     override val deviceDisplayName: String? = null,
-    override val additionalSpecifications: ApplicationData? = null
+    override val additionalSpecifications: ApplicationData? = null,
+    @Required
+    override val registrationCreatedOn: Instant = Clock.System.now()
 ) : DeviceRegistration()
 {
     init

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DefaultDeviceRegistration.kt
@@ -1,8 +1,12 @@
+@file:Suppress( "NON_EXPORTABLE_TYPE" )
+
 package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlin.js.JsExport
 
@@ -18,7 +22,9 @@ data class DefaultDeviceRegistration(
     override val deviceDisplayName: String? = null,
     override val additionalSpecifications: ApplicationData? = null,
     @Required
-    override val deviceId: String = UUID.randomUUID().toString()
+    override val deviceId: String = UUID.randomUUID().toString(),
+    @Required
+    override val registrationCreatedOn: Instant = Clock.System.now()
 ) : DeviceRegistration()
 
 

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/DeviceRegistration.kt
@@ -1,4 +1,4 @@
-@file:Suppress( "NON_EXPORTABLE_TYPE" )
+@file:Suppress( "NON_EXPORTABLE_TYPE", "UnnecessaryAbstractClass" )
 
 package dk.cachet.carp.common.application.devices
 
@@ -6,7 +6,6 @@ import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.Immutable
 import dk.cachet.carp.common.application.ImplementAsDataClass
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlin.js.JsExport
@@ -41,7 +40,7 @@ abstract class DeviceRegistration
     abstract val deviceDisplayName: String?
 
     @Required
-    val registrationCreatedOn: Instant = Clock.System.now()
+    abstract val registrationCreatedOn: Instant
 
     /**
      * Additional device specifications which may be relevant to the researcher when interpreting collected data.

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistration.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/MACAddressDeviceRegistration.kt
@@ -1,8 +1,12 @@
+@file:Suppress( "NON_EXPORTABLE_TYPE" )
+
 package dk.cachet.carp.common.application.devices
 
 import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.MACAddress
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlin.js.JsExport
 
@@ -15,7 +19,9 @@ import kotlin.js.JsExport
 data class MACAddressDeviceRegistration(
     val macAddress: MACAddress,
     override val deviceDisplayName: String? = null,
-    override val additionalSpecifications: ApplicationData? = null
+    override val additionalSpecifications: ApplicationData? = null,
+    @Required
+    override val registrationCreatedOn: Instant = Clock.System.now()
 ) : DeviceRegistration()
 {
     @Required

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Website.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/application/devices/Website.kt
@@ -9,6 +9,8 @@ import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.application.tasks.TaskConfigurationList
 import dk.cachet.carp.common.infrastructure.serialization.NotSerializable
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
@@ -52,7 +54,9 @@ data class WebsiteDeviceRegistration(
      */
     val userAgent: String,
     override val deviceDisplayName: String? = userAgent,
-    override val additionalSpecifications: ApplicationData? = null
+    override val additionalSpecifications: ApplicationData? = null,
+    @Required
+    override val registrationCreatedOn: Instant = Clock.System.now()
 ) : DeviceRegistration()
 {
     @Required

--- a/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
+++ b/carp.common/src/commonMain/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializers.kt
@@ -11,6 +11,7 @@ import dk.cachet.carp.common.application.devices.DeviceRegistrationBuilder
 import dk.cachet.carp.common.application.devices.PrimaryDeviceConfiguration
 import dk.cachet.carp.common.application.sampling.DataTypeSamplingSchemeMap
 import dk.cachet.carp.common.application.sampling.SamplingConfiguration
+import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 import kotlin.reflect.KClass
@@ -180,11 +181,13 @@ data class CustomDeviceRegistration internal constructor(
     private data class BaseMembers(
         override val deviceId: String,
         override val deviceDisplayName: String? = null,
+        override val registrationCreatedOn: Instant,
         override val additionalSpecifications: ApplicationData? = null
     ) : DeviceRegistration()
 
     override val deviceId: String
     override val deviceDisplayName: String?
+    override val registrationCreatedOn: Instant
     override val additionalSpecifications: ApplicationData?
 
     init
@@ -193,6 +196,7 @@ data class CustomDeviceRegistration internal constructor(
         val baseMembers = json.decodeFromString( BaseMembers.serializer(), jsonSource )
         deviceId = baseMembers.deviceId
         deviceDisplayName = baseMembers.deviceDisplayName
+        registrationCreatedOn = baseMembers.registrationCreatedOn
         additionalSpecifications = baseMembers.additionalSpecifications
     }
 }

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/data/DataSerializationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/application/data/DataSerializationTest.kt
@@ -7,8 +7,6 @@ import dk.cachet.carp.common.infrastructure.test.StubDataTypes
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
 import dk.cachet.carp.common.infrastructure.test.makeUnknown
 import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/DeviceRegistrationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/DeviceRegistrationTest.kt
@@ -4,7 +4,6 @@ import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.application.devices.DefaultDeviceRegistration
 import dk.cachet.carp.common.application.devices.DeviceRegistration
 import dk.cachet.carp.common.infrastructure.test.makeUnknown
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/SerializationTest.kt
@@ -13,7 +13,6 @@ import dk.cachet.carp.common.application.sampling.SamplingConfiguration
 import dk.cachet.carp.common.infrastructure.test.*
 import dk.cachet.carp.test.serialization.ConcreteTypesSerializationTest
 import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDataSerializersTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDataSerializersTest.kt
@@ -6,8 +6,6 @@ import dk.cachet.carp.common.application.data.CompletedTask
 import dk.cachet.carp.common.infrastructure.test.StubDataPoint
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
 import dk.cachet.carp.common.infrastructure.test.makeUnknown
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.test.*
 

--- a/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializersTest.kt
+++ b/carp.common/src/commonTest/kotlin/dk/cachet/carp/common/infrastructure/serialization/UnknownDeviceSerializersTest.kt
@@ -3,6 +3,7 @@ package dk.cachet.carp.common.infrastructure.serialization
 import dk.cachet.carp.common.application.devices.DefaultDeviceRegistration
 import dk.cachet.carp.common.infrastructure.test.StubDeviceConfiguration
 import dk.cachet.carp.common.infrastructure.test.StubPrimaryDeviceConfiguration
+import dk.cachet.carp.test.TestClock
 import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import kotlin.test.*
@@ -126,12 +127,16 @@ class CustomDeviceRegistrationTest
     @Test
     fun initialization_from_json_extracts_base_DeviceRegistration_properties()
     {
-        val registration = DefaultDeviceRegistration()
+        val expectedRegistrationCreatedOn = TestClock.now()
+        val registration = DefaultDeviceRegistration(
+            registrationCreatedOn = expectedRegistrationCreatedOn
+        )
         val serialized: String = JSON.encodeToString( DefaultDeviceRegistration.serializer(), registration )
 
         val custom = CustomDeviceRegistration( "Irrelevant", serialized, JSON )
         assertEquals( registration.deviceId, custom.deviceId )
         assertEquals( registration.deviceDisplayName, custom.deviceDisplayName )
+        assertEquals( expectedRegistrationCreatedOn, custom.registrationCreatedOn )
     }
 
     @Serializable

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/InMemoryDataStreamServiceTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/InMemoryDataStreamServiceTest.kt
@@ -17,8 +17,6 @@ import dk.cachet.carp.data.application.MutableDataStreamSequence
 import dk.cachet.carp.data.application.SyncPoint
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlin.test.*
 
 

--- a/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/MeasurementTest.kt
+++ b/carp.data.core/src/commonTest/kotlin/dk/cachet/carp/data/infrastructure/MeasurementTest.kt
@@ -7,7 +7,6 @@ import dk.cachet.carp.common.infrastructure.test.StubDataPoint
 import dk.cachet.carp.common.infrastructure.test.makeUnknown
 import dk.cachet.carp.data.application.Measurement
 import dk.cachet.carp.data.application.MeasurementSerializer
-import kotlinx.serialization.encodeToString
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHost.kt
+++ b/carp.deployments.core/src/commonMain/kotlin/dk/cachet/carp/deployments/application/ParticipationServiceHost.kt
@@ -5,7 +5,6 @@ import dk.cachet.carp.common.application.data.Data
 import dk.cachet.carp.common.application.data.input.CarpInputDataTypes
 import dk.cachet.carp.common.application.data.input.InputDataType
 import dk.cachet.carp.common.application.data.input.InputDataTypeList
-import dk.cachet.carp.common.application.devices.AnyPrimaryDeviceConfiguration
 import dk.cachet.carp.common.application.devices.isPrimary
 import dk.cachet.carp.common.application.services.ApplicationServiceEventBus
 import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitation

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/application/ValidationTest.kt
@@ -13,6 +13,8 @@ import dk.cachet.carp.deployments.application.users.StudyInvitation
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSinglePrimaryDeviceProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSinglePrimaryWithConnectedDeviceProtocol
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.test.*
 
 
@@ -159,6 +161,7 @@ class ValidationTest
             {
                 override val deviceId: String = "Invalid"
                 override val deviceDisplayName: String? = null
+                override val registrationCreatedOn: Instant = Clock.System.now()
                 override val additionalSpecifications: ApplicationData? = null
             }
         val preregistrations = mapOf( connectedRoleName to invalidRegistration )

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ActiveParticipationInvitationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ActiveParticipationInvitationTest.kt
@@ -8,7 +8,6 @@ import dk.cachet.carp.deployments.application.users.ActiveParticipationInvitatio
 import dk.cachet.carp.deployments.application.users.AssignedPrimaryDevice
 import dk.cachet.carp.deployments.application.users.Participation
 import dk.cachet.carp.deployments.application.users.StudyInvitation
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipantDataTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipantDataTest.kt
@@ -8,7 +8,6 @@ import dk.cachet.carp.common.application.data.input.Sex
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
 import dk.cachet.carp.deployments.application.users.ParticipantData
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/ParticipationTest.kt
@@ -3,7 +3,6 @@ package dk.cachet.carp.deployments.infrastructure
 import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.deployments.application.users.Participation
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/PrimaryDeviceDeploymentTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/PrimaryDeviceDeploymentTest.kt
@@ -12,7 +12,6 @@ import dk.cachet.carp.common.infrastructure.test.StubTaskConfiguration
 import dk.cachet.carp.common.infrastructure.test.StubTriggerConfiguration
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
 import dk.cachet.carp.deployments.application.PrimaryDeviceDeployment
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentSnapshotTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentSnapshotTest.kt
@@ -12,7 +12,6 @@ import dk.cachet.carp.deployments.domain.StudyDeploymentSnapshot
 import dk.cachet.carp.deployments.domain.createComplexDeployment
 import dk.cachet.carp.deployments.domain.studyDeploymentFor
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentStatusTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyDeploymentStatusTest.kt
@@ -16,7 +16,6 @@ import dk.cachet.carp.deployments.domain.studyDeploymentFor
 import dk.cachet.carp.protocols.application.StudyProtocolSnapshot
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createSinglePrimaryWithConnectedDeviceProtocol
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyInvitationTest.kt
+++ b/carp.deployments.core/src/commonTest/kotlin/dk/cachet/carp/deployments/infrastructure/StudyInvitationTest.kt
@@ -3,7 +3,6 @@ package dk.cachet.carp.deployments.infrastructure
 import dk.cachet.carp.common.application.ApplicationData
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.deployments.application.users.StudyInvitation
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/EmptyProtocolParticipantConfiguration.kt
+++ b/carp.protocols.core/src/commonMain/kotlin/dk/cachet/carp/protocols/domain/configuration/EmptyProtocolParticipantConfiguration.kt
@@ -1,6 +1,5 @@
 package dk.cachet.carp.protocols.domain.configuration
 
-import dk.cachet.carp.common.application.users.AssignedTo
 import dk.cachet.carp.common.application.users.ExpectedParticipantData
 import dk.cachet.carp.common.application.users.ParticipantRole
 import dk.cachet.carp.common.application.users.hasNoConflicts

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/ProtocolsCodeSamples.kt
@@ -14,7 +14,6 @@ import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.start
 import dk.cachet.carp.protocols.domain.within
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/configuration/ProtocolParticipantConfigurationTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/domain/configuration/ProtocolParticipantConfigurationTest.kt
@@ -7,7 +7,6 @@ import dk.cachet.carp.common.application.users.ExpectedParticipantData
 import dk.cachet.carp.common.application.users.ParticipantAttribute
 import dk.cachet.carp.common.application.users.ParticipantRole
 import dk.cachet.carp.common.infrastructure.test.createTestJSON
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolVersionTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/ProtocolVersionTest.kt
@@ -3,7 +3,6 @@ package dk.cachet.carp.protocols.infrastructure
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.protocols.application.ProtocolVersion
 import kotlinx.datetime.Clock
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
+++ b/carp.protocols.core/src/commonTest/kotlin/dk/cachet/carp/protocols/infrastructure/StudyProtocolSnapshotTest.kt
@@ -21,7 +21,6 @@ import dk.cachet.carp.protocols.domain.StudyProtocol
 import dk.cachet.carp.protocols.domain.start
 import dk.cachet.carp.protocols.infrastructure.test.createComplexProtocol
 import dk.cachet.carp.protocols.infrastructure.test.createEmptyProtocol
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/AssignedParticipantRolesTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/AssignedParticipantRolesTest.kt
@@ -4,7 +4,6 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.application.users.AssignedTo
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.studies.application.users.AssignedParticipantRoles
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/ParticipantTest.kt
@@ -3,7 +3,6 @@ package dk.cachet.carp.studies.infrastructure
 import dk.cachet.carp.common.application.users.AccountIdentity
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.studies.application.users.Participant
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyStatusTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/infrastructure/StudyStatusTest.kt
@@ -4,7 +4,6 @@ import dk.cachet.carp.common.application.UUID
 import dk.cachet.carp.common.infrastructure.serialization.JSON
 import dk.cachet.carp.studies.application.StudyStatus
 import kotlinx.datetime.Clock
-import kotlinx.serialization.*
 import kotlin.test.*
 
 

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -37,7 +37,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KFunction
 import kotlin.reflect.KSuspendFunction3
-import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.kotlinFunction
 import kotlin.time.Duration.Companion.days
@@ -77,16 +76,6 @@ fun generateExampleRequests( serviceInfo: ApplicationServiceInfo ): List<Example
         )
     }
 }
-
-private fun <T : DeviceRegistration> T.setRegistrationCreatedOn( createdOn: Instant ): T
-{
-    val backingField = DeviceRegistration::registrationCreatedOn.javaField!!
-    backingField.isAccessible = true
-    backingField.set( this, createdOn )
-
-    return this
-}
-
 
 // Example protocol with a single smartphone.
 private val ownerId = UUID( "491f03fc-964b-4783-86a6-a528bbfe4e94" )
@@ -193,10 +182,10 @@ private val bikeBeaconPreregistration = bikeBeacon.createRegistration {
     majorId = 42
     minorId = 42
     additionalSpecifications = ApplicationData( """{"Model": "AnyBeacon B42"}""" )
-}.setRegistrationCreatedOn( deploymentCreatedOn )
+}.copy( registrationCreatedOn = deploymentCreatedOn )
 private val phoneRegistration = phone.createRegistration {
     deviceId = UUID( "fc7b41b0-e9e2-4b5d-8c3d-5119b556a3f0" ).toString()
-}.setRegistrationCreatedOn( Instant.fromEpochSeconds( 1642514110 ) )
+}.copy( registrationCreatedOn = Instant.fromEpochSeconds( 1642514110 ) )
 private val bikeBeaconStatus = DeviceDeploymentStatus.Registered( bikeBeacon, phoneRegistration, false, emptySet(), emptySet() )
 private val participantStatusList = listOf(
     ParticipantStatus( participantId, participantAssignedRoles, setOf( phone.roleName ) )

--- a/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
+++ b/rpc/src/main/kotlin/dk/cachet/carp/rpc/GenerateExampleRequests.kt
@@ -380,17 +380,22 @@ private val exampleRequests: Map<KFunction<*>, LoggedRequest.Succeeded<*>> = map
             Participant( UsernameAccountIdentity( "John Doe" ), UUID( "d7436912-ac9f-4f9b-a29e-376af8a0fbb4" ) )
         )
     ),
-    RecruitmentService::inviteNewParticipantGroup to example(
-        request = RecruitmentServiceRequest.InviteNewParticipantGroup(
-            studyId,
-            setOf( AssignedParticipantRoles( participantId, participantAssignedRoles ) )
-        ),
-        response = ParticipantGroupStatus.Invited(
-            deploymentId,
-            participants,
-            roleAssignment,
-            participantGroupInvitedOn,
-            invitedDeploymentStatus
+    @Suppress( "DEPRECATION" )
+    Pair(
+        RecruitmentService::inviteNewParticipantGroup,
+        example(
+            request =
+                RecruitmentServiceRequest.InviteNewParticipantGroup(
+                    studyId,
+                    setOf( AssignedParticipantRoles( participantId, participantAssignedRoles ) )
+                ),
+            response = ParticipantGroupStatus.Invited(
+                deploymentId,
+                participants,
+                roleAssignment,
+                participantGroupInvitedOn,
+                invitedDeploymentStatus
+            )
         )
     ),
     RecruitmentService::createParticipantGroup to example(


### PR DESCRIPTION
Fix #535 

We are tightening the model so `registrationCreatedOn` is always required on a device registration. The downside is that older serialized registrations which were saved without this field may no longer deserialize.

The tricky part is that making this backward compatible would mean filling in a timestamp that was never actually there. That would keep old payloads working, but it would also bring back the original problem by silently inventing required data instead of enforcing it.

I think this is acceptable, since `deviceDeployed` would already fail for these registrations because of the mismatch caused by the original bug, so this is not functionality we expect to be used in practice. However, it should still be called out in the release notes as a backward-incompatible change.

Note: 
- This fix requires a database migration for existing`CustomDeviceRegistration` records to include `registrationCreatedOn`.
- `DefaultDeviceRegistration` constructor args were reordered to keep `additionalSpecifications` last. Positional external callers may need to update to named args. This does not affect migrating from 1.2
