### PR TITLE
Fix: `stopParticipantGroup` verifies study membership using the wrong ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ buildscript {
     ext {
         // Version used for submodule artifacts.
         // Snapshot publishing changes (or adds) the suffix after '-' with 'SNAPSHOT' prior to publishing.
-        globalVersion = '1.3.0'
-        clientsVersion = '1.3.0-alpha.1' // The clients subsystem is still expected to change drastically.
+        globalVersion = '1.3.1'
+        clientsVersion = '1.3.1-alpha.1' // The clients subsystem is still expected to change drastically.
         if (project.hasProperty("snapshot"))
         {
             def versionSplit = globalVersion.split('-')

--- a/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
+++ b/carp.studies.core/src/commonMain/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHost.kt
@@ -290,7 +290,7 @@ class RecruitmentServiceHost(
     {
         val (recruitment, participantGroup) = getRecruitmentWithGroupOrThrow( groupId )
 
-        require( recruitment.id == studyId ) {
+        require( recruitment.studyId == studyId ) {
             "Participant group with ID \"$groupId\" does not belong to study with ID \"$studyId\"."
         }
 

--- a/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
+++ b/carp.studies.core/src/commonTest/kotlin/dk/cachet/carp/studies/application/RecruitmentServiceHostTest.kt
@@ -22,13 +22,14 @@ class RecruitmentServiceHostTest : RecruitmentServiceTest
         fun createSUT(): RecruitmentServiceTest.SUT
         {
             val eventBus = SingleThreadedEventBus()
+            val uuidFactory = TestUUIDFactory()
 
             // Create dependent study service.
             val studyRepo = InMemoryStudyRepository()
             val studyService = StudyServiceHost(
                 studyRepo,
                 eventBus.createApplicationServiceAdapter( StudyService::class ),
-                TestUUIDFactory(),
+                uuidFactory,
                 TestClock
             )
 
@@ -44,7 +45,7 @@ class RecruitmentServiceHostTest : RecruitmentServiceTest
                 InMemoryParticipantRepository(),
                 deploymentService,
                 eventBus.createApplicationServiceAdapter( RecruitmentService::class ),
-                TestUUIDFactory(),
+                uuidFactory,
                 TestClock
             )
 


### PR DESCRIPTION
`stopParticipantGroup` checked `require( recruitment.id == studyId )`, but `recruitment.id` is the aggregate's own random ID — so the check always threw `IllegalArgumentException`, even for the correct study. 

Existing tests pass unchanged, they couldn't catch this because deterministic test UUIDs made `recruitment.id` coincidentally equal the study ID. This is tracked #548.

---
Update: Also bumped snapshot versions, and updated test infrastructure so this bug can be caught.