### PR TITLE
Replace custom TypeScript collection exports with Kotlin generated ones

### DIFF
--- a/publish-npm-packages/src/commonMain/kotlin/KotlinExport.kt
+++ b/publish-npm-packages/src/commonMain/kotlin/KotlinExport.kt
@@ -15,31 +15,12 @@ import kotlin.time.Duration
 @JsExport
 class KotlinExport
 {
-    fun collection( collection: Collection<Any> )
-    {
-        val contains = collection.contains( 42 )
-        val size = collection.size
-    }
-
-    // Two values needed to ensure export which takes an array and unpacks it.
-    val listOf = listOf( 42, 42 )
-    val setOf = setOf( 42, 42 )
-
-    fun map( map: Map<Any, Any> )
-    {
-        val get = map[ 42 ]
-        val keys = map.keys
-        val values = map.values
-    }
-
     fun pair( pair: Pair<Any, Any> )
     {
         val to = 42 to "answer"
         val first = pair.first
         val second = pair.second
     }
-
-    val mapOf = mapOf( 42 to "answer", 13 to "unlucky" )
 
     fun duration( duration: Duration )
     {

--- a/publish-npm-packages/src/forced-exports/kotlin-kotlin-stdlib
+++ b/publish-npm-packages/src/forced-exports/kotlin-kotlin-stdlib
@@ -1,3 +1,4 @@
+Collection
 EmptyList
 AbstractMutableList
 HashSet
@@ -5,9 +6,6 @@ EmptySet
 HashMap
 Pair
 to
-listOf_0
-setOf_0
-mapOf_0
 Companion_getInstance_20
 _Duration___get_inWholeMilliseconds__impl__msfiry
 _Duration___get_inWholeMicroseconds__impl__8oe8vv

--- a/publish-npm-packages/src/known-facade-types
+++ b/publish-npm-packages/src/known-facade-types
@@ -1,8 +1,4 @@
 kotlin.Pair
-kotlin.collections.Collection
-kotlin.collections.List
-kotlin.collections.Set
-kotlin.collections.Map
 kotlin.time.Duration
 kotlinx.datetime.Clock
 kotlinx.datetime.Instant

--- a/typescript-declarations/carp-kotlin/index.ts
+++ b/typescript-declarations/carp-kotlin/index.ts
@@ -7,13 +7,16 @@ export namespace kotlinExport
 {
     export type Nullable<T> = T | null | undefined
     /**
-     * @deprecated Use bigint directly.
+     * @deprecated Use bigint instead.
      */
     export type Long = bigint
     /**
-     * @deprecated Use BigInt( number ) or bigint literal.
+     * @deprecated Use {@link BigInt} constructor or bigint literal instead.
      */
     export const toLong = (number: number): Long => BigInt( number )
+    /**
+     * @deprecated Use {@link KtMap} and initialize using JS arrays instead.
+     */
     export class Pair<K, V>
     {
         constructor( first: K, second: V ) {
@@ -22,8 +25,8 @@ export namespace kotlinExport
             kotlinPair.second = kotlinPair.pd_1;
             return kotlinPair;
         }
-        get first(): K { return this.first; }
-        get second(): V { return this.second; }
+        declare readonly first: K
+        declare readonly second: V
     }
 }
 declare global
@@ -31,6 +34,9 @@ declare global
     // Backwards compatibility for codebases which still use Long.
     interface BigInt
     {
+        /**
+         * @deprecated Keep as {@link bigint} to prevent losing precision, or use {@link Number} constructor instead.
+         */
         toNumber(): number
     }
 }
@@ -44,23 +50,39 @@ export namespace kotlinExport.collections
     {
         contains( value: T ): boolean
         size(): number
+
+        /**
+         * Copies all elements of this collection to a new array.
+         */
         toArray(): Array<T>
     }
-    export interface List<T> extends Collection<T> {}
-    export interface Set<T> extends Collection<T> {}
-    export interface Map<K, V>
+    /**
+     * @deprecated Use {@link KtList} instead.
+     */
+    export type List<T> = extend.kotlin.collections.KtList<T>
+    /**
+     * @deprecated Use {@link KtSet} instead.
+     */
+    export type Set<T> = extend.kotlin.collections.KtSet<T>
+    /**
+     * @deprecated Use {@link KtMap} instead.
+     */
+    export type Map<K, V> = extend.kotlin.collections.KtMap<K, V>
+    /**
+     * @deprecated Use {@link KtList.fromJsArray} instead.
+     */
+    export function listOf<T>( array: T[] ) { return KtList.fromJsArray( array ); }
+    /**
+     * @deprecated Use {@link KtSet.fromJsSet} instead.
+     */
+    export function setOf<T>( array: T[] ) { return KtSet.fromJsSet( new Set( array ) ) }
+    /**
+     * @deprecated Use {@link KtMap.fromJsMap} instead.
+     */
+    export function mapOf<K, V>( pairs: kotlinExport.Pair<K, V>[] )
     {
-        get( key: K ): V
-        keys: Set<K>
-        values: Collection<V>
+        return KtMap.fromJsMap( new Map( pairs.map( pair => [ pair.first, pair.second ] ) ) )
     }
-    export const listOf: <T>(array: T[]) => List<T> = extend.$_$.listOf_0
-    export const setOf: <T>(array: T[]) => Set<T> = extend.$_$.setOf_0
-    export const mapOf =
-        function<K, V>( pairs: kotlinExport.Pair<K, V>[] ): Map<K, V>
-        {
-            return extend.$_$.mapOf_0( pairs as any )
-        }
 }
 export namespace kotlinExport.time
 {
@@ -91,17 +113,26 @@ declare module "@cachet/kotlin-kotlin-stdlib"
             second: V
         }
         interface Collection<T> extends kotlinExport.collections.Collection<T> {}
-        abstract class EmptyList<T> implements kotlinExport.collections.List<T> {}
-        abstract class AbstractMutableList<T> implements kotlinExport.collections.List<T> {}
-        interface Set<T> extends kotlinExport.collections.Set<T> {}
-        abstract class EmptySet<T> implements kotlinExport.collections.Set<T> {}
-        abstract class HashSet<T> implements kotlinExport.collections.Set<T> {}
-        interface Map<K, V> extends kotlinExport.collections.Map<K, V> {}
-        abstract class HashMap<K, V> implements kotlinExport.collections.Map<K, V>
+        abstract class EmptyList<T> implements kotlin.collections.KtList<T> {}
+        abstract class AbstractMutableList<T> implements kotlin.collections.KtList<T> {}
+        interface Set<T> extends kotlin.collections.KtSet<T> {}
+        abstract class EmptySet<T> implements kotlin.collections.KtSet<T> {}
+        abstract class HashSet<T> implements kotlin.collections.KtSet<T> {}
+        interface Map<K, V> extends kotlin.collections.KtMap<K, V> {}
+        abstract class HashMap<K, V> implements kotlin.collections.KtMap<K, V> {}
+    }
+    namespace kotlin
+    {
+        namespace collections
         {
-            get( key: K ): V
-            keys: kotlinExport.collections.Set<K>
-            values: kotlinExport.collections.Collection<V>
+            interface KtList<T> extends kotlinExport.collections.Collection<T> {}
+            interface KtSet<T> extends kotlinExport.collections.Collection<T> {}
+            interface KtMap<K, V>
+            {
+                get( key: K ): V
+                keys: KtSet<K>
+                values: kotlinExport.collections.Collection<V>
+            }
         }
     }
 }
@@ -125,19 +156,19 @@ Object.defineProperty( BigInt.prototype, "inWholeMicroseconds", {
 extend.$_$.EmptyList.prototype.contains = function<T>( value: T ): boolean { return false; }
 extend.$_$.EmptyList.prototype.size = function<T>(): number { return 0; }
 extend.$_$.EmptyList.prototype.toArray = function<T>(): T[] { return []; }
-extend.$_$.AbstractMutableList.prototype.contains = function<T>( value: T ): boolean { return this.e1( value ); }
-extend.$_$.AbstractMutableList.prototype.size = function<T>(): number { return this.o(); }
+extend.$_$.AbstractMutableList.prototype.contains = function<T>( value: T ): boolean { return this.asJsReadonlyArrayView().includes( value ); }
+extend.$_$.AbstractMutableList.prototype.size = function<T>(): number { return this.asJsReadonlyArrayView().length; }
 extend.$_$.EmptySet.prototype.contains = function<T>( value: T ): boolean { return false; }
 extend.$_$.EmptySet.prototype.size = function<T>(): number { return 0; }
 extend.$_$.EmptySet.prototype.toArray = function<T>(): T[] { return []; }
-extend.$_$.HashSet.prototype.contains = function<T>( value: T ): boolean { return this.e1( value ); }
-extend.$_$.HashSet.prototype.size = function<T>(): number { return this.o(); }
-extend.$_$.HashMap.prototype.get = function<K, V>( key: K ): V { return this.d2( key ); }
+extend.$_$.HashSet.prototype.contains = function<T>( value: T ): boolean { return this.asJsReadonlySetView().has( value ); }
+extend.$_$.HashSet.prototype.size = function<T>(): number { return this.asJsReadonlySetView().size; }
+extend.$_$.HashMap.prototype.get = function<K, V>( key: K ): V { return this.asJsReadonlyMapView().get( key ); }
 Object.defineProperty( extend.$_$.HashMap.prototype, "keys", {
-    get: function keys() { return this.z1(); }
+    get: function keys() { return extend.kotlin.collections.KtSet.fromJsSet( new Set( this.asJsReadonlyMapView().keys() ) ); }
 } );
 Object.defineProperty( extend.$_$.HashMap.prototype, "values", {
-    get: function values() { return this.a2(); }
+    get: function values() { return extend.kotlin.collections.KtList.fromJsArray( [ ...this.asJsReadonlyMapView().values() ] ); }
 } );
 
 

--- a/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
+++ b/typescript-declarations/carp-kotlin/kotlin-kotlin-stdlib.d.ts
@@ -15,38 +15,19 @@ declare module "@cachet/kotlin-kotlin-stdlib"
 
         interface Collection<T>
         {
-            // contains
-            e1( value: T ): boolean
-
-            // size
-            o(): number
-
             toArray(): Array<T>
         }
 
-        interface List<T> extends Collection<T> {}
+        interface List<T> extends Collection<T>, kotlin.collections.KtList<T> {}
         interface EmptyList<T> extends List<T> {}
         interface AbstractMutableList<T> extends List<T> {}
-        function listOf_0<T>( elements: T[] ): List<T>
 
-        interface Set<T> extends Collection<T> {}
+        interface Set<T> extends Collection<T>, kotlin.collections.KtSet<T> {}
         interface EmptySet<T> extends Set<T> {}
         interface HashSet<T> extends Set<T> {}
-        function setOf_0<T>( elements: T[] ): Set<T>
 
-        interface Map<K, V>
-        {
-            // get
-            d2( key: K ): V
-
-            // keys
-            z1(): Set<K>
-
-            // values
-            a2(): Collection<V>
-        }
+        interface Map<K, V> extends kotlin.collections.KtMap<K, V> {}
         interface HashMap<K, V> extends Map<K, V> {}
-        function mapOf_0<K, V>( pairs: Pair<K, V>[] ): Map<K, V>
 
         type Duration = bigint
         interface DurationCompanion
@@ -70,9 +51,30 @@ declare module "@cachet/kotlin-kotlin-stdlib"
     {
         namespace collections
         {
-            const KtList: any
-            const KtSet: any
-            const KtMap: any
+            namespace KtList
+            {
+                function fromJsArray<T>( elements: T[] ): KtList<T>
+            }
+            interface KtList<T>
+            {
+                asJsReadonlyArrayView(): readonly T[]
+            }
+            namespace KtSet
+            {
+                function fromJsSet<T>( elements: Set<T> ): KtSet<T>
+            }
+            interface KtSet<T>
+            {
+                asJsReadonlySetView (): Readonly<Set<T>>
+            }
+            namespace KtMap
+            {
+                function fromJsMap<K, V>( entries: ReadonlyMap<K, V> ): KtMap<K, V>
+            }
+            interface KtMap<K, V>
+            {
+                asJsReadonlyMapView(): ReadonlyMap<K, V>
+            }
         }
     }
 }

--- a/typescript-declarations/tests/carp-kotlin-test.ts
+++ b/typescript-declarations/tests/carp-kotlin-test.ts
@@ -6,6 +6,9 @@ import toLong = kotlin.toLong
 import Long = kotlin.Long
 import Pair = kotlin.Pair
 import Duration = kotlin.time.Duration
+import KtList = kotlin.collections.KtList
+import KtSet = kotlin.collections.KtSet
+import KtMap = kotlin.collections.KtMap
 import listOf = kotlin.collections.listOf
 import setOf = kotlin.collections.setOf
 import mapOf = kotlin.collections.mapOf
@@ -20,12 +23,15 @@ describe( "kotlin", () => {
             toLong( 42 ),
             new Pair( 42, "answer" ),
             [ "Collection", list ],
+            [ "KtList", KtList.fromJsArray( [ 42 ] ) ],
             [ "List", list ],
             [ "EmptyList", listOf<number>( [] ) ],
             [ "AbstractMutableList", list ],
+            [ "KtSet", KtSet.fromJsSet( new Set( [ 42 ] ) ) ],
             [ "Set", set ],
             [ "EmptySet", setOf<number>( [] ) ],
             [ "HashSet", set ],
+            [ "KtMap", KtMap.fromJsMap( new Map( [ [ 42, "answer" ] ] ) ) ],
             [ "Map", map ],
             [ "HashMap", map ],
             [ "DurationCompanion", Duration.Companion ],
@@ -97,6 +103,45 @@ describe( "kotlin", () => {
         } )
     } )
 
+    describe( "KtList", () => {
+        it( "fromJsArray and back to array succeeds", () => {
+            const numbers = [ 1, 2, 3 ]
+            const numbersList = KtList.fromJsArray( numbers )
+
+            const numbersArray = numbersList.asJsReadonlyArrayView()
+            expect( numbersArray[ 0 ] ).equals( 1 )
+
+            // The view is a proxy on which Chai's deep equals fails without applying the spread operator.
+            expect( [...numbersArray] ).deep.equals( numbers )
+        } )
+
+        it( "toArray provides a mutable copy of the original collection", () => {
+            const numbers = [ 1, 2, 3 ]
+            const numbersList = KtList.fromJsArray( numbers )
+
+            const newArray = numbersList.toArray()
+            newArray[ 0 ] = 42
+            
+            expect( numbers[ 0 ] ).equals( 1 )
+            expect( newArray[ 0 ] ).equals( 42 )
+        } )
+
+        it( "includes succeeds", () => {
+            const kotlinList = KtList.fromJsArray( [ 0, 42, 50 ] )
+            const includesAnswer = kotlinList.asJsReadonlyArrayView()
+
+            expect( includesAnswer.includes( 42 ) ).is.true
+            expect( includesAnswer.includes( 100 ) ).is.false
+        } )
+
+        it( "length succeeds", () => {
+            const kotlinList = KtList.fromJsArray( [ 1, 2, 3 ] )
+            const three = kotlinList.asJsReadonlyArrayView()
+
+            expect( three.length ).equals( 3 )
+        } )
+    } )
+
     describe( "Set", () => {
         it( "setOf and conversion back to array succeeds", () => {
             const answers = [ 42 ]
@@ -140,6 +185,15 @@ describe( "kotlin", () => {
 
             expect( answersMap.keys.toArray() ).deep.equals( [ "answer" ] )
             expect( answersMap.values.toArray() ).deep.equals( [ 42 ] )
+        } )
+    } )
+
+    describe( "KtMap", () => {
+        it( "fromJsMap and back to map succeeds", () => {
+            const answers = new Map( [ [ "answer", 42 ] ] )
+            const answersMap = KtMap.fromJsMap( answers )
+
+            expect( answersMap.asJsReadonlyMapView().get( "answer" ) ).equals( 42 )
         } )
     } )
 


### PR DESCRIPTION
Since Kotlin 2.0.0, collection types are exported to TypeScript by default. Re-export these instead of custom exports relying on mangled JS names.

Progress:
- [x] List
- [x] Set
- [x] Map (+ Pair?) 